### PR TITLE
docker: Update docker registry URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # Copyright (C) 2021 Cisco Systems, Inc. and/or its affiliates. All rights reserved.
 
 # hadolint ignore=DL3007  latest is the latest stable for alpine
-FROM registry.hub.docker.com/library/alpine:latest AS builder
+FROM index.docker.io/library/alpine:latest AS builder
 
 LABEL maintainer="ClamAV bugs <clamav-bugs@external.cisco.com>"
 
@@ -85,7 +85,7 @@ RUN apk add --no-cache \
     exit 1 && \
     ctest -V
 
-FROM registry.hub.docker.com/library/alpine:latest
+FROM index.docker.io/library/alpine:latest
 
 RUN apk add --no-cache \
         fts \


### PR DESCRIPTION
The URL registry.hub.docker.com was apparently deprecated for a while,
and started to give 404 errors as of today for some repo's. The correct
URL is index.docker.io, so lets use that instead.