### PR TITLE
libclamav: Increase max PE section count to 65535

### DIFF
--- a/libclamav/pe.c
+++ b/libclamav/pe.c
@@ -107,9 +107,7 @@
 
 #define PE_MAXNAMESIZE 256
 #define PE_MAXIMPORTS 1024
-// TODO On Vista and above, up to 65535 sections are allowed.  Make sure
-// that using this lower limit from XP is acceptable in all cases
-#define PE_MAXSECTIONS 96
+#define PE_MAXSECTIONS 65535
 
 #define EC64(x) ((uint64_t)cli_readint64(&(x))) /* Convert little endian to host */
 #define EC32(x) ((uint32_t)cli_readint32(&(x)))


### PR DESCRIPTION
Windows XP had a maximum section count of 96, and this has been
the max for ClamAV forever as well. Raising this prevents malicious
executables from being able to evade certain ClamAV signatures by
having 97 or more sections.