### PR TITLE
Memory leak in Byte Compare function

### DIFF
--- a/libclamav/matcher-byte-comp.c
+++ b/libclamav/matcher-byte-comp.c
@@ -460,7 +460,7 @@ cl_error_t cli_bcomp_addpatt(struct cli_matcher *root, const char *virname, cons
 cl_error_t cli_bcomp_scanbuf(const unsigned char *buffer, size_t buffer_length, const char **virname, struct cli_ac_result **res, const struct cli_matcher *root, struct cli_ac_data *mdata, cli_ctx *ctx)
 {
 
-    int64_t i = 0, ret = CL_SUCCESS;
+    int64_t i = 0, val = 0, ret = CL_SUCCESS;
     uint32_t lsigid, ref_subsigid;
     uint32_t offset              = 0;
     uint8_t viruses_found        = 0;
@@ -488,8 +488,14 @@ cl_error_t cli_bcomp_scanbuf(const unsigned char *buffer, size_t buffer_length, 
             snprintf(subsigid, 3, "%hu", bcomp->ref_subsigid);
 
             /* verify the ref_subsigid */
-            if (cli_ac_chklsig(subsigid, subsigid + strlen(subsigid),
-                               mdata->lsigcnt[bcomp->lsigid[1]], &evalcnt, &evalids, 0) != 1) {
+            val = cli_ac_chklsig(subsigid, subsigid + strlen(subsigid), mdata->lsigcnt[bcomp->lsigid[1]], &evalcnt, &evalids, 0);
+
+            if (subsigid) {
+                free(subsigid);
+                subsigid = NULL;
+            }
+
+            if (val != 1) {
                 bcm_dbgmsg("cli_bcomp_scanbuf: could not verify a match for lsig reference subsigid (%s)\n", subsigid);
                 continue;
             }
@@ -544,11 +550,6 @@ cl_error_t cli_bcomp_scanbuf(const unsigned char *buffer, size_t buffer_length, 
                 ret = cli_append_virus(ctx, (const char *)bcomp->virname);
             }
         }
-    }
-
-    if (subsigid) {
-        free(subsigid);
-        subsigid = NULL;
     }
 
     if (ret == CL_SUCCESS && viruses_found) {


### PR DESCRIPTION
The for loop in `cli_bcomp_scanbuf` contains a few `continue` directives that do not free the three-bytes `subsigid` buffer allocated within the loop.
```
==182199==    by 0x4AD6182: cli_calloc (others_common.c:216)
==182199==    by 0x4A19EAB: cli_bcomp_scanbuf (matcher-byte-comp.c:487)
==182199==    by 0x48A090A: matcher_run (matcher.c:184)
==182199==    by 0x48A3D33: cli_fmap_scandesc (matcher.c:1168)
==182199==    by 0x48CC175: magic_scandesc (scanners.c:3992)
==182199==    by 0x48CC654: cli_base_scandesc (scanners.c:4074)
==182199==    by 0x48CC700: cli_magic_scandesc (scanners.c:4087)
==182199==    by 0x4928CD1: unz (unzip.c:344)
==182199==    by 0x492B7D0: cli_unzip (unzip.c:1165)
==182199==    by 0x48CAB01: magic_scandesc (scanners.c:3638)
==182199==    by 0x48CC654: cli_base_scandesc (scanners.c:4074)
```

This code path is triggered only when a signature contains more than one byte compare subsignatures:
```
Single_ByteCompare_MemoryLeak_Absent;Engine:100-255,Target:0;0&1;0:504b0304;0(>>0x12#il4#>0x0000800,<0x00020000)
Multiple_ByteCompare_MemoryLeak_Present;Engine:100-255,Target:0;0&1&2;0:504b0304;0(>>0x12#il4#>0x0000800,<0x00020000);0(>>0x16#il4#>0x0001000,<0x00030000)
```
(I know the above size check could be achieved using `.cdb` signatures, it's just an example to trigger the bug.)

Over a significant amount of time, as for example when using clamd, this leads to memory exhaustion.
```
==182199== LEAK SUMMARY:
==182199==    definitely lost: 210 bytes in 70 blocks
==182199==    indirectly lost: 0 bytes in 0 blocks
==182199==      possibly lost: 0 bytes in 0 blocks
==182199==    still reachable: 4,599 bytes in 40 blocks
==182199==         suppressed: 0 bytes in 0 blocks
```
[Full output of valgrind command](https://github.com/Cisco-Talos/clamav-devel/files/6420215/valgrind.txt)

A few notes:
* Tested with clamav-0.102.4 tag but also affecting dev/0.104 branch
* I did not add unit tests, but here are the files I used to reproduce the issue:
  * [trigger.ldb](https://github.com/Cisco-Talos/clamav-devel/files/6420213/trigger.ldb.txt)
  * [target.zip](https://github.com/Cisco-Talos/clamav-devel/files/6420214/target.zip)



