### PR TITLE
fix logg with time in foreground

### DIFF
--- a/common/output.c
+++ b/common/output.c
@@ -434,10 +434,10 @@ int logg(const char *str, ...)
                 cli_ctime(&currtime, timestr, sizeof(timestr));
                 /* cut trailing \n */
                 timestr[strlen(timestr) - 1] = '\0';
-                mprintf("%s -> %s", timestr, buff);
-            } else {
-                mprintf("%s", buff);
-            }
+                mprintf("%s -> ", timestr);
+            } 
+             mprintf("%s", buff);
+            
         }
     }
 


### PR DESCRIPTION
when we use the mprintf function and pass the time string as the first parameter, the mprintf function cannot recognize specific character (such as ! ^ * ,...) so does not replace it with the appropriate word (such as ERROR, WARNNING)
I separated the time string from the error message and print they separately with call twice mprintf.