### PR TITLE
Execute VirusEvent before notifying peer of match

### DIFF
--- a/clamd/scanner.c
+++ b/clamd/scanner.c
@@ -301,6 +301,7 @@ cl_error_t scan_callback(STATBUF *sb, char *filename, const char *msg, enum cli_
             virusaction(filename, virname, scandata->opts);
         } else {
             scandata->infected++;
+            virusaction(filename, virname, scandata->opts);
             if (conn_reply_virus(scandata->conn, filename, virname) == -1) {
                 free(filename);
                 return CL_ETIMEOUT;
@@ -313,7 +314,6 @@ cl_error_t scan_callback(STATBUF *sb, char *filename, const char *msg, enum cli_
                 logg("~%s: %s(%s:%llu) FOUND\n", filename, virname, context.virhash, context.virsize);
             else
                 logg("~%s: %s FOUND\n", filename, virname);
-            virusaction(filename, virname, scandata->opts);
         }
     } else if (ret != CL_CLEAN) {
         scandata->errors++;
@@ -437,13 +437,13 @@ cl_error_t scanfd(
     }
 
     if (ret == CL_VIRUS) {
+        virusaction(log_filename, virname, opts);
         if (conn_reply_virus(conn, reply_fdstr, virname) == -1)
             ret = CL_ETIMEOUT;
         if (context.virsize && optget(opts, "ExtendedDetectionInfo")->enabled)
             logg("%s: %s(%s:%llu) FOUND\n", log_filename, virname, context.virhash, context.virsize);
         else
             logg("%s: %s FOUND\n", log_filename, virname);
-        virusaction(log_filename, virname, opts);
     } else if (ret != CL_CLEAN) {
         if (conn_reply(conn, reply_fdstr, cl_strerror(ret), "ERROR") == -1)
             ret = CL_ETIMEOUT;


### PR DESCRIPTION
### Summary
Change to address an apparent bug where `virusaction(...)` (which services the _VirusEvent_ command) is unable to access a file before it is acted upon (`action(...)` callback). This is particularly noticeable when using _VirusEvent_ to take an action based off of the file's contents or status while _clamonacc_ is configured to quarantine or delete the file.

Affects 0.104 and v.103.2 (likely prior versions as well).

### Testing
1. Configure _VirusEvent_ to log file properties (owner, permissions, etc.) on detection (_journalctl_, _syslog_, file, etc.)
2. Configure _clamonacc_ to quarantine files
3. Trigger _clamonacc_ by writing/moving a file into a watched directory
4. Depending on logging mechanism from step 1, note the captured file properties

Further logs and configurations available upon request. I'm fairly new to the codebase so any feedback would be greatly appreciated.