### PR TITLE
clang-format: c++ bytecode source

### DIFF
--- a/clam-format
+++ b/clam-format
@@ -31,6 +31,8 @@ clang-format -i -verbose libclamav/jsparse/*.h
 clang-format -i -verbose libclamav/lzw/*.c
 clang-format -i -verbose libclamav/lzw/*.h
 clang-format -i -verbose libclamav/nsis/nulsft.*
+clang-format -i -verbose libclamav/c++/*.cpp
+clang-format -i -verbose libclamav/c++/*.h
 clang-format -i -verbose libclamunrar_iface/*.cpp
 clang-format -i -verbose libclamunrar_iface/*.h
 clang-format -i -verbose libfreshclam/*.c

--- a/libclamav/c++/ClamBCDiagnostics.h
+++ b/libclamav/c++/ClamBCDiagnostics.h
@@ -20,9 +20,10 @@
  *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
  *  MA 02110-1301, USA.
  */
-namespace llvm {
-    class Value;
+namespace llvm
+{
+class Value;
 }
 // match the prototype used in the bytecode compiler
-void printValue(llvm::Value *V, bool a=false, bool b=false);
-void printLocation(llvm::Instruction *I, bool a=false, bool b=false);
+void printValue(llvm::Value *V, bool a = false, bool b = false);
+void printLocation(llvm::Instruction *I, bool a = false, bool b = false);

--- a/libclamav/c++/ClamBCModule.h
+++ b/libclamav/c++/ClamBCModule.h
@@ -1,10 +1,12 @@
 #include "llvm/Support/raw_ostream.h"
-namespace llvm {
-    class Function;
-    class Instruction;
-    class Pass;
+namespace llvm
+{
+class Function;
+class Instruction;
+class Pass;
+} // namespace llvm
+namespace ClamBCModule
+{
+void stop(const char* msg, llvm::Function* F, llvm::Instruction* I = 0);
 }
-namespace ClamBCModule {
-    void stop(const char *msg, llvm::Function* F, llvm::Instruction* I=0);
-}
-llvm::Pass *createClamBCRTChecks();
+llvm::Pass* createClamBCRTChecks();

--- a/libclamav/c++/ClamBCRTChecks.cpp
+++ b/libclamav/c++/ClamBCRTChecks.cpp
@@ -111,36 +111,40 @@ static Value *GetUnderlyingObject(Value *P, TargetData *TD)
 }
 #endif
 
-namespace llvm {
-  class PtrVerifier;
+namespace llvm
+{
+class PtrVerifier;
 #if LLVM_VERSION >= 29
-  void initializePtrVerifierPass(PassRegistry&);
+void initializePtrVerifierPass(PassRegistry &);
 #endif
 
-  class PtrVerifier : public FunctionPass {
+class PtrVerifier : public FunctionPass
+{
   private:
-      DenseSet<Function*> badFunctions;
-      std::vector<Instruction*> delInst;
+    DenseSet<Function *> badFunctions;
+    std::vector<Instruction *> delInst;
 #if LLVM_VERSION < 35
-      CallGraphNode *rootNode;
+    CallGraphNode *rootNode;
 #else
-      CallGraph *CG;
+    CallGraph *CG;
 #endif
   public:
-      static char ID;
+    static char ID;
 #if LLVM_VERSION < 35
-      DEFINEPASS(PtrVerifier), rootNode(0), PT(), TD(), SE(), expander(),
+    DEFINEPASS(PtrVerifier), rootNode(0), PT(), TD(), SE(), expander(),
 #else
-      DEFINEPASS(PtrVerifier), CG(0), PT(), TD(), SE(), expander(),
+    DEFINEPASS(PtrVerifier), CG(0), PT(), TD(), SE(), expander(),
 #endif
-          DT(), AbrtBB(), Changed(false), valid(false), EP() {
+        DT(), AbrtBB(), Changed(false), valid(false), EP()
+    {
 #if LLVM_VERSION >= 29
-          initializePtrVerifierPass(*PassRegistry::getPassRegistry());
+        initializePtrVerifierPass(*PassRegistry::getPassRegistry());
 #endif
-      }
+    }
 
-      virtual bool runOnFunction(Function &F) {
-          /*
+    virtual bool runOnFunction(Function &F)
+    {
+        /*
 #ifndef CLAMBC_COMPILER
           // Bytecode was already verified and had stack protector applied.
           // We get called again because ALL bytecode functions loaded are part of
@@ -150,792 +154,801 @@ namespace llvm {
 #endif
           */
 
-          DEBUG(errs() << "Running on " << F.getName() << "\n");
-          DEBUG(F.dump());
-          Changed = false;
-          BaseMap.clear();
-          BoundsMap.clear();
-          delInst.clear();
-          AbrtBB = 0;
-          valid = true;
+        DEBUG(errs() << "Running on " << F.getName() << "\n");
+        DEBUG(F.dump());
+        Changed = false;
+        BaseMap.clear();
+        BoundsMap.clear();
+        delInst.clear();
+        AbrtBB = 0;
+        valid  = true;
 
 #if LLVM_VERSION < 35
-          if (!rootNode) {
-              rootNode = getAnalysis<CallGraph>().getRoot();
+        if (!rootNode) {
+            rootNode = getAnalysis<CallGraph>().getRoot();
 #else
-          if (!CG) {
-              CG = &getAnalysis<CallGraphWrapperPass>().getCallGraph();
+        if (!CG) {
+            CG = &getAnalysis<CallGraphWrapperPass>().getCallGraph();
 #endif
-              // No recursive functions for now.
-              // In the future we may insert runtime checks for stack depth.
+            // No recursive functions for now.
+            // In the future we may insert runtime checks for stack depth.
 #if LLVM_VERSION < 35
-              for (scc_iterator<CallGraphNode*> SCCI = scc_begin(rootNode),
-                       E = scc_end(rootNode); SCCI != E; ++SCCI) {
+            for (scc_iterator<CallGraphNode *> SCCI = scc_begin(rootNode),
+                                               E    = scc_end(rootNode);
+                 SCCI != E; ++SCCI) {
 #else
-              for (scc_iterator<CallGraph*> SCCI = scc_begin(CG); !SCCI.isAtEnd(); ++SCCI) {
+            for (scc_iterator<CallGraph *> SCCI = scc_begin(CG); !SCCI.isAtEnd(); ++SCCI) {
 #endif
-                  const std::vector<CallGraphNode*> &nextSCC = *SCCI;
-                  if (nextSCC.size() > 1 || SCCI.hasLoop()) {
-                      errs() << "INVALID: Recursion detected, callgraph SCC components: ";
-                      for (std::vector<CallGraphNode*>::const_iterator I = nextSCC.begin(),
-                               E = nextSCC.end(); I != E; ++I) {
-                          Function *FF = (*I)->getFunction();
-                          if (FF) {
-                              errs() << FF->getName() << ", ";
-                              badFunctions.insert(FF);
-                          }
-                      }
-                      if (SCCI.hasLoop())
-                          errs() << "(self-loop)";
-                      errs() << "\n";
-                  }
-                  // we could also have recursion via function pointers, but we don't
-                  // allow calls to unknown functions, see runOnFunction() below
-              }
-          }
+                const std::vector<CallGraphNode *> &nextSCC = *SCCI;
+                if (nextSCC.size() > 1 || SCCI.hasLoop()) {
+                    errs() << "INVALID: Recursion detected, callgraph SCC components: ";
+                    for (std::vector<CallGraphNode *>::const_iterator I = nextSCC.begin(),
+                                                                      E = nextSCC.end();
+                         I != E; ++I) {
+                        Function *FF = (*I)->getFunction();
+                        if (FF) {
+                            errs() << FF->getName() << ", ";
+                            badFunctions.insert(FF);
+                        }
+                    }
+                    if (SCCI.hasLoop())
+                        errs() << "(self-loop)";
+                    errs() << "\n";
+                }
+                // we could also have recursion via function pointers, but we don't
+                // allow calls to unknown functions, see runOnFunction() below
+            }
+        }
 
-          BasicBlock::iterator It = F.getEntryBlock().begin();
-          while (isa<AllocaInst>(It) || isa<PHINode>(It)) ++It;
-          EP = &*It;
+        BasicBlock::iterator It = F.getEntryBlock().begin();
+        while (isa<AllocaInst>(It) || isa<PHINode>(It)) ++It;
+        EP = &*It;
 #if LLVM_VERSION < 32
-          TD = &getAnalysis<TargetData>();
+        TD = &getAnalysis<TargetData>();
 #elif LLVM_VERSION < 35
-          TD = &getAnalysis<DataLayout>();
+        TD = &getAnalysis<DataLayout>();
 #else
-          DataLayoutPass *DLP = getAnalysisIfAvailable<DataLayoutPass>();
-          TD = DLP ? &DLP->getDataLayout() : 0;
+DataLayoutPass *DLP = getAnalysisIfAvailable<DataLayoutPass>();
+TD                  = DLP ? &DLP->getDataLayout() : 0;
 #endif
-          SE = &getAnalysis<ScalarEvolution>();
-          PT = &getAnalysis<PointerTracking>();
+        SE = &getAnalysis<ScalarEvolution>();
+        PT = &getAnalysis<PointerTracking>();
 #if LLVM_VERSION < 35
-          DT = &getAnalysis<DominatorTree>();
+        DT = &getAnalysis<DominatorTree>();
 #else
-          DT = &getAnalysis<DominatorTreeWrapperPass>().getDomTree();
+        DT = &getAnalysis<DominatorTreeWrapperPass>().getDomTree();
 #endif
-          expander = new SCEVExpander(*SE OPT("SCEVexpander"));
+        expander = new SCEVExpander(*SE OPT("SCEVexpander"));
 
-          std::vector<Instruction*> insns;
+        std::vector<Instruction *> insns;
 
-          BasicBlock *LastBB = 0;
-          for (inst_iterator I=inst_begin(F),E=inst_end(F); I != E;++I) {
-              Instruction *II = &*I;
-              /* only appears in the libclamav version */
-              if (II->getParent() != LastBB) {
-                  LastBB = II->getParent();
-                  if (DT->getNode(LastBB) == 0)
-                      continue;
-              }
-              /* end-block */
-              if (isa<LoadInst>(II) || isa<StoreInst>(II) || isa<MemIntrinsic>(II))
-                  insns.push_back(II);
-              else if (CallInst *CI = dyn_cast<CallInst>(II)) {
-                  Value *V = CI->getCalledValue()->stripPointerCasts();
-                  Function *F = dyn_cast<Function>(V);
-                  if (!F) {
-                      printLocation(CI, true);
-                      errs() << "Could not determine call target\n";
-                      valid = 0;
-                      continue;
-                  }
-                  // this statement disable checks on user-defined CallInst
-                  //if (!F->isDeclaration())
-                  //continue;
-                  insns.push_back(CI);
-              }
-          }
+        BasicBlock *LastBB = 0;
+        for (inst_iterator I = inst_begin(F), E = inst_end(F); I != E; ++I) {
+            Instruction *II = &*I;
+            /* only appears in the libclamav version */
+            if (II->getParent() != LastBB) {
+                LastBB = II->getParent();
+                if (DT->getNode(LastBB) == 0)
+                    continue;
+            }
+            /* end-block */
+            if (isa<LoadInst>(II) || isa<StoreInst>(II) || isa<MemIntrinsic>(II))
+                insns.push_back(II);
+            else if (CallInst *CI = dyn_cast<CallInst>(II)) {
+                Value *V    = CI->getCalledValue()->stripPointerCasts();
+                Function *F = dyn_cast<Function>(V);
+                if (!F) {
+                    printLocation(CI, true);
+                    errs() << "Could not determine call target\n";
+                    valid = 0;
+                    continue;
+                }
+                // this statement disable checks on user-defined CallInst
+                //if (!F->isDeclaration())
+                //continue;
+                insns.push_back(CI);
+            }
+        }
 
-          for (unsigned Idx = 0; Idx < insns.size(); ++Idx) {
-              Instruction *II = insns[Idx];
-              DEBUG(dbgs() << "checking " << *II << "\n");
-              if (LoadInst *LI = dyn_cast<LoadInst>(II)) {
-                  constType *Ty = LI->getType();
-                  valid &= validateAccess(LI->getPointerOperand(),
-                                          TD->getTypeAllocSize(Ty), LI);
-              } else if (StoreInst *SI = dyn_cast<StoreInst>(II)) {
-                  constType *Ty = SI->getOperand(0)->getType();
-                  valid &= validateAccess(SI->getPointerOperand(),
-                                          TD->getTypeAllocSize(Ty), SI);
-              } else if (MemIntrinsic *MI = dyn_cast<MemIntrinsic>(II)) {
-                  valid &= validateAccess(MI->getDest(), MI->getLength(), MI);
-                  if (MemTransferInst *MTI = dyn_cast<MemTransferInst>(MI)) {
-                      valid &= validateAccess(MTI->getSource(), MI->getLength(), MI);
-                  }
-              } else if (CallInst *CI = dyn_cast<CallInst>(II)) {
-                  Value *V = CI->getCalledValue()->stripPointerCasts();
-                  Function *F = cast<Function>(V);
-                  constFunctionType *FTy = F->getFunctionType();
-                  CallSite CS(CI);
-                  if (F->getName().equals("memcmp") && FTy->getNumParams() == 3) {
-                      valid &= validateAccess(CS.getArgument(0), CS.getArgument(2), CI);
-                      valid &= validateAccess(CS.getArgument(1), CS.getArgument(2), CI);
-                      continue;
-                  }
-                  unsigned i;
+        for (unsigned Idx = 0; Idx < insns.size(); ++Idx) {
+            Instruction *II = insns[Idx];
+            DEBUG(dbgs() << "checking " << *II << "\n");
+            if (LoadInst *LI = dyn_cast<LoadInst>(II)) {
+                constType *Ty = LI->getType();
+                valid &= validateAccess(LI->getPointerOperand(),
+                                        TD->getTypeAllocSize(Ty), LI);
+            } else if (StoreInst *SI = dyn_cast<StoreInst>(II)) {
+                constType *Ty = SI->getOperand(0)->getType();
+                valid &= validateAccess(SI->getPointerOperand(),
+                                        TD->getTypeAllocSize(Ty), SI);
+            } else if (MemIntrinsic *MI = dyn_cast<MemIntrinsic>(II)) {
+                valid &= validateAccess(MI->getDest(), MI->getLength(), MI);
+                if (MemTransferInst *MTI = dyn_cast<MemTransferInst>(MI)) {
+                    valid &= validateAccess(MTI->getSource(), MI->getLength(), MI);
+                }
+            } else if (CallInst *CI = dyn_cast<CallInst>(II)) {
+                Value *V               = CI->getCalledValue()->stripPointerCasts();
+                Function *F            = cast<Function>(V);
+                constFunctionType *FTy = F->getFunctionType();
+                CallSite CS(CI);
+                if (F->getName().equals("memcmp") && FTy->getNumParams() == 3) {
+                    valid &= validateAccess(CS.getArgument(0), CS.getArgument(2), CI);
+                    valid &= validateAccess(CS.getArgument(1), CS.getArgument(2), CI);
+                    continue;
+                }
+                unsigned i;
 #ifdef CLAMBC_COMPILER
-                  i = 0;
+                i = 0;
 #else
-                  i = 1;// skip hidden ctx*
+                i = 1; // skip hidden ctx*
 #endif
-                  for (;i<FTy->getNumParams();i++) {
-                      if (isa<PointerType>(FTy->getParamType(i))) {
-                          Value *Ptr = CS.getArgument(i);
-                          if (i+1 >= FTy->getNumParams()) {
-                              printLocation(CI, false);
-                              errs() << "Call to external function with pointer parameter last"
-                                  " cannot be analyzed\n";
-                              errs() << *CI << "\n";
-                              valid = 0;
-                              break;
-                          }
-                          Value *Size = CS.getArgument(i+1);
-                          if (!Size->getType()->isIntegerTy()) {
-                              printLocation(CI, false);
-                              errs() << "Pointer argument must be followed by integer argument"
-                                  " representing its size\n";
-                              errs() << *CI << "\n";
-                              valid = 0;
-                              break;
-                          }
-                          valid &= validateAccess(Ptr, Size, CI);
-                      }
-                  }
-              }
-          }
-          if (badFunctions.count(&F))
-              valid = 0;
+                for (; i < FTy->getNumParams(); i++) {
+                    if (isa<PointerType>(FTy->getParamType(i))) {
+                        Value *Ptr = CS.getArgument(i);
+                        if (i + 1 >= FTy->getNumParams()) {
+                            printLocation(CI, false);
+                            errs() << "Call to external function with pointer parameter last"
+                                      " cannot be analyzed\n";
+                            errs() << *CI << "\n";
+                            valid = 0;
+                            break;
+                        }
+                        Value *Size = CS.getArgument(i + 1);
+                        if (!Size->getType()->isIntegerTy()) {
+                            printLocation(CI, false);
+                            errs() << "Pointer argument must be followed by integer argument"
+                                      " representing its size\n";
+                            errs() << *CI << "\n";
+                            valid = 0;
+                            break;
+                        }
+                        valid &= validateAccess(Ptr, Size, CI);
+                    }
+                }
+            }
+        }
+        if (badFunctions.count(&F))
+            valid = 0;
 
-          if (!valid) {
-              DEBUG(F.dump());
-              ClamBCModule::stop("Verification found errors!", &F);
-              // replace function with call to abort
-              std::vector<constType*>args;
-              FunctionType* abrtTy = FunctionType::get(Type::getVoidTy(F.getContext()),args,false);
-              Constant *func_abort = F.getParent()->getOrInsertFunction("abort", abrtTy);
+        if (!valid) {
+            DEBUG(F.dump());
+            ClamBCModule::stop("Verification found errors!", &F);
+            // replace function with call to abort
+            std::vector<constType *> args;
+            FunctionType *abrtTy = FunctionType::get(Type::getVoidTy(F.getContext()), args, false);
+            Constant *func_abort = F.getParent()->getOrInsertFunction("abort", abrtTy);
 
-              BasicBlock *BB = &F.getEntryBlock();
-              Instruction *I = &*BB->begin();
-              Instruction *UI = new UnreachableInst(F.getContext(), I);
-              CallInst *AbrtC = CallInst::Create(func_abort, "", UI);
-              AbrtC->setCallingConv(CallingConv::C);
-              AbrtC->setTailCall(true);
+            BasicBlock *BB  = &F.getEntryBlock();
+            Instruction *I  = &*BB->begin();
+            Instruction *UI = new UnreachableInst(F.getContext(), I);
+            CallInst *AbrtC = CallInst::Create(func_abort, "", UI);
+            AbrtC->setCallingConv(CallingConv::C);
+            AbrtC->setTailCall(true);
 #if LLVM_VERSION < 32
-              AbrtC->setDoesNotReturn(true);
-              AbrtC->setDoesNotThrow(true);
+            AbrtC->setDoesNotReturn(true);
+            AbrtC->setDoesNotThrow(true);
 #else
-              AbrtC->setDoesNotReturn();
-              AbrtC->setDoesNotThrow();
+            AbrtC->setDoesNotReturn();
+            AbrtC->setDoesNotThrow();
 #endif
-              // remove all instructions from entry
-              BasicBlock::iterator BBI = I, BBE=BB->end();
-              while (BBI != BBE) {
-                  if (!BBI->use_empty())
-                      BBI->replaceAllUsesWith(UndefValue::get(BBI->getType()));
-                  BB->getInstList().erase(BBI++);
-              }
-          }
+            // remove all instructions from entry
+            BasicBlock::iterator BBI = I, BBE = BB->end();
+            while (BBI != BBE) {
+                if (!BBI->use_empty())
+                    BBI->replaceAllUsesWith(UndefValue::get(BBI->getType()));
+                BB->getInstList().erase(BBI++);
+            }
+        }
 
-          // bb#9967 - deleting obsolete termination instructions
-          for (unsigned i = 0; i < delInst.size(); ++i)
-              delInst[i]->eraseFromParent();
+        // bb#9967 - deleting obsolete termination instructions
+        for (unsigned i = 0; i < delInst.size(); ++i)
+            delInst[i]->eraseFromParent();
 
-          delete expander;
-          return Changed;
-      }
+        delete expander;
+        return Changed;
+    } // namespace llvm
 
-      virtual void releaseMemory() {
-          badFunctions.clear();
-      }
+    virtual void releaseMemory()
+    {
+        badFunctions.clear();
+    }
 
-      virtual void getAnalysisUsage(AnalysisUsage &AU) const {
+    virtual void getAnalysisUsage(AnalysisUsage &AU) const
+    {
 #if LLVM_VERSION < 32
-          AU.addRequired<TargetData>();
+        AU.addRequired<TargetData>();
 #elif LLVM_VERSION < 35
-          AU.addRequired<DataLayout>();
+        AU.addRequired<DataLayout>();
 #else
-          AU.addRequired<DataLayoutPass>();
+    AU.addRequired<DataLayoutPass>();
 #endif
 #if LLVM_VERSION < 35
-          AU.addRequired<DominatorTree>();
+        AU.addRequired<DominatorTree>();
 #else
-          AU.addRequired<DominatorTreeWrapperPass>();
+        AU.addRequired<DominatorTreeWrapperPass>();
 #endif
-          AU.addRequired<ScalarEvolution>();
-          AU.addRequired<PointerTracking>();
+        AU.addRequired<ScalarEvolution>();
+        AU.addRequired<PointerTracking>();
 #if LLVM_VERSION < 35
-          AU.addRequired<CallGraph>();
+        AU.addRequired<CallGraph>();
 #else
-          AU.addRequired<CallGraphWrapperPass>();
+        AU.addRequired<CallGraphWrapperPass>();
 #endif
-      }
+    }
 
-      bool isValid() const { return valid; }
+    bool isValid() const
+    {
+        return valid;
+    }
+
   private:
-      PointerTracking *PT;
+    PointerTracking *PT;
 #if LLVM_VERSION < 32
-      TargetData *TD;
+    TargetData *TD;
 #elif LLVM_VERSION < 35
-      DataLayout *TD;
+    DataLayout *TD;
 #else
-      const DataLayout *TD;
+const DataLayout *TD;
 #endif
-      ScalarEvolution *SE;
-      SCEVExpander *expander;
-      DominatorTree *DT;
-      DenseMap<Value*, Value*> BaseMap;
-      DenseMap<Value*, Value*> BoundsMap;
-      BasicBlock *AbrtBB;
-      bool Changed;
-      bool valid;
-      Instruction *EP;
+    ScalarEvolution *SE;
+    SCEVExpander *expander;
+    DominatorTree *DT;
+    DenseMap<Value *, Value *> BaseMap;
+    DenseMap<Value *, Value *> BoundsMap;
+    BasicBlock *AbrtBB;
+    bool Changed;
+    bool valid;
+    Instruction *EP;
 
-      Instruction *getInsertPoint(Value *V)
-      {
-          BasicBlock::iterator It = EP;
-          if (Instruction *I = dyn_cast<Instruction>(V)) {
-              It = I;
-              ++It;
-          }
-          return &*It;
-      }
+    Instruction *getInsertPoint(Value *V)
+    {
+        BasicBlock::iterator It = EP;
+        if (Instruction *I = dyn_cast<Instruction>(V)) {
+            It = I;
+            ++It;
+        }
+        return &*It;
+    }
 
-      Value *getPointerBase(Value *Ptr)
-      {
-          if (BaseMap.count(Ptr))
-              return BaseMap[Ptr];
-          Value *P = Ptr->stripPointerCasts();
-          if (BaseMap.count(P)) {
-              return BaseMap[Ptr] = BaseMap[P];
-          }
-          Value *P2 = GetUnderlyingObject(P, TD);
-          if (P2 != P) {
-              Value *V = getPointerBase(P2);
-              return BaseMap[Ptr] = V;
-          }
+    Value *getPointerBase(Value *Ptr)
+    {
+        if (BaseMap.count(Ptr))
+            return BaseMap[Ptr];
+        Value *P = Ptr->stripPointerCasts();
+        if (BaseMap.count(P)) {
+            return BaseMap[Ptr] = BaseMap[P];
+        }
+        Value *P2 = GetUnderlyingObject(P, TD);
+        if (P2 != P) {
+            Value *V            = getPointerBase(P2);
+            return BaseMap[Ptr] = V;
+        }
 
-          constType *P8Ty =
-              PointerType::getUnqual(Type::getInt8Ty(Ptr->getContext()));
-          if (PHINode *PN = dyn_cast<PHINode>(Ptr)) {
-              BasicBlock::iterator It = PN;
-              ++It;
-              PHINode *newPN = PHINode::Create(P8Ty, HINT(PN->getNumIncomingValues()) ".verif.base", &*It);
-              Changed = true;
-              BaseMap[Ptr] = newPN;
+        constType *P8Ty =
+            PointerType::getUnqual(Type::getInt8Ty(Ptr->getContext()));
+        if (PHINode *PN = dyn_cast<PHINode>(Ptr)) {
+            BasicBlock::iterator It = PN;
+            ++It;
+            PHINode *newPN = PHINode::Create(P8Ty, HINT(PN->getNumIncomingValues()) ".verif.base", &*It);
+            Changed        = true;
+            BaseMap[Ptr]   = newPN;
 
-              for (unsigned i=0;i<PN->getNumIncomingValues();i++) {
-                  Value *Inc = PN->getIncomingValue(i);
-                  Value *V = getPointerBase(Inc);
-                  newPN->addIncoming(V, PN->getIncomingBlock(i));
-              }
-              return newPN;
-          }
-          if (SelectInst *SI = dyn_cast<SelectInst>(Ptr)) {
-              BasicBlock::iterator It = SI;
-              ++It;
-              Value *TrueB = getPointerBase(SI->getTrueValue());
-              Value *FalseB = getPointerBase(SI->getFalseValue());
-              if (TrueB && FalseB) {
-                  SelectInst *NewSI = SelectInst::Create(SI->getCondition(), TrueB,
-                                                         FalseB, ".select.base", &*It);
-                  Changed = true;
-                  return BaseMap[Ptr] = NewSI;
-              }
-          }
-          if (Ptr->getType() != P8Ty) {
-              if (Constant *C = dyn_cast<Constant>(Ptr))
-                  Ptr = ConstantExpr::getPointerCast(C, P8Ty);
-              else {
-                  Instruction *I = getInsertPoint(Ptr);
-                  Ptr = new BitCastInst(Ptr, P8Ty, "", I);
-              }
-          }
-          return BaseMap[Ptr] = Ptr;
-      }
+            for (unsigned i = 0; i < PN->getNumIncomingValues(); i++) {
+                Value *Inc = PN->getIncomingValue(i);
+                Value *V   = getPointerBase(Inc);
+                newPN->addIncoming(V, PN->getIncomingBlock(i));
+            }
+            return newPN;
+        }
+        if (SelectInst *SI = dyn_cast<SelectInst>(Ptr)) {
+            BasicBlock::iterator It = SI;
+            ++It;
+            Value *TrueB  = getPointerBase(SI->getTrueValue());
+            Value *FalseB = getPointerBase(SI->getFalseValue());
+            if (TrueB && FalseB) {
+                SelectInst *NewSI   = SelectInst::Create(SI->getCondition(), TrueB,
+                                                       FalseB, ".select.base", &*It);
+                Changed             = true;
+                return BaseMap[Ptr] = NewSI;
+            }
+        }
+        if (Ptr->getType() != P8Ty) {
+            if (Constant *C = dyn_cast<Constant>(Ptr))
+                Ptr = ConstantExpr::getPointerCast(C, P8Ty);
+            else {
+                Instruction *I = getInsertPoint(Ptr);
+                Ptr            = new BitCastInst(Ptr, P8Ty, "", I);
+            }
+        }
+        return BaseMap[Ptr] = Ptr;
+    }
 
-      Value* getValAtIdx(Function *F, unsigned Idx) {
-          Value *Val= NULL;
+    Value *getValAtIdx(Function *F, unsigned Idx)
+    {
+        Value *Val = NULL;
 
-          // check if accessed Idx is within function parameter list
-          if (Idx < F->arg_size()) {
-              Function::arg_iterator It = F->arg_begin();
-              Function::arg_iterator ItEnd = F->arg_end();
-              for (unsigned i = 0; i < Idx; ++i, ++It) {
-                  // redundant check, should not be possible
-                  if (It == ItEnd) {
-                      // Houston, the impossible has become possible
-                      //printDiagnostic("Idx is outside of Function parameters", F);
-                      errs() << "Idx is outside of Function parameters\n";
-                      errs() << *F << "\n";
-                      //valid = 0;
-                      break;
-                  }
-              }
-              // retrieve value ptr of argument of F at Idx
-              Val = &(*It);
-          }
-          else {
-              // Idx is outside function parameter list
-              //printDiagnostic("Idx is outside of Function parameters", F);
-              errs() << "Idx is outside of Function parameters\n";
-              errs() << *F << "\n";
-              //valid = 0;
-          }
-          return Val;
-      }
+        // check if accessed Idx is within function parameter list
+        if (Idx < F->arg_size()) {
+            Function::arg_iterator It    = F->arg_begin();
+            Function::arg_iterator ItEnd = F->arg_end();
+            for (unsigned i = 0; i < Idx; ++i, ++It) {
+                // redundant check, should not be possible
+                if (It == ItEnd) {
+                    // Houston, the impossible has become possible
+                    //printDiagnostic("Idx is outside of Function parameters", F);
+                    errs() << "Idx is outside of Function parameters\n";
+                    errs() << *F << "\n";
+                    //valid = 0;
+                    break;
+                }
+            }
+            // retrieve value ptr of argument of F at Idx
+            Val = &(*It);
+        } else {
+            // Idx is outside function parameter list
+            //printDiagnostic("Idx is outside of Function parameters", F);
+            errs() << "Idx is outside of Function parameters\n";
+            errs() << *F << "\n";
+            //valid = 0;
+        }
+        return Val;
+    }
 
-      Value* getPointerBounds(Value *Base) {
-          if (BoundsMap.count(Base))
-              return BoundsMap[Base];
-          constType *I64Ty =
-              Type::getInt64Ty(Base->getContext());
+    Value *getPointerBounds(Value *Base)
+    {
+        if (BoundsMap.count(Base))
+            return BoundsMap[Base];
+        constType *I64Ty =
+            Type::getInt64Ty(Base->getContext());
 
 #ifndef CLAMBC_COMPILER
-          // first arg is hidden ctx
-          if (Argument *A = dyn_cast<Argument>(Base)) {
-              if (A->getArgNo() == 0) {
-                  constType *Ty = cast<PointerType>(A->getType())->getElementType();
-                  return ConstantInt::get(I64Ty, TD->getTypeAllocSize(Ty));
-              } else if (Base->getType()->isPointerTy()) {
-                  Function *F = A->getParent();
-                  const FunctionType *FT = F->getFunctionType();
+        // first arg is hidden ctx
+        if (Argument *A = dyn_cast<Argument>(Base)) {
+            if (A->getArgNo() == 0) {
+                constType *Ty = cast<PointerType>(A->getType())->getElementType();
+                return ConstantInt::get(I64Ty, TD->getTypeAllocSize(Ty));
+            } else if (Base->getType()->isPointerTy()) {
+                Function *F            = A->getParent();
+                const FunctionType *FT = F->getFunctionType();
 
-                  bool checks = true;
-                  // last argument check
-                  if (A->getArgNo() == (FT->getNumParams()-1)) {
-                      //printDiagnostic("pointer argument cannot be last argument", F);
-                      errs() << "pointer argument cannot be last argument\n";
-                      errs() << *F << "\n";
-                      checks = false;
-                  }
+                bool checks = true;
+                // last argument check
+                if (A->getArgNo() == (FT->getNumParams() - 1)) {
+                    //printDiagnostic("pointer argument cannot be last argument", F);
+                    errs() << "pointer argument cannot be last argument\n";
+                    errs() << *F << "\n";
+                    checks = false;
+                }
 
-                  // argument after pointer MUST be a integer (unsigned probably too)
-                  if (checks && !FT->getParamType(A->getArgNo()+1)->isIntegerTy()) {
-                      //printDiagnostic("argument following pointer argument is not an integer", F);
-                      errs() << "argument following pointer argument is not an integer\n";
-                      errs() << *F << "\n";
-                      checks = false;
-                  }
+                // argument after pointer MUST be a integer (unsigned probably too)
+                if (checks && !FT->getParamType(A->getArgNo() + 1)->isIntegerTy()) {
+                    //printDiagnostic("argument following pointer argument is not an integer", F);
+                    errs() << "argument following pointer argument is not an integer\n";
+                    errs() << *F << "\n";
+                    checks = false;
+                }
 
-                  if (checks)
-                      return BoundsMap[Base] = getValAtIdx(F, A->getArgNo()+1);
-              }
-          }
-          if (LoadInst *LI = dyn_cast<LoadInst>(Base)) {
-              Value *V = GetUnderlyingObject(LI->getPointerOperand()->stripPointerCasts(), TD);
-              if (Argument *A = dyn_cast<Argument>(V)) {
-                  if (A->getArgNo() == 0) {
-                      // pointers from hidden ctx are trusted to be at least the
-                      // size they say they are
-                      constType *Ty = cast<PointerType>(LI->getType())->getElementType();
-                      return ConstantInt::get(I64Ty, TD->getTypeAllocSize(Ty));
-                  }
-              }
-          }
+                if (checks)
+                    return BoundsMap[Base] = getValAtIdx(F, A->getArgNo() + 1);
+            }
+        }
+        if (LoadInst *LI = dyn_cast<LoadInst>(Base)) {
+            Value *V = GetUnderlyingObject(LI->getPointerOperand()->stripPointerCasts(), TD);
+            if (Argument *A = dyn_cast<Argument>(V)) {
+                if (A->getArgNo() == 0) {
+                    // pointers from hidden ctx are trusted to be at least the
+                    // size they say they are
+                    constType *Ty = cast<PointerType>(LI->getType())->getElementType();
+                    return ConstantInt::get(I64Ty, TD->getTypeAllocSize(Ty));
+                }
+            }
+        }
 #else
-          if (Base->getType()->isPointerTy()) {
-              if (Argument *A = dyn_cast<Argument>(Base)) {
-                  Function *F = A->getParent();
-                  const FunctionType *FT = F->getFunctionType();
+        if (Base->getType()->isPointerTy()) {
+            if (Argument *A = dyn_cast<Argument>(Base)) {
+                Function *F            = A->getParent();
+                const FunctionType *FT = F->getFunctionType();
 
-                  bool checks = true;
-                  // last argument check
-                  if (A->getArgNo() == (FT->getNumParams()-1)) {
-                      //printDiagnostic("pointer argument cannot be last argument", F);
-                      errs() << "pointer argument cannot be last argument\n";
-                      errs() << *F << "\n";
-                      checks = false;
-                  }
+                bool checks = true;
+                // last argument check
+                if (A->getArgNo() == (FT->getNumParams() - 1)) {
+                    //printDiagnostic("pointer argument cannot be last argument", F);
+                    errs() << "pointer argument cannot be last argument\n";
+                    errs() << *F << "\n";
+                    checks = false;
+                }
 
-                  // argument after pointer MUST be a integer (unsigned probably too)
-                  if (checks && !FT->getParamType(A->getArgNo()+1)->isIntegerTy()) {
-                      //printDiagnostic("argument following pointer argument is not an integer", F);
-                      errs() << "argument following pointer argument is not an integer\n";
-                      errs() << *F << "\n";
-                      checks = false;
-                  }
+                // argument after pointer MUST be a integer (unsigned probably too)
+                if (checks && !FT->getParamType(A->getArgNo() + 1)->isIntegerTy()) {
+                    //printDiagnostic("argument following pointer argument is not an integer", F);
+                    errs() << "argument following pointer argument is not an integer\n";
+                    errs() << *F << "\n";
+                    checks = false;
+                }
 
-                  if (checks)
-                      return BoundsMap[Base] = getValAtIdx(F, A->getArgNo()+1);
-              }
-          }
+                if (checks)
+                    return BoundsMap[Base] = getValAtIdx(F, A->getArgNo() + 1);
+            }
+        }
 #endif
-          if (PHINode *PN = dyn_cast<PHINode>(Base)) {
-              BasicBlock::iterator It = PN;
-              ++It;
-              PHINode *newPN = PHINode::Create(I64Ty, HINT(PN->getNumIncomingValues()) ".verif.bounds", &*It);
-              Changed = true;
-              BoundsMap[Base] = newPN;
+        if (PHINode *PN = dyn_cast<PHINode>(Base)) {
+            BasicBlock::iterator It = PN;
+            ++It;
+            PHINode *newPN  = PHINode::Create(I64Ty, HINT(PN->getNumIncomingValues()) ".verif.bounds", &*It);
+            Changed         = true;
+            BoundsMap[Base] = newPN;
 
-              bool good = true;
-              for (unsigned i=0;i<PN->getNumIncomingValues();i++) {
-                  Value *Inc = PN->getIncomingValue(i);
-                  Value *B = getPointerBounds(Inc);
-                  if (!B) {
-                      good = false;
-                      B = ConstantInt::get(newPN->getType(), 0);
-                      DEBUG(dbgs() << "bounds not found while solving phi node: " << *Inc
-                            << "\n");
-                  }
-                  newPN->addIncoming(B, PN->getIncomingBlock(i));
-              }
-              if (!good)
-                  newPN = 0;
-              return BoundsMap[Base] = newPN;
-          }
-          if (SelectInst *SI = dyn_cast<SelectInst>(Base)) {
-              BasicBlock::iterator It = SI;
-              ++It;
-              Value *TrueB = getPointerBounds(SI->getTrueValue());
-              Value *FalseB = getPointerBounds(SI->getFalseValue());
-              if (TrueB && FalseB) {
-                  SelectInst *NewSI = SelectInst::Create(SI->getCondition(), TrueB,
-                                                         FalseB, ".select.bounds", &*It);
-                  Changed = true;
-                  return BoundsMap[Base] = NewSI;
-              }
-          }
+            bool good = true;
+            for (unsigned i = 0; i < PN->getNumIncomingValues(); i++) {
+                Value *Inc = PN->getIncomingValue(i);
+                Value *B   = getPointerBounds(Inc);
+                if (!B) {
+                    good = false;
+                    B    = ConstantInt::get(newPN->getType(), 0);
+                    DEBUG(dbgs() << "bounds not found while solving phi node: " << *Inc
+                                 << "\n");
+                }
+                newPN->addIncoming(B, PN->getIncomingBlock(i));
+            }
+            if (!good)
+                newPN = 0;
+            return BoundsMap[Base] = newPN;
+        }
+        if (SelectInst *SI = dyn_cast<SelectInst>(Base)) {
+            BasicBlock::iterator It = SI;
+            ++It;
+            Value *TrueB  = getPointerBounds(SI->getTrueValue());
+            Value *FalseB = getPointerBounds(SI->getFalseValue());
+            if (TrueB && FalseB) {
+                SelectInst *NewSI      = SelectInst::Create(SI->getCondition(), TrueB,
+                                                       FalseB, ".select.bounds", &*It);
+                Changed                = true;
+                return BoundsMap[Base] = NewSI;
+            }
+        }
 
-          constType *Ty;
-          Value *V = PT->computeAllocationCountValue(Base, Ty);
-          if (!V) {
-              Base = Base->stripPointerCasts();
-              if (CallInst *CI = dyn_cast<CallInst>(Base)) {
-                  Function *F = CI->getCalledFunction();
-                  constFunctionType *FTy = F->getFunctionType();
-                  // last operand is always size for this API call kind
-                  if (F->isDeclaration() && FTy->getNumParams() > 0) {
-                      CallSite CS(CI);
-                      if (FTy->getParamType(FTy->getNumParams()-1)->isIntegerTy())
-                          V = CS.getArgument(FTy->getNumParams()-1);
-                  }
-              }
-              if (!V)
-                  return BoundsMap[Base] = 0;
-          } else {
-              unsigned size = TD->getTypeAllocSize(Ty);
-              if (size > 1) {
-                  Constant *C = cast<Constant>(V);
-                  C = ConstantExpr::getMul(C,
-                                           ConstantInt::get(Type::getInt32Ty(C->getContext()),
-                                                            size));
-                  V = C;
-              }
-          }
-          if (V->getType() != I64Ty) {
-              if (Constant *C = dyn_cast<Constant>(V))
-                  V = ConstantExpr::getZExt(C, I64Ty);
-              else {
-                  Instruction *I = getInsertPoint(V);
-                  V = new ZExtInst(V, I64Ty, "", I);
-              }
-          }
-          return BoundsMap[Base] = V;
-      }
+        constType *Ty;
+        Value *V = PT->computeAllocationCountValue(Base, Ty);
+        if (!V) {
+            Base = Base->stripPointerCasts();
+            if (CallInst *CI = dyn_cast<CallInst>(Base)) {
+                Function *F            = CI->getCalledFunction();
+                constFunctionType *FTy = F->getFunctionType();
+                // last operand is always size for this API call kind
+                if (F->isDeclaration() && FTy->getNumParams() > 0) {
+                    CallSite CS(CI);
+                    if (FTy->getParamType(FTy->getNumParams() - 1)->isIntegerTy())
+                        V = CS.getArgument(FTy->getNumParams() - 1);
+                }
+            }
+            if (!V)
+                return BoundsMap[Base] = 0;
+        } else {
+            unsigned size = TD->getTypeAllocSize(Ty);
+            if (size > 1) {
+                Constant *C = cast<Constant>(V);
+                C           = ConstantExpr::getMul(C,
+                                         ConstantInt::get(Type::getInt32Ty(C->getContext()),
+                                                          size));
+                V           = C;
+            }
+        }
+        if (V->getType() != I64Ty) {
+            if (Constant *C = dyn_cast<Constant>(V))
+                V = ConstantExpr::getZExt(C, I64Ty);
+            else {
+                Instruction *I = getInsertPoint(V);
+                V              = new ZExtInst(V, I64Ty, "", I);
+            }
+        }
+        return BoundsMap[Base] = V;
+    }
 
-      MDNode *getLocation(Instruction *I, bool &Approximate, unsigned MDDbgKind)
-      {
-          Approximate = false;
-          if (MDNode *Dbg = I->getMetadata(MDDbgKind))
-              return Dbg;
-          if (!MDDbgKind)
-              return 0;
-          Approximate = true;
-          BasicBlock::iterator It = I;
-          while (It != I->getParent()->begin()) {
-              --It;
-              if (MDNode *Dbg = It->getMetadata(MDDbgKind))
-                  return Dbg;
-          }
-          BasicBlock *BB = I->getParent();
-          while ((BB = BB->getUniquePredecessor())) {
-              It = BB->end();
-              while (It != BB->begin()) {
-                  --It;
-                  if (MDNode *Dbg = It->getMetadata(MDDbgKind))
-                      return Dbg;
-              }
-          }
-          return 0;
-      }
+    MDNode *getLocation(Instruction *I, bool &Approximate, unsigned MDDbgKind)
+    {
+        Approximate = false;
+        if (MDNode *Dbg = I->getMetadata(MDDbgKind))
+            return Dbg;
+        if (!MDDbgKind)
+            return 0;
+        Approximate             = true;
+        BasicBlock::iterator It = I;
+        while (It != I->getParent()->begin()) {
+            --It;
+            if (MDNode *Dbg = It->getMetadata(MDDbgKind))
+                return Dbg;
+        }
+        BasicBlock *BB = I->getParent();
+        while ((BB = BB->getUniquePredecessor())) {
+            It = BB->end();
+            while (It != BB->begin()) {
+                --It;
+                if (MDNode *Dbg = It->getMetadata(MDDbgKind))
+                    return Dbg;
+            }
+        }
+        return 0;
+    }
 
-      bool insertCheck(const SCEV *Idx, const SCEV *Limit, Instruction *I,
-                       bool strict)
-      {
-          if (isa<SCEVCouldNotCompute>(Idx) && isa<SCEVCouldNotCompute>(Limit)) {
-              errs() << "Could not compute the index and the limit!: \n" << *I << "\n";
-              return false;
-          }
-          if (isa<SCEVCouldNotCompute>(Idx)) {
-              errs() << "Could not compute index: \n" << *I << "\n";
-              return false;
-          }
-          if (isa<SCEVCouldNotCompute>(Limit)) {
-              errs() << "Could not compute limit: " << *I << "\n";
-              return false;
-          }
-          BasicBlock *BB = I->getParent();
-          BasicBlock::iterator It = I;
-          BasicBlock *newBB = SplitBlock(BB, &*It, this);
-          PHINode *PN;
-          unsigned MDDbgKind = I->getContext().getMDKindID("dbg");
-          //verifyFunction(*BB->getParent());
-          if (!AbrtBB) {
-              std::vector<constType*>args;
-              FunctionType* abrtTy = FunctionType::get(Type::getVoidTy(BB->getContext()),args,false);
-              args.push_back(Type::getInt32Ty(BB->getContext()));
-              FunctionType* rterrTy = FunctionType::get(Type::getInt32Ty(BB->getContext()),args,false);
-              Constant *func_abort = BB->getParent()->getParent()->getOrInsertFunction("abort", abrtTy);
-              Constant *func_rterr = BB->getParent()->getParent()->getOrInsertFunction("bytecode_rt_error",
-                                                                                       rterrTy);
-              AbrtBB = BasicBlock::Create(BB->getContext(), "rterr.trig", BB->getParent());
+    bool insertCheck(const SCEV *Idx, const SCEV *Limit, Instruction *I,
+                     bool strict)
+    {
+        if (isa<SCEVCouldNotCompute>(Idx) && isa<SCEVCouldNotCompute>(Limit)) {
+            errs() << "Could not compute the index and the limit!: \n"
+                   << *I << "\n";
+            return false;
+        }
+        if (isa<SCEVCouldNotCompute>(Idx)) {
+            errs() << "Could not compute index: \n"
+                   << *I << "\n";
+            return false;
+        }
+        if (isa<SCEVCouldNotCompute>(Limit)) {
+            errs() << "Could not compute limit: " << *I << "\n";
+            return false;
+        }
+        BasicBlock *BB          = I->getParent();
+        BasicBlock::iterator It = I;
+        BasicBlock *newBB       = SplitBlock(BB, &*It, this);
+        PHINode *PN;
+        unsigned MDDbgKind = I->getContext().getMDKindID("dbg");
+        //verifyFunction(*BB->getParent());
+        if (!AbrtBB) {
+            std::vector<constType *> args;
+            FunctionType *abrtTy = FunctionType::get(Type::getVoidTy(BB->getContext()), args, false);
+            args.push_back(Type::getInt32Ty(BB->getContext()));
+            FunctionType *rterrTy = FunctionType::get(Type::getInt32Ty(BB->getContext()), args, false);
+            Constant *func_abort  = BB->getParent()->getParent()->getOrInsertFunction("abort", abrtTy);
+            Constant *func_rterr  = BB->getParent()->getParent()->getOrInsertFunction("bytecode_rt_error",
+                                                                                     rterrTy);
+            AbrtBB                = BasicBlock::Create(BB->getContext(), "rterr.trig", BB->getParent());
 
-              PN = PHINode::Create(Type::getInt32Ty(BB->getContext()),HINT(1) "",
-                                   AbrtBB);
-              if (MDDbgKind) {
-                  CallInst *RtErrCall = CallInst::Create(func_rterr, PN, "", AbrtBB);
-                  RtErrCall->setCallingConv(CallingConv::C);
-                  RtErrCall->setTailCall(true);
+            PN = PHINode::Create(Type::getInt32Ty(BB->getContext()), HINT(1) "",
+                                 AbrtBB);
+            if (MDDbgKind) {
+                CallInst *RtErrCall = CallInst::Create(func_rterr, PN, "", AbrtBB);
+                RtErrCall->setCallingConv(CallingConv::C);
+                RtErrCall->setTailCall(true);
 #if LLVM_VERSION < 32
-                  RtErrCall->setDoesNotThrow(true);
+                RtErrCall->setDoesNotThrow(true);
 #else
-                  RtErrCall->setDoesNotThrow();
+                RtErrCall->setDoesNotThrow();
 #endif
-              }
-              CallInst* AbrtC = CallInst::Create(func_abort, "", AbrtBB);
-              AbrtC->setCallingConv(CallingConv::C);
-              AbrtC->setTailCall(true);
+            }
+            CallInst *AbrtC = CallInst::Create(func_abort, "", AbrtBB);
+            AbrtC->setCallingConv(CallingConv::C);
+            AbrtC->setTailCall(true);
 #if LLVM_VERSION < 32
-              AbrtC->setDoesNotReturn(true);
-              AbrtC->setDoesNotThrow(true);
+            AbrtC->setDoesNotReturn(true);
+            AbrtC->setDoesNotThrow(true);
 #else
-              AbrtC->setDoesNotReturn();
-              AbrtC->setDoesNotThrow();
+            AbrtC->setDoesNotReturn();
+            AbrtC->setDoesNotThrow();
 #endif
-              new UnreachableInst(BB->getContext(), AbrtBB);
-              DT->addNewBlock(AbrtBB, BB);
-              //verifyFunction(*BB->getParent());
-          } else {
-              PN = cast<PHINode>(AbrtBB->begin());
-          }
-          unsigned locationid = 0;
-          bool Approximate;
-          if (MDNode *Dbg = getLocation(I, Approximate, MDDbgKind)) {
-              DILocation Loc(Dbg);
-              locationid = Loc.getLineNumber() << 8;
-              unsigned col = Loc.getColumnNumber();
-              if (col > 254)
-                  col = 254;
-              if (Approximate)
-                  col = 255;
-              locationid |= col;
-          }
-          PN->addIncoming(ConstantInt::get(Type::getInt32Ty(BB->getContext()),
-                                           locationid), BB);
-          TerminatorInst *TI = BB->getTerminator();
-          Value *IdxV = expander->expandCodeFor(Idx, Limit->getType(), TI);
-          Value *LimitV = expander->expandCodeFor(Limit, Limit->getType(), TI);
-          if (isa<Instruction>(IdxV) &&
-              !DT->dominates(cast<Instruction>(IdxV)->getParent(),I->getParent())) {
-              printLocation(I, true);
-              errs() << "basic block with value [ " << IdxV->getName();
-              errs() << " ] with limit [ " << LimitV->getName();
-              errs() << " ] does not dominate" << *I << "\n";
-              return false;
-          }
-          if (isa<Instruction>(LimitV) &&
-              !DT->dominates(cast<Instruction>(LimitV)->getParent(),I->getParent())) {
-              printLocation(I, true);
-              errs() << "basic block with limit [" << LimitV->getName();
-              errs() << " ] on value [ " << IdxV->getName();
-              errs() << " ] does not dominate" << *I << "\n";
-              return false;
-          }
-          Value *Cond = new ICmpInst(TI, strict ?
-                                     ICmpInst::ICMP_ULT :
-                                     ICmpInst::ICMP_ULE, IdxV, LimitV);
-          BranchInst::Create(newBB, AbrtBB, Cond, TI);
-          //TI->eraseFromParent();
-          delInst.push_back(TI);
-          // Update dominator info
-          BasicBlock *DomBB =
-              DT->findNearestCommonDominator(BB, DT->getNode(AbrtBB)->getIDom()->getBlock());
-          DT->changeImmediateDominator(AbrtBB, DomBB);
-          return true;
-      }
+            new UnreachableInst(BB->getContext(), AbrtBB);
+            DT->addNewBlock(AbrtBB, BB);
+            //verifyFunction(*BB->getParent());
+        } else {
+            PN = cast<PHINode>(AbrtBB->begin());
+        }
+        unsigned locationid = 0;
+        bool Approximate;
+        if (MDNode *Dbg = getLocation(I, Approximate, MDDbgKind)) {
+            DILocation Loc(Dbg);
+            locationid   = Loc.getLineNumber() << 8;
+            unsigned col = Loc.getColumnNumber();
+            if (col > 254)
+                col = 254;
+            if (Approximate)
+                col = 255;
+            locationid |= col;
+        }
+        PN->addIncoming(ConstantInt::get(Type::getInt32Ty(BB->getContext()),
+                                         locationid),
+                        BB);
+        TerminatorInst *TI = BB->getTerminator();
+        Value *IdxV        = expander->expandCodeFor(Idx, Limit->getType(), TI);
+        Value *LimitV      = expander->expandCodeFor(Limit, Limit->getType(), TI);
+        if (isa<Instruction>(IdxV) &&
+            !DT->dominates(cast<Instruction>(IdxV)->getParent(), I->getParent())) {
+            printLocation(I, true);
+            errs() << "basic block with value [ " << IdxV->getName();
+            errs() << " ] with limit [ " << LimitV->getName();
+            errs() << " ] does not dominate" << *I << "\n";
+            return false;
+        }
+        if (isa<Instruction>(LimitV) &&
+            !DT->dominates(cast<Instruction>(LimitV)->getParent(), I->getParent())) {
+            printLocation(I, true);
+            errs() << "basic block with limit [" << LimitV->getName();
+            errs() << " ] on value [ " << IdxV->getName();
+            errs() << " ] does not dominate" << *I << "\n";
+            return false;
+        }
+        Value *Cond = new ICmpInst(TI, strict ? ICmpInst::ICMP_ULT : ICmpInst::ICMP_ULE, IdxV, LimitV);
+        BranchInst::Create(newBB, AbrtBB, Cond, TI);
+        //TI->eraseFromParent();
+        delInst.push_back(TI);
+        // Update dominator info
+        BasicBlock *DomBB =
+            DT->findNearestCommonDominator(BB, DT->getNode(AbrtBB)->getIDom()->getBlock());
+        DT->changeImmediateDominator(AbrtBB, DomBB);
+        return true;
+    }
 
-      static void MakeCompatible(ScalarEvolution *SE, const SCEV*& LHS, const SCEV*& RHS)
-      {
-          if (const SCEVZeroExtendExpr *ZL = dyn_cast<SCEVZeroExtendExpr>(LHS))
-              LHS = ZL->getOperand();
-          if (const SCEVZeroExtendExpr *ZR = dyn_cast<SCEVZeroExtendExpr>(RHS))
-              RHS = ZR->getOperand();
+    static void MakeCompatible(ScalarEvolution *SE, const SCEV *&LHS, const SCEV *&RHS)
+    {
+        if (const SCEVZeroExtendExpr *ZL = dyn_cast<SCEVZeroExtendExpr>(LHS))
+            LHS = ZL->getOperand();
+        if (const SCEVZeroExtendExpr *ZR = dyn_cast<SCEVZeroExtendExpr>(RHS))
+            RHS = ZR->getOperand();
 
-          constType* LTy = SE->getEffectiveSCEVType(LHS->getType());
-          constType *RTy = SE->getEffectiveSCEVType(RHS->getType());
-          if (SE->getTypeSizeInBits(RTy) > SE->getTypeSizeInBits(LTy))
-              LTy = RTy;
-          LHS = SE->getNoopOrZeroExtend(LHS, LTy);
-          RHS = SE->getNoopOrZeroExtend(RHS, LTy);
-      }
+        constType *LTy = SE->getEffectiveSCEVType(LHS->getType());
+        constType *RTy = SE->getEffectiveSCEVType(RHS->getType());
+        if (SE->getTypeSizeInBits(RTy) > SE->getTypeSizeInBits(LTy))
+            LTy = RTy;
+        LHS = SE->getNoopOrZeroExtend(LHS, LTy);
+        RHS = SE->getNoopOrZeroExtend(RHS, LTy);
+    }
 
-      bool checkCond(Instruction *ICI, Instruction *I, bool equal)
-      {
+    bool checkCond(Instruction *ICI, Instruction *I, bool equal)
+    {
 #if LLVM_VERSION < 35
-          for (Value::use_iterator JU=ICI->use_begin(),JUE=ICI->use_end();
-               JU != JUE; ++JU) {
+        for (Value::use_iterator JU = ICI->use_begin(), JUE = ICI->use_end();
+             JU != JUE; ++JU) {
 #else
-          for (Value::user_iterator JU=ICI->user_begin(),JUE=ICI->user_end();
-               JU != JUE; ++JU) {
+        for (Value::user_iterator JU = ICI->user_begin(), JUE = ICI->user_end();
+             JU != JUE; ++JU) {
 #endif
-              Value *JU_V = *JU;
-              if (BranchInst *BI = dyn_cast<BranchInst>(JU_V)) {
-                  if (!BI->isConditional())
-                      continue;
-                  BasicBlock *S = BI->getSuccessor(equal);
-                  if (DT->dominates(S, I->getParent()))
-                      return true;
-              }
-              if (BinaryOperator *BI = dyn_cast<BinaryOperator>(JU_V)) {
-                  if (BI->getOpcode() == Instruction::Or &&
-                      checkCond(BI, I, equal))
-                      return true;
-                  if (BI->getOpcode() == Instruction::And &&
-                      checkCond(BI, I, !equal))
-                      return true;
-              }
-          }
-          return false;
-      }
+            Value *JU_V = *JU;
+            if (BranchInst *BI = dyn_cast<BranchInst>(JU_V)) {
+                if (!BI->isConditional())
+                    continue;
+                BasicBlock *S = BI->getSuccessor(equal);
+                if (DT->dominates(S, I->getParent()))
+                    return true;
+            }
+            if (BinaryOperator *BI = dyn_cast<BinaryOperator>(JU_V)) {
+                if (BI->getOpcode() == Instruction::Or &&
+                    checkCond(BI, I, equal))
+                    return true;
+                if (BI->getOpcode() == Instruction::And &&
+                    checkCond(BI, I, !equal))
+                    return true;
+            }
+        }
+        return false;
+    }
 
-      bool checkCondition(Instruction *CI, Instruction *I)
-      {
+    bool checkCondition(Instruction *CI, Instruction *I)
+    {
 #if LLVM_VERSION < 35
-          for (Value::use_iterator U=CI->use_begin(),UE=CI->use_end();
-               U != UE; ++U) {
+        for (Value::use_iterator U = CI->use_begin(), UE = CI->use_end();
+             U != UE; ++U) {
 #else
-          for (Value::user_iterator U=CI->user_begin(),UE=CI->user_end();
-               U != UE; ++U) {
+        for (Value::user_iterator U = CI->user_begin(), UE = CI->user_end();
+             U != UE; ++U) {
 #endif
-              Value *U_V = *U;
-              if (ICmpInst *ICI = dyn_cast<ICmpInst>(U_V)) {
-                  if (ICI->getOperand(0)->stripPointerCasts() == CI &&
-                      isa<ConstantPointerNull>(ICI->getOperand(1))) {
-                      if (checkCond(ICI, I, ICI->getPredicate() == ICmpInst::ICMP_EQ))
-                          return true;
-                  }
-              }
-          }
-          return false;
-      }
+            Value *U_V = *U;
+            if (ICmpInst *ICI = dyn_cast<ICmpInst>(U_V)) {
+                if (ICI->getOperand(0)->stripPointerCasts() == CI &&
+                    isa<ConstantPointerNull>(ICI->getOperand(1))) {
+                    if (checkCond(ICI, I, ICI->getPredicate() == ICmpInst::ICMP_EQ))
+                        return true;
+                }
+            }
+        }
+        return false;
+    }
 
-      bool validateAccess(Value *Pointer, Value *Length, Instruction *I)
-      {
-          // get base
-          Value *Base = getPointerBase(Pointer);
+    bool validateAccess(Value *Pointer, Value *Length, Instruction *I)
+    {
+        // get base
+        Value *Base = getPointerBase(Pointer);
 
-          Value *SBase = Base->stripPointerCasts();
-          // get bounds
-          Value *Bounds = getPointerBounds(SBase);
-          if (!Bounds) {
-              printLocation(I, true);
-              errs() << "no bounds for base ";
-              printValue(SBase);
-              errs() << " while checking access to ";
-              printValue(Pointer);
-              errs() << " of length ";
-              printValue(Length);
-              errs() << "\n";
+        Value *SBase = Base->stripPointerCasts();
+        // get bounds
+        Value *Bounds = getPointerBounds(SBase);
+        if (!Bounds) {
+            printLocation(I, true);
+            errs() << "no bounds for base ";
+            printValue(SBase);
+            errs() << " while checking access to ";
+            printValue(Pointer);
+            errs() << " of length ";
+            printValue(Length);
+            errs() << "\n";
 
-              return false;
-          }
+            return false;
+        }
 
-          // checks if a NULL pointer check (returned from function) is made:
-          if (CallInst *CI = dyn_cast<CallInst>(Base->stripPointerCasts())) {
-              // by checking if use is in the same block (i.e. no branching decisions)
-              if (I->getParent() == CI->getParent()) {
-                  printLocation(I, true);
-                  errs() << "no null pointer check of pointer ";
-                  printValue(Base, false, true);
-                  errs() << " obtained by function call";
-                  errs() << " before use in same block\n";
-                  return false;
-              }
-              // by checking if a conditional contains the values in question somewhere
-              // between their usage
-              if (!checkCondition(CI, I)) {
-                  printLocation(I, true);
-                  errs() << "no null pointer check of pointer ";
-                  printValue(Base, false, true);
-                  errs() << " obtained by function call";
-                  errs() << " before use\n";
-                  return false;
-              }
-          }
+        // checks if a NULL pointer check (returned from function) is made:
+        if (CallInst *CI = dyn_cast<CallInst>(Base->stripPointerCasts())) {
+            // by checking if use is in the same block (i.e. no branching decisions)
+            if (I->getParent() == CI->getParent()) {
+                printLocation(I, true);
+                errs() << "no null pointer check of pointer ";
+                printValue(Base, false, true);
+                errs() << " obtained by function call";
+                errs() << " before use in same block\n";
+                return false;
+            }
+            // by checking if a conditional contains the values in question somewhere
+            // between their usage
+            if (!checkCondition(CI, I)) {
+                printLocation(I, true);
+                errs() << "no null pointer check of pointer ";
+                printValue(Base, false, true);
+                errs() << " obtained by function call";
+                errs() << " before use\n";
+                return false;
+            }
+        }
 
-      constType *I64Ty =
-          Type::getInt64Ty(Base->getContext());
-      const SCEV *SLen = SE->getSCEV(Length);
-      const SCEV *OffsetP = SE->getMinusSCEV(SE->getSCEV(Pointer),
-                                             SE->getSCEV(Base));
-      SLen = SE->getNoopOrZeroExtend(SLen, I64Ty);
-      OffsetP = SE->getNoopOrZeroExtend(OffsetP, I64Ty);
-      const SCEV *Limit = SE->getSCEV(Bounds);
-      Limit = SE->getNoopOrZeroExtend(Limit, I64Ty);
+        constType *I64Ty =
+            Type::getInt64Ty(Base->getContext());
+        const SCEV *SLen    = SE->getSCEV(Length);
+        const SCEV *OffsetP = SE->getMinusSCEV(SE->getSCEV(Pointer),
+                                               SE->getSCEV(Base));
+        SLen                = SE->getNoopOrZeroExtend(SLen, I64Ty);
+        OffsetP             = SE->getNoopOrZeroExtend(OffsetP, I64Ty);
+        const SCEV *Limit   = SE->getSCEV(Bounds);
+        Limit               = SE->getNoopOrZeroExtend(Limit, I64Ty);
 
-      DEBUG(dbgs() << "Checking access to " << *Pointer << " of length " <<
-            *Length << "\n");
-      if (OffsetP == Limit) {
-          printLocation(I, true);
-          errs() << "OffsetP == Limit: " << *OffsetP << "\n";
-          errs() << " while checking access to ";
-          printValue(Pointer);
-          errs() << " of length ";
-          printValue(Length);
-          errs() << "\n";
-          return false;
-      }
+        DEBUG(dbgs() << "Checking access to " << *Pointer << " of length " << *Length << "\n");
+        if (OffsetP == Limit) {
+            printLocation(I, true);
+            errs() << "OffsetP == Limit: " << *OffsetP << "\n";
+            errs() << " while checking access to ";
+            printValue(Pointer);
+            errs() << " of length ";
+            printValue(Length);
+            errs() << "\n";
+            return false;
+        }
 
-      if (SLen == Limit) {
-          if (const SCEVConstant *SC = dyn_cast<SCEVConstant>(OffsetP)) {
-              if (SC->isZero())
-                  return true;
-          }
-          errs() << "SLen == Limit: " << *SLen << "\n";
-          errs() << " while checking access to " << *Pointer << " of length "
-                 << *Length << " at " << *I << "\n";
-          return false;
-      }
+        if (SLen == Limit) {
+            if (const SCEVConstant *SC = dyn_cast<SCEVConstant>(OffsetP)) {
+                if (SC->isZero())
+                    return true;
+            }
+            errs() << "SLen == Limit: " << *SLen << "\n";
+            errs() << " while checking access to " << *Pointer << " of length "
+                   << *Length << " at " << *I << "\n";
+            return false;
+        }
 
-      bool valid = true;
-      SLen = SE->getAddExpr(OffsetP, SLen);
-      // check that offset + slen <= limit;
-      // umax(offset+slen, limit) == limit is a sufficient (but not necessary
-      // condition)
-      const SCEV *MaxL = SE->getUMaxExpr(SLen, Limit);
-      if (MaxL != Limit) {
-          DEBUG(dbgs() << "MaxL != Limit: " << *MaxL << ", " << *Limit << "\n");
-          valid &= insertCheck(SLen, Limit, I, false);
-      }
+        bool valid = true;
+        SLen       = SE->getAddExpr(OffsetP, SLen);
+        // check that offset + slen <= limit;
+        // umax(offset+slen, limit) == limit is a sufficient (but not necessary
+        // condition)
+        const SCEV *MaxL = SE->getUMaxExpr(SLen, Limit);
+        if (MaxL != Limit) {
+            DEBUG(dbgs() << "MaxL != Limit: " << *MaxL << ", " << *Limit << "\n");
+            valid &= insertCheck(SLen, Limit, I, false);
+        }
 
-      //TODO: nullpointer check
-      const SCEV *Max = SE->getUMaxExpr(OffsetP, Limit);
-      if (Max == Limit)
-          return valid;
-      DEBUG(dbgs() << "Max != Limit: " << *Max << ", " << *Limit << "\n");
+        //TODO: nullpointer check
+        const SCEV *Max = SE->getUMaxExpr(OffsetP, Limit);
+        if (Max == Limit)
+            return valid;
+        DEBUG(dbgs() << "Max != Limit: " << *Max << ", " << *Limit << "\n");
 
-      // check that offset < limit
-      valid &= insertCheck(OffsetP, Limit, I, true);
-      return valid;
-      }
+        // check that offset < limit
+        valid &= insertCheck(OffsetP, Limit, I, true);
+        return valid;
+    }
 
-      bool validateAccess(Value *Pointer, unsigned size, Instruction *I)
-      {
-          return validateAccess(Pointer,
-                                ConstantInt::get(Type::getInt32Ty(Pointer->getContext()),
-                                                 size), I);
-      }
-
-  };
-    char PtrVerifier::ID;
+    bool validateAccess(Value *Pointer, unsigned size, Instruction *I)
+    {
+        return validateAccess(Pointer,
+                              ConstantInt::get(Type::getInt32Ty(Pointer->getContext()),
+                                               size),
+                              I);
+    }
+};
+char PtrVerifier::ID;
 
 } /* end namespace llvm */
 #if LLVM_VERSION >= 29
@@ -963,7 +976,6 @@ INITIALIZE_PASS_DEPENDENCY(CallGraphWrapperPass)
 INITIALIZE_PASS_DEPENDENCY(PointerTracking)
 INITIALIZE_PASS_END(PtrVerifier, "clambc-rtchecks", "ClamBC RTchecks", false, false)
 #endif
-
 
 llvm::Pass *createClamBCRTChecks()
 {

--- a/libclamav/c++/PointerTracking.cpp
+++ b/libclamav/c++/PointerTracking.cpp
@@ -60,11 +60,12 @@ static Value *GetUnderlyingObject(Value *P, TargetData *TD)
 #endif
 
 #if LLVM_VERSION >= 29
-namespace llvm {
-    void initializePointerTrackingPass(llvm::PassRegistry&);
+namespace llvm
+{
+void initializePointerTrackingPass(llvm::PassRegistry &);
 };
 INITIALIZE_PASS_BEGIN(PointerTracking, "pointertracking",
-                "Track pointer bounds", false, true)
+                      "Track pointer bounds", false, true)
 #if LLVM_VERSION < 35
 INITIALIZE_PASS_DEPENDENCY(DominatorTree)
 #else
@@ -78,272 +79,282 @@ INITIALIZE_PASS_DEPENDENCY(DominatorTree)
 INITIALIZE_PASS_DEPENDENCY(DominatorTreeWrapperPass)
 #endif
 INITIALIZE_PASS_END(PointerTracking, "pointertracking",
-                "Track pointer bounds", false, true)
+                    "Track pointer bounds", false, true)
 #endif
 
 char PointerTracking::ID = 0;
-PointerTracking::PointerTracking() : FunctionPass(ID) {
+PointerTracking::PointerTracking()
+    : FunctionPass(ID)
+{
 #if LLVM_VERSION >= 29
     initializePointerTrackingPass(*PassRegistry::getPassRegistry());
 #endif
 }
 
-bool PointerTracking::runOnFunction(Function &F) {
-  predCache.clear();
-  assert(analyzing.empty());
-  FF = &F;
+bool PointerTracking::runOnFunction(Function &F)
+{
+    predCache.clear();
+    assert(analyzing.empty());
+    FF = &F;
 #if LLVM_VERSION < 32
-  TD = getAnalysisIfAvailable<TargetData>();
+    TD = getAnalysisIfAvailable<TargetData>();
 #elif LLVM_VERSION < 35
-  TD = getAnalysisIfAvailable<DataLayout>();
+    TD = getAnalysisIfAvailable<DataLayout>();
 #else
-  DataLayoutPass *DLP = getAnalysisIfAvailable<DataLayoutPass>();
-  TD = DLP ? &DLP->getDataLayout() : 0;
+    DataLayoutPass *DLP = getAnalysisIfAvailable<DataLayoutPass>();
+    TD                  = DLP ? &DLP->getDataLayout() : 0;
 #endif
-  SE = &getAnalysis<ScalarEvolution>();
-  LI = &getAnalysis<LoopInfo>();
+    SE = &getAnalysis<ScalarEvolution>();
+    LI = &getAnalysis<LoopInfo>();
 #if LLVM_VERSION < 35
-  DT = &getAnalysis<DominatorTree>();
+    DT = &getAnalysis<DominatorTree>();
 #else
-  DT = &getAnalysis<DominatorTreeWrapperPass>().getDomTree();
+    DT = &getAnalysis<DominatorTreeWrapperPass>().getDomTree();
 #endif
-  return false;
+    return false;
 }
 
-void PointerTracking::getAnalysisUsage(AnalysisUsage &AU) const {
+void PointerTracking::getAnalysisUsage(AnalysisUsage &AU) const
+{
 #if LLVM_VERSION < 35
-  AU.addRequiredTransitive<DominatorTree>();
+    AU.addRequiredTransitive<DominatorTree>();
 #else
-  AU.addRequiredTransitive<DominatorTreeWrapperPass>();
+    AU.addRequiredTransitive<DominatorTreeWrapperPass>();
 #endif
-  AU.addRequiredTransitive<LoopInfo>();
-  AU.addRequiredTransitive<ScalarEvolution>();
-  AU.setPreservesAll();
+    AU.addRequiredTransitive<LoopInfo>();
+    AU.addRequiredTransitive<ScalarEvolution>();
+    AU.setPreservesAll();
 }
 
-bool PointerTracking::doInitialization(Module &M) {
-  constType *PTy = Type::getInt8PtrTy(M.getContext());
+bool PointerTracking::doInitialization(Module &M)
+{
+    constType *PTy = Type::getInt8PtrTy(M.getContext());
 
-  // Find calloc(i64, i64) or calloc(i32, i32).
-  callocFunc = M.getFunction("calloc");
-  if (callocFunc) {
-    constFunctionType *Ty = callocFunc->getFunctionType();
+    // Find calloc(i64, i64) or calloc(i32, i32).
+    callocFunc = M.getFunction("calloc");
+    if (callocFunc) {
+        constFunctionType *Ty = callocFunc->getFunctionType();
 
-    std::vector<constType*> args, args2;
-    args.push_back(Type::getInt64Ty(M.getContext()));
-    args.push_back(Type::getInt64Ty(M.getContext()));
-    args2.push_back(Type::getInt32Ty(M.getContext()));
-    args2.push_back(Type::getInt32Ty(M.getContext()));
-    constFunctionType *Calloc1Type =
-      FunctionType::get(PTy, args, false);
-    constFunctionType *Calloc2Type =
-      FunctionType::get(PTy, args2, false);
-    if (Ty != Calloc1Type && Ty != Calloc2Type)
-      callocFunc = 0; // Give up
-  }
+        std::vector<constType *> args, args2;
+        args.push_back(Type::getInt64Ty(M.getContext()));
+        args.push_back(Type::getInt64Ty(M.getContext()));
+        args2.push_back(Type::getInt32Ty(M.getContext()));
+        args2.push_back(Type::getInt32Ty(M.getContext()));
+        constFunctionType *Calloc1Type =
+            FunctionType::get(PTy, args, false);
+        constFunctionType *Calloc2Type =
+            FunctionType::get(PTy, args2, false);
+        if (Ty != Calloc1Type && Ty != Calloc2Type)
+            callocFunc = 0; // Give up
+    }
 
-  // Find realloc(i8*, i64) or realloc(i8*, i32).
-  reallocFunc = M.getFunction("realloc");
-  if (reallocFunc) {
-    constFunctionType *Ty = reallocFunc->getFunctionType();
-    std::vector<constType*> args, args2;
-    args.push_back(PTy);
-    args.push_back(Type::getInt64Ty(M.getContext()));
-    args2.push_back(PTy);
-    args2.push_back(Type::getInt32Ty(M.getContext()));
+    // Find realloc(i8*, i64) or realloc(i8*, i32).
+    reallocFunc = M.getFunction("realloc");
+    if (reallocFunc) {
+        constFunctionType *Ty = reallocFunc->getFunctionType();
+        std::vector<constType *> args, args2;
+        args.push_back(PTy);
+        args.push_back(Type::getInt64Ty(M.getContext()));
+        args2.push_back(PTy);
+        args2.push_back(Type::getInt32Ty(M.getContext()));
 
-    constFunctionType *Realloc1Type =
-      FunctionType::get(PTy, args, false);
-    constFunctionType *Realloc2Type =
-      FunctionType::get(PTy, args2, false);
-    if (Ty != Realloc1Type && Ty != Realloc2Type)
-      reallocFunc = 0; // Give up
-  }
-  return false;
+        constFunctionType *Realloc1Type =
+            FunctionType::get(PTy, args, false);
+        constFunctionType *Realloc2Type =
+            FunctionType::get(PTy, args2, false);
+        if (Ty != Realloc1Type && Ty != Realloc2Type)
+            reallocFunc = 0; // Give up
+    }
+    return false;
 }
 
 // Calculates the number of elements allocated for pointer P,
 // the type of the element is stored in Ty.
 const SCEV *PointerTracking::computeAllocationCount(Value *P,
-                                                    constType *&Ty) const {
-  Value *V = P->stripPointerCasts();
-  if (AllocaInst *AI = dyn_cast<AllocaInst>(V)) {
-    Value *arraySize = AI->getArraySize();
-    Ty = AI->getAllocatedType();
-    // arraySize elements of type Ty.
-    return SE->getSCEV(arraySize);
-  }
+                                                    constType *&Ty) const
+{
+    Value *V = P->stripPointerCasts();
+    if (AllocaInst *AI = dyn_cast<AllocaInst>(V)) {
+        Value *arraySize = AI->getArraySize();
+        Ty               = AI->getAllocatedType();
+        // arraySize elements of type Ty.
+        return SE->getSCEV(arraySize);
+    }
 
 #if LLVM_VERSION < 32
-  if (CallInst *CI = extractMallocCall(V)) {
-    Value *arraySize = getMallocArraySize(CI, TD);
-    constType* AllocTy = getMallocAllocatedType(CI);
+    if (CallInst *CI = extractMallocCall(V)) {
+        Value *arraySize   = getMallocArraySize(CI, TD);
+        constType *AllocTy = getMallocAllocatedType(CI);
 #else
-  TargetLibraryInfo* TLI = new TargetLibraryInfo();
+    TargetLibraryInfo *TLI = new TargetLibraryInfo();
 
-  if (CallInst *CI = extractMallocCall(V, TLI)) {
-    Value *arraySize = getMallocArraySize(CI, TD, TLI);
-    constType* AllocTy = getMallocAllocatedType(CI, TLI);
+    if (CallInst *CI = extractMallocCall(V, TLI)) {
+        Value *arraySize   = getMallocArraySize(CI, TD, TLI);
+        constType *AllocTy = getMallocAllocatedType(CI, TLI);
 #endif
-    if (!AllocTy || !arraySize) return SE->getCouldNotCompute();
-    Ty = AllocTy;
-    // arraySize elements of type Ty.
-    return SE->getSCEV(arraySize);
-  }
-
-  if (GlobalVariable *GV = dyn_cast<GlobalVariable>(V)) {
-    if (GV->hasDefinitiveInitializer()) {
-      Constant *C = GV->getInitializer();
-      if (const ArrayType *ATy = dyn_cast<ArrayType>(C->getType())) {
-        Ty = ATy->getElementType();
-        return SE->getConstant(Type::getInt32Ty(P->getContext()),
-                               ATy->getNumElements());
-      }
+        if (!AllocTy || !arraySize) return SE->getCouldNotCompute();
+        Ty = AllocTy;
+        // arraySize elements of type Ty.
+        return SE->getSCEV(arraySize);
     }
-    Ty = GV->getType();
-    return SE->getConstant(Type::getInt32Ty(P->getContext()), 1);
-    //TODO: implement more tracking for globals
-  }
 
-  if (CallInst *CI = dyn_cast<CallInst>(V)) {
-    CallSite CS(CI);
-    Function *F = dyn_cast<Function>(CS.getCalledValue()->stripPointerCasts());
-    const Loop *L = LI->getLoopFor(CI->getParent());
-    if (F == callocFunc) {
-      Ty = Type::getInt8Ty(P->getContext());
-      // calloc allocates arg0*arg1 bytes.
-      return SE->getSCEVAtScope(SE->getMulExpr(SE->getSCEV(CS.getArgument(0)),
-                                               SE->getSCEV(CS.getArgument(1))),
-                                L);
-    } else if (F == reallocFunc) {
-      Ty = Type::getInt8Ty(P->getContext());
-      // realloc allocates arg1 bytes.
-      return SE->getSCEVAtScope(CS.getArgument(1), L);
+    if (GlobalVariable *GV = dyn_cast<GlobalVariable>(V)) {
+        if (GV->hasDefinitiveInitializer()) {
+            Constant *C = GV->getInitializer();
+            if (const ArrayType *ATy = dyn_cast<ArrayType>(C->getType())) {
+                Ty = ATy->getElementType();
+                return SE->getConstant(Type::getInt32Ty(P->getContext()),
+                                       ATy->getNumElements());
+            }
+        }
+        Ty = GV->getType();
+        return SE->getConstant(Type::getInt32Ty(P->getContext()), 1);
+        //TODO: implement more tracking for globals
     }
-  }
 
-  return SE->getCouldNotCompute();
+    if (CallInst *CI = dyn_cast<CallInst>(V)) {
+        CallSite CS(CI);
+        Function *F   = dyn_cast<Function>(CS.getCalledValue()->stripPointerCasts());
+        const Loop *L = LI->getLoopFor(CI->getParent());
+        if (F == callocFunc) {
+            Ty = Type::getInt8Ty(P->getContext());
+            // calloc allocates arg0*arg1 bytes.
+            return SE->getSCEVAtScope(SE->getMulExpr(SE->getSCEV(CS.getArgument(0)),
+                                                     SE->getSCEV(CS.getArgument(1))),
+                                      L);
+        } else if (F == reallocFunc) {
+            Ty = Type::getInt8Ty(P->getContext());
+            // realloc allocates arg1 bytes.
+            return SE->getSCEVAtScope(CS.getArgument(1), L);
+        }
+    }
+
+    return SE->getCouldNotCompute();
 }
 
-Value *PointerTracking::computeAllocationCountValue(Value *P, constType *&Ty) const 
+Value *PointerTracking::computeAllocationCountValue(Value *P, constType *&Ty) const
 {
-  Value *V = P->stripPointerCasts();
-  if (AllocaInst *AI = dyn_cast<AllocaInst>(V)) {
-    Ty = AI->getAllocatedType();
-    // arraySize elements of type Ty.
-    return AI->getArraySize();
-  }
+    Value *V = P->stripPointerCasts();
+    if (AllocaInst *AI = dyn_cast<AllocaInst>(V)) {
+        Ty = AI->getAllocatedType();
+        // arraySize elements of type Ty.
+        return AI->getArraySize();
+    }
 
 #if LLVM_VERSION < 32
-  if (CallInst *CI = extractMallocCall(V)) {
-    Ty = getMallocAllocatedType(CI);
-    if (!Ty)
-      return 0;
-    Value *arraySize = getMallocArraySize(CI, TD);
+    if (CallInst *CI = extractMallocCall(V)) {
+        Ty = getMallocAllocatedType(CI);
+        if (!Ty)
+            return 0;
+        Value *arraySize = getMallocArraySize(CI, TD);
 #else
-  TargetLibraryInfo* TLI = new TargetLibraryInfo();
+    TargetLibraryInfo *TLI = new TargetLibraryInfo();
 
-  if (CallInst *CI = extractMallocCall(V, TLI)) {
-    Ty = getMallocAllocatedType(CI, TLI);
-    if (!Ty)
-      return 0;
-    Value *arraySize = getMallocArraySize(CI, TD, TLI);
+    if (CallInst *CI = extractMallocCall(V, TLI)) {
+        Ty = getMallocAllocatedType(CI, TLI);
+        if (!Ty)
+            return 0;
+        Value *arraySize = getMallocArraySize(CI, TD, TLI);
 #endif
-    if (!arraySize) {
-      Ty = Type::getInt8Ty(P->getContext());
-      return CI->getArgOperand(0);
+        if (!arraySize) {
+            Ty = Type::getInt8Ty(P->getContext());
+            return CI->getArgOperand(0);
+        }
+        // arraySize elements of type Ty.
+        return arraySize;
     }
-    // arraySize elements of type Ty.
-    return arraySize;
-  }
 
-  if (GlobalVariable *GV = dyn_cast<GlobalVariable>(V)) {
-    if (GV->hasDefinitiveInitializer()) {
-      Constant *C = GV->getInitializer();
-      if (const ArrayType *ATy = dyn_cast<ArrayType>(C->getType())) {
-        Ty = ATy->getElementType();
-        return ConstantInt::get(Type::getInt32Ty(P->getContext()),
-                               ATy->getNumElements());
-      }
+    if (GlobalVariable *GV = dyn_cast<GlobalVariable>(V)) {
+        if (GV->hasDefinitiveInitializer()) {
+            Constant *C = GV->getInitializer();
+            if (const ArrayType *ATy = dyn_cast<ArrayType>(C->getType())) {
+                Ty = ATy->getElementType();
+                return ConstantInt::get(Type::getInt32Ty(P->getContext()),
+                                        ATy->getNumElements());
+            }
+        }
+        Ty = cast<PointerType>(GV->getType())->getElementType();
+        return ConstantInt::get(Type::getInt32Ty(P->getContext()), 1);
+        //TODO: implement more tracking for globals
     }
-    Ty = cast<PointerType>(GV->getType())->getElementType();
-    return ConstantInt::get(Type::getInt32Ty(P->getContext()), 1);
-    //TODO: implement more tracking for globals
-  }
 
-  if (CallInst *CI = dyn_cast<CallInst>(V)) {
-    CallSite CS(CI);
-    Function *F = dyn_cast<Function>(CS.getCalledValue()->stripPointerCasts());
-    if (F == reallocFunc) {
-      Ty = Type::getInt8Ty(P->getContext());
-      // realloc allocates arg1 bytes.
-      return CS.getArgument(1);
+    if (CallInst *CI = dyn_cast<CallInst>(V)) {
+        CallSite CS(CI);
+        Function *F = dyn_cast<Function>(CS.getCalledValue()->stripPointerCasts());
+        if (F == reallocFunc) {
+            Ty = Type::getInt8Ty(P->getContext());
+            // realloc allocates arg1 bytes.
+            return CS.getArgument(1);
+        }
     }
-  }
 
-  return 0;
+    return 0;
 }
 
 // Calculates the number of elements of type Ty allocated for P.
 const SCEV *PointerTracking::computeAllocationCountForType(Value *P,
                                                            constType *Ty)
-  const {
+    const
+{
     constType *elementTy;
     const SCEV *Count = computeAllocationCount(P, elementTy);
     if (isa<SCEVCouldNotCompute>(Count))
-      return Count;
+        return Count;
     if (elementTy == Ty)
-      return Count;
+        return Count;
 
     if (!TD) // need TargetData from this point forward
-      return SE->getCouldNotCompute();
+        return SE->getCouldNotCompute();
 
     uint64_t elementSize = TD->getTypeAllocSize(elementTy);
-    uint64_t wantSize = TD->getTypeAllocSize(Ty);
+    uint64_t wantSize    = TD->getTypeAllocSize(Ty);
     if (elementSize == wantSize)
-      return Count;
+        return Count;
     if (elementSize % wantSize) //fractional counts not possible
-      return SE->getCouldNotCompute();
+        return SE->getCouldNotCompute();
     return SE->getMulExpr(Count, SE->getConstant(Count->getType(),
-                                                 elementSize/wantSize));
+                                                 elementSize / wantSize));
 }
 
-const SCEV *PointerTracking::getAllocationElementCount(Value *V) const {
-  // We only deal with pointers.
-  const PointerType *PTy = cast<PointerType>(V->getType());
-  return computeAllocationCountForType(V, PTy->getElementType());
+const SCEV *PointerTracking::getAllocationElementCount(Value *V) const
+{
+    // We only deal with pointers.
+    const PointerType *PTy = cast<PointerType>(V->getType());
+    return computeAllocationCountForType(V, PTy->getElementType());
 }
 
-const SCEV *PointerTracking::getAllocationSizeInBytes(Value *V) const {
-  return computeAllocationCountForType(V, Type::getInt8Ty(V->getContext()));
+const SCEV *PointerTracking::getAllocationSizeInBytes(Value *V) const
+{
+    return computeAllocationCountForType(V, Type::getInt8Ty(V->getContext()));
 }
 
 // Helper for isLoopGuardedBy that checks the swapped and inverted predicate too
 enum SolverResult PointerTracking::isLoopGuardedBy(const Loop *L,
                                                    Predicate Pred,
                                                    const SCEV *A,
-                                                   const SCEV *B) const {
-  if (SE->isLoopEntryGuardedByCond(L, Pred, A, B))
-    return AlwaysTrue;
-  Pred = ICmpInst::getSwappedPredicate(Pred);
-  if (SE->isLoopEntryGuardedByCond(L, Pred, B, A))
-    return AlwaysTrue;
+                                                   const SCEV *B) const
+{
+    if (SE->isLoopEntryGuardedByCond(L, Pred, A, B))
+        return AlwaysTrue;
+    Pred = ICmpInst::getSwappedPredicate(Pred);
+    if (SE->isLoopEntryGuardedByCond(L, Pred, B, A))
+        return AlwaysTrue;
 
-  Pred = ICmpInst::getInversePredicate(Pred);
-  if (SE->isLoopEntryGuardedByCond(L, Pred, B, A))
-    return AlwaysFalse;
-  Pred = ICmpInst::getSwappedPredicate(Pred);
-  if (SE->isLoopEntryGuardedByCond(L, Pred, A, B))
-    return AlwaysTrue;
-  return Unknown;
+    Pred = ICmpInst::getInversePredicate(Pred);
+    if (SE->isLoopEntryGuardedByCond(L, Pred, B, A))
+        return AlwaysFalse;
+    Pred = ICmpInst::getSwappedPredicate(Pred);
+    if (SE->isLoopEntryGuardedByCond(L, Pred, A, B))
+        return AlwaysTrue;
+    return Unknown;
 }
 
 enum SolverResult PointerTracking::checkLimits(const SCEV *Offset,
                                                const SCEV *Limit,
                                                BasicBlock *BB)
 {
-  //FIXME: merge implementation
-  return Unknown;
+    //FIXME: merge implementation
+    return Unknown;
 }
 
 void PointerTracking::getPointerOffset(Value *Pointer, Value *&Base,
@@ -351,55 +362,56 @@ void PointerTracking::getPointerOffset(Value *Pointer, Value *&Base,
                                        const SCEV *&Offset) const
 {
     Pointer = Pointer->stripPointerCasts();
-    Base = GetUnderlyingObject(Pointer, TD);
-    Limit = getAllocationSizeInBytes(Base);
+    Base    = GetUnderlyingObject(Pointer, TD);
+    Limit   = getAllocationSizeInBytes(Base);
     if (isa<SCEVCouldNotCompute>(Limit)) {
-      Base = 0;
-      Offset = Limit;
-      return;
+        Base   = 0;
+        Offset = Limit;
+        return;
     }
 
     Offset = SE->getMinusSCEV(SE->getSCEV(Pointer), SE->getSCEV(Base));
     if (isa<SCEVCouldNotCompute>(Offset)) {
-      Base = 0;
-      Limit = Offset;
+        Base  = 0;
+        Limit = Offset;
     }
 }
 
-void PointerTracking::print(raw_ostream &OS, const Module* M) const {
-  // Calling some PT methods may cause caches to be updated, however
-  // this should be safe for the same reason its safe for SCEV.
-  PointerTracking &PT = *const_cast<PointerTracking*>(this);
-  for (inst_iterator I=inst_begin(*FF), E=inst_end(*FF); I != E; ++I) {
-    if (!I->getType()->isPointerTy())
-      continue;
-    Value *Base;
-    const SCEV *Limit, *Offset;
-    getPointerOffset(&*I, Base, Limit, Offset);
-    if (!Base)
-      continue;
+void PointerTracking::print(raw_ostream &OS, const Module *M) const
+{
+    // Calling some PT methods may cause caches to be updated, however
+    // this should be safe for the same reason its safe for SCEV.
+    PointerTracking &PT = *const_cast<PointerTracking *>(this);
+    for (inst_iterator I = inst_begin(*FF), E = inst_end(*FF); I != E; ++I) {
+        if (!I->getType()->isPointerTy())
+            continue;
+        Value *Base;
+        const SCEV *Limit, *Offset;
+        getPointerOffset(&*I, Base, Limit, Offset);
+        if (!Base)
+            continue;
 
-    if (Base == &*I) {
-      const SCEV *S = getAllocationElementCount(Base);
-      OS << *Base << " ==> " << *S << " elements, ";
-      OS << *Limit << " bytes allocated\n";
-      continue;
-    }
-    OS << &*I << " -- base: " << *Base;
-    OS << " offset: " << *Offset;
+        if (Base == &*I) {
+            const SCEV *S = getAllocationElementCount(Base);
+            OS << *Base << " ==> " << *S << " elements, ";
+            OS << *Limit << " bytes allocated\n";
+            continue;
+        }
+        OS << &*I << " -- base: " << *Base;
+        OS << " offset: " << *Offset;
 
-    enum SolverResult res = PT.checkLimits(Offset, Limit, I->getParent());
-    switch (res) {
-    case AlwaysTrue:
-      OS << " always safe\n";
-      break;
-    case AlwaysFalse:
-      OS << " always unsafe\n";
-      break;
-    case Unknown:
-      OS << " <<unknown>>\n";
-      break;
+        enum SolverResult res = PT.checkLimits(Offset, Limit, I->getParent());
+        switch (res) {
+            case AlwaysTrue:
+                OS << " always safe\n";
+                break;
+            case AlwaysFalse:
+                OS << " always unsafe\n";
+                break;
+            case Unknown:
+                OS << " <<unknown>>\n";
+                break;
+        }
     }
-  }
 }
 #endif

--- a/libclamav/c++/PointerTracking.h
+++ b/libclamav/c++/PointerTracking.h
@@ -45,31 +45,33 @@
 #include "llvm/IR/Instructions.h"
 #endif
 
-namespace llvm {
-  class DominatorTree;
-  class ScalarEvolution;
-  class SCEV;
-  class Loop;
-  class LoopInfo;
+namespace llvm
+{
+class DominatorTree;
+class ScalarEvolution;
+class SCEV;
+class Loop;
+class LoopInfo;
 #if LLVM_VERSION < 32
-  class TargetData;
+class TargetData;
 #else
-  class DataLayout;
+class DataLayout;
 #endif
 
-  // Result from solver, assuming pointer is not NULL,
-  // and it is not a use-after-free situation.
-  enum SolverResult {
-    AlwaysFalse,// always false with above constraints
-    AlwaysTrue,// always true with above constraints
-    Unknown // it can sometimes be true, sometimes false, or it is undecided
-  };
+// Result from solver, assuming pointer is not NULL,
+// and it is not a use-after-free situation.
+enum SolverResult {
+    AlwaysFalse, // always false with above constraints
+    AlwaysTrue,  // always true with above constraints
+    Unknown      // it can sometimes be true, sometimes false, or it is undecided
+};
 
 #if LLVM_VERSION >= 29
-  void initializePointerTrackingPass(PassRegistry&);
+void initializePointerTrackingPass(PassRegistry &);
 #endif
 
-  class PointerTracking : public FunctionPass {
+class PointerTracking : public FunctionPass
+{
   public:
     typedef ICmpInst::Predicate Predicate;
     static char ID;
@@ -93,7 +95,7 @@ namespace llvm {
     // When unable to determine, sets Base to NULL, and Limit/Offset to
     // CouldNotCompute.
     // BaseSize, and Offset are in bytes: Pointer == Base + Offset
-    void getPointerOffset(Value *Pointer, Value *&Base, const SCEV *& BaseSize,
+    void getPointerOffset(Value *Pointer, Value *&Base, const SCEV *&BaseSize,
                           const SCEV *&Offset) const;
 
     // Compares the 2 scalar evolution expressions according to predicate,
@@ -117,8 +119,9 @@ namespace llvm {
 
     virtual bool runOnFunction(Function &F);
     virtual void getAnalysisUsage(AnalysisUsage &AU) const;
-    void print(raw_ostream &OS, const Module* = 0) const;
+    void print(raw_ostream &OS, const Module * = 0) const;
     Value *computeAllocationCountValue(Value *P, constType *&Ty) const;
+
   private:
     Function *FF;
 #if LLVM_VERSION < 32
@@ -136,12 +139,12 @@ namespace llvm {
     Function *reallocFunc;
     PredIteratorCache predCache;
 
-    SmallPtrSet<const SCEV*, 1> analyzing;
+    SmallPtrSet<const SCEV *, 1> analyzing;
 
     enum SolverResult isLoopGuardedBy(const Loop *L, Predicate Pred,
                                       const SCEV *A, const SCEV *B) const;
     static bool isMonotonic(const SCEV *S);
-    bool scevPositive(const SCEV *A, const Loop *L, bool strict=true) const;
+    bool scevPositive(const SCEV *A, const Loop *L, bool strict = true) const;
     bool conditionSufficient(Value *Cond, bool negated,
                              const SCEV *A, Predicate Pred, const SCEV *B);
     Value *getConditionToReach(BasicBlock *A,
@@ -152,7 +155,6 @@ namespace llvm {
                                bool &negated);
     const SCEV *computeAllocationCount(Value *P, constType *&Ty) const;
     const SCEV *computeAllocationCountForType(Value *P, constType *Ty) const;
-  };
-}
+};
+} // namespace llvm
 #endif
-

--- a/libclamav/c++/bytecode2llvm.cpp
+++ b/libclamav/c++/bytecode2llvm.cpp
@@ -208,25 +208,27 @@ void LLVMInitializePowerPCAsmPrinter();
 
 extern "C" unsigned int cli_rndnum(unsigned int max);
 using namespace llvm;
-typedef DenseMap<const struct cli_bc_func*, void*> FunctionMapTy;
+typedef DenseMap<const struct cli_bc_func *, void *> FunctionMapTy;
 struct cli_bcengine {
     ExecutionEngine *EE;
     JITEventListener *Listener;
     LLVMContext Context;
     FunctionMapTy compiledFunctions;
     union {
-	unsigned char b[16];
-	void* align;/* just to align field to ptr */
+        unsigned char b[16];
+        void *align; /* just to align field to ptr */
     } guard;
 };
 
 extern "C" uint8_t cli_debug_flag;
 #if LLVM_VERSION >= 29
-namespace llvm {
-    void initializeRuntimeLimitsPass(PassRegistry&);
+namespace llvm
+{
+void initializeRuntimeLimitsPass(PassRegistry &);
 };
 #endif
-namespace {
+namespace
+{
 
 #if LLVM_VERSION >= 28
 #define llvm_report_error(x) report_fatal_error(x)
@@ -248,7 +250,7 @@ static void UpgradeCall(CallInst *&C, Function *Intr)
 {
     Function *New;
     if (!UpgradeIntrinsicFunction(Intr, New) || New == Intr)
-	return;
+        return;
     UpgradeIntrinsicCall(C, New);
 }
 
@@ -272,39 +274,48 @@ void cli_dbgmsg_internal(const char *str, ...);
 #endif
 }
 
-class ScopedExceptionHandler {
-    public:
-	jmp_buf &getEnv() { return env;}
-	void Set() {
-	    /* set the exception handler's return location to here for the
+class ScopedExceptionHandler
+{
+  public:
+    jmp_buf &getEnv()
+    {
+        return env;
+    }
+    void Set()
+    {
+        /* set the exception handler's return location to here for the
 	     * current thread */
-	    ExceptionReturn.set((const jmp_buf*)&env);
-	}
-	~ScopedExceptionHandler() {
-	    /* leaving scope, remove exception handler for current thread */
-	    ExceptionReturn.erase();
-	}
-    private:
-	jmp_buf env;
+        ExceptionReturn.set((const jmp_buf *)&env);
+    }
+    ~ScopedExceptionHandler()
+    {
+        /* leaving scope, remove exception handler for current thread */
+        ExceptionReturn.erase();
+    }
+
+  private:
+    jmp_buf env;
 };
-#define HANDLER_TRY(handler) \
-    if (setjmp(handler.getEnv()) == 0) {\
-	handler.Set();
+#define HANDLER_TRY(handler)             \
+    if (setjmp(handler.getEnv()) == 0) { \
+        handler.Set();
 
 #define HANDLER_END(handler) \
-    } else cli_warnmsg("[Bytecode JIT]: recovered from error\n");
+    }                        \
+    else cli_warnmsg("[Bytecode JIT]: recovered from error\n");
 
-
-void do_shutdown() {
+void do_shutdown()
+{
     ScopedExceptionHandler handler;
-    HANDLER_TRY(handler) {
-	// TODO: be on the safe side, and clear errors here,
-	// otherwise destructor calls report_fatal_error
-	((class raw_fd_ostream&)errs()).clear_error();
+    HANDLER_TRY(handler)
+    {
+        // TODO: be on the safe side, and clear errors here,
+        // otherwise destructor calls report_fatal_error
+        ((class raw_fd_ostream &)errs()).clear_error();
 
-	llvm_shutdown();
+        llvm_shutdown();
 
-	((class raw_fd_ostream&)errs()).clear_error();
+        ((class raw_fd_ostream &)errs()).clear_error();
     }
     HANDLER_END(handler);
     remove_fatal_error_handler();
@@ -312,17 +323,17 @@ void do_shutdown() {
 
 static void NORETURN jit_exception_handler(void)
 {
-    jmp_buf* buf = const_cast<jmp_buf*>(ExceptionReturn.get());
+    jmp_buf *buf = const_cast<jmp_buf *>(ExceptionReturn.get());
     if (buf) {
-	// For errors raised during bytecode generation and execution.
-	longjmp(*buf, 1);
+        // For errors raised during bytecode generation and execution.
+        longjmp(*buf, 1);
     } else {
-	// Oops, got no error recovery pointer set up,
-	// this is probably an error raised during shutdown.
-	cli_errmsg("[Bytecode JIT]: exception handler called, but no recovery point set up");
-	// should never happen, we remove the error handler when we don't use
-	// LLVM anymore, and when we use it, we do set an error recovery point.
-	llvm_unreachable("Bytecode JIT]: no exception handler recovery installed, but exception hit!");
+        // Oops, got no error recovery pointer set up,
+        // this is probably an error raised during shutdown.
+        cli_errmsg("[Bytecode JIT]: exception handler called, but no recovery point set up");
+        // should never happen, we remove the error handler when we don't use
+        // LLVM anymore, and when we use it, we do set an error recovery point.
+        llvm_unreachable("Bytecode JIT]: no exception handler recovery installed, but exception hit!");
     }
 }
 
@@ -348,27 +359,27 @@ void llvm_error_handler(void *user_data, const std::string &reason, bool gen_cra
 // the appropriate libcall if needed.
 static int64_t rtlib_sdiv_i64(int64_t a, int64_t b)
 {
-    return a/b;
+    return a / b;
 }
 
 static uint64_t rtlib_udiv_i64(uint64_t a, uint64_t b)
 {
-    return a/b;
+    return a / b;
 }
 
 static int64_t rtlib_srem_i64(int64_t a, int64_t b)
 {
-    return a%b;
+    return a % b;
 }
 
 static uint64_t rtlib_urem_i64(uint64_t a, uint64_t b)
 {
-    return a%b;
+    return a % b;
 }
 
 static int64_t rtlib_mul_i64(uint64_t a, uint64_t b)
 {
-    return a*b;
+    return a * b;
 }
 
 static int64_t rtlib_shl_i64(int64_t a, int32_t b)
@@ -382,13 +393,13 @@ static int64_t rtlib_srl_i64(int64_t a, int32_t b)
 }
 /* Implementation independent sign-extended signed right shift */
 #ifdef HAVE_SAR
-#define CLI_SRS(n,s) ((n)>>(s))
+#define CLI_SRS(n, s) ((n) >> (s))
 #else
-#define CLI_SRS(n,s) ((((n)>>(s)) ^ (1<<(sizeof(n)*8-1-s))) - (1<<(sizeof(n)*8-1-s)))
+#define CLI_SRS(n, s) ((((n) >> (s)) ^ (1 << (sizeof(n) * 8 - 1 - s))) - (1 << (sizeof(n) * 8 - 1 - s)))
 #endif
 static int64_t rtlib_sra_i64(int64_t a, int32_t b)
 {
-    return CLI_SRS(a, b);//CLI_./..
+    return CLI_SRS(a, b); //CLI_./..
 }
 
 static void rtlib_bzero(void *s, size_t n)
@@ -404,57 +415,59 @@ extern "C" void _chkstk(void);
 #endif
 #endif
 // Resolve integer libcalls, but nothing else.
-static void* noUnknownFunctions(const std::string& name) {
+static void *noUnknownFunctions(const std::string &name)
+{
     void *addr =
-	StringSwitch<void*>(name)
-	.Case("__divdi3", (void*)(intptr_t)rtlib_sdiv_i64)
-	.Case("__udivdi3", (void*)(intptr_t)rtlib_udiv_i64)
-	.Case("__moddi3", (void*)(intptr_t)rtlib_srem_i64)
-	.Case("__umoddi3", (void*)(intptr_t)rtlib_urem_i64)
-	.Case("__muldi3", (void*)(intptr_t)rtlib_mul_i64)
-	.Case("__ashrdi3", (void*)(intptr_t)rtlib_sra_i64)
-	.Case("__ashldi3", (void*)(intptr_t)rtlib_shl_i64)
-	.Case("__lshrdi3", (void*)(intptr_t)rtlib_srl_i64)
-	.Case("__bzero", (void*)(intptr_t)rtlib_bzero)
-	.Case("memmove", (void*)(intptr_t)memmove)
-	.Case("memcpy", (void*)(intptr_t)memcpy)
-	.Case("memset", (void*)(intptr_t)memset)
-	.Case("abort", (void*)(intptr_t)jit_exception_handler)
+        StringSwitch<void *>(name)
+            .Case("__divdi3", (void *)(intptr_t)rtlib_sdiv_i64)
+            .Case("__udivdi3", (void *)(intptr_t)rtlib_udiv_i64)
+            .Case("__moddi3", (void *)(intptr_t)rtlib_srem_i64)
+            .Case("__umoddi3", (void *)(intptr_t)rtlib_urem_i64)
+            .Case("__muldi3", (void *)(intptr_t)rtlib_mul_i64)
+            .Case("__ashrdi3", (void *)(intptr_t)rtlib_sra_i64)
+            .Case("__ashldi3", (void *)(intptr_t)rtlib_shl_i64)
+            .Case("__lshrdi3", (void *)(intptr_t)rtlib_srl_i64)
+            .Case("__bzero", (void *)(intptr_t)rtlib_bzero)
+            .Case("memmove", (void *)(intptr_t)memmove)
+            .Case("memcpy", (void *)(intptr_t)memcpy)
+            .Case("memset", (void *)(intptr_t)memset)
+            .Case("abort", (void *)(intptr_t)jit_exception_handler)
 #ifdef _WIN32
 #ifdef _WIN64
-	.Case("_chkstk", (void*)(intptr_t)__chkstk)
+            .Case("_chkstk", (void *)(intptr_t)__chkstk)
 #else
-	.Case("_chkstk", (void*)(intptr_t)_chkstk)
+            .Case("_chkstk", (void *)(intptr_t)_chkstk)
 #endif
 #endif
-	.Default(0);
+            .Default(0);
     if (addr)
-	return addr;
+        return addr;
 
 #if LLVM_VERSION < 36
-    std::string reason((Twine("Attempt to call external function ")+name).str());
+    std::string reason((Twine("Attempt to call external function ") + name).str());
     llvm_error_handler(0, reason);
 #else
-    // noUnknownFunctions relies on addGlobalMapping, which doesn't work with MCJIT.
-    // Now the function pointers are found with SymbolSearching.
+        // noUnknownFunctions relies on addGlobalMapping, which doesn't work with MCJIT.
+        // Now the function pointers are found with SymbolSearching.
 #endif
     return 0;
 }
 
-class NotifyListener : public JITEventListener {
-public:
+class NotifyListener : public JITEventListener
+{
+  public:
 #if LLVM_VERSION < 36
     virtual void NotifyFunctionEmitted(const Function &F,
-				       void *Code, size_t Size,
-				       const EmittedFunctionDetails &Details)
+                                       void *Code, size_t Size,
+                                       const EmittedFunctionDetails &Details)
     {
-	if (!cli_debug_flag)
-	    return;
-	cli_dbgmsg_internal("[Bytecode JIT]: emitted function %s of %ld bytes at %p\n",
+        if (!cli_debug_flag)
+            return;
+        cli_dbgmsg_internal("[Bytecode JIT]: emitted function %s of %ld bytes at %p\n",
 #if LLVM_VERSION < 31
-			    F.getNameStr().c_str(), (long)Size, Code);
+                            F.getNameStr().c_str(), (long)Size, Code);
 #else
-			    F.getName().str().c_str(), (long)Size, Code);
+                            F.getName().str().c_str(), (long)Size, Code);
 #endif
     }
 #else
@@ -471,150 +484,155 @@ public:
 #endif
 };
 
-class TimerWrapper {
-private:
+class TimerWrapper
+{
+  private:
     Timer *t;
-public:
-    TimerWrapper(const std::string &name) {
-	t = 0;
+
+  public:
+    TimerWrapper(const std::string &name)
+    {
+        t = 0;
 #ifdef TIMING
-	t = new Timer(name);
+        t = new Timer(name);
 #endif
     }
     ~TimerWrapper()
     {
-	if (t)
-	    delete t;
+        if (t)
+            delete t;
     }
     void startTimer()
     {
-	if (t)
-	    t->startTimer();
+        if (t)
+            t->startTimer();
     }
     void stopTimer()
     {
-	if (t)
-	    t->stopTimer();
+        if (t)
+            t->stopTimer();
     }
 };
 
-class LLVMTypeMapper {
-private:
+class LLVMTypeMapper
+{
+  private:
 #if LLVM_VERSION < 30
     std::vector<PATypeHolder> TypeMap;
 #else
-    std::vector<Type*> TypeMap;
+    std::vector<Type *> TypeMap;
 #endif
     LLVMContext &Context;
     unsigned numTypes;
     constType *getStatic(uint16_t ty)
     {
-	if (!ty)
-	    return Type::getVoidTy(Context);
-	if (ty <= 64)
-	    return IntegerType::get(Context, ty);
-	switch (ty) {
-	    case 65:
-		return PointerType::getUnqual(Type::getInt8Ty(Context));
-	    case 66:
-		return PointerType::getUnqual(Type::getInt16Ty(Context));
-	    case 67:
-		return PointerType::getUnqual(Type::getInt32Ty(Context));
-	    case 68:
-		return PointerType::getUnqual(Type::getInt64Ty(Context));
-	}
-	llvm_unreachable("getStatic");
+        if (!ty)
+            return Type::getVoidTy(Context);
+        if (ty <= 64)
+            return IntegerType::get(Context, ty);
+        switch (ty) {
+            case 65:
+                return PointerType::getUnqual(Type::getInt8Ty(Context));
+            case 66:
+                return PointerType::getUnqual(Type::getInt16Ty(Context));
+            case 67:
+                return PointerType::getUnqual(Type::getInt32Ty(Context));
+            case 68:
+                return PointerType::getUnqual(Type::getInt64Ty(Context));
+        }
+        llvm_unreachable("getStatic");
     }
-public:
+
+  public:
     TimerWrapper pmTimer;
     TimerWrapper irgenTimer;
 
     LLVMTypeMapper(LLVMContext &Context, const struct cli_bc_type *types,
-		   unsigned count, constType *Hidden=0) : Context(Context), numTypes(count),
-    pmTimer("Function passes"),irgenTimer("IR generation")
+                   unsigned count, constType *Hidden = 0)
+        : Context(Context), numTypes(count),
+          pmTimer("Function passes"), irgenTimer("IR generation")
     {
-	TypeMap.reserve(count);
-	// During recursive type construction pointers to Type* may be
-	// invalidated, so we must use a TypeHolder to an Opaque type as a
-	// start.
-	for (unsigned i=0;i<count;i++) {
+        TypeMap.reserve(count);
+        // During recursive type construction pointers to Type* may be
+        // invalidated, so we must use a TypeHolder to an Opaque type as a
+        // start.
+        for (unsigned i = 0; i < count; i++) {
 #if LLVM_VERSION < 30
-	    TypeMap.push_back(OpaqueType::get(Context));
+            TypeMap.push_back(OpaqueType::get(Context));
 #else
-	    TypeMap.push_back(0);
+            TypeMap.push_back(0);
 #endif
-	}
-	for (unsigned i=0;i<count;i++) {
-	    const struct cli_bc_type *type = &types[i];
+        }
+        for (unsigned i = 0; i < count; i++) {
+            const struct cli_bc_type *type = &types[i];
 
-	    constType *Ty = buildType(type, types, Hidden, 0);
+            constType *Ty = buildType(type, types, Hidden, 0);
 #if LLVM_VERSION < 30
-	    // Make the opaque type a concrete type, doing recursive type
-	    // unification if needed.
-	    cast<OpaqueType>(TypeMap[i].get())->refineAbstractTypeTo(Ty);
+            // Make the opaque type a concrete type, doing recursive type
+            // unification if needed.
+            cast<OpaqueType>(TypeMap[i].get())->refineAbstractTypeTo(Ty);
 #else
-	    TypeMap[i] = Ty;
+            TypeMap[i] = Ty;
 #endif
-	}
+        }
     }
 
     constType *buildType(const struct cli_bc_type *type, const struct cli_bc_type *types, constType *Hidden,
-			 int recursive)
+                         int recursive)
     {
-	std::vector<constType*> Elts;
-	unsigned n = type->kind == DArrayType ? 1 : type->numElements;
-	for (unsigned j=0;j<n;j++) {
-	    Elts.push_back(get(type->containedTypes[j], types, Hidden));
-	}
-	constType *Ty;
-	switch (type->kind) {
-	    case DFunctionType:
-		{
-		    assert(Elts.size() > 0 && "Function with no return type?");
-		    constType *RetTy = Elts[0];
-		    if (Hidden)
-			Elts[0] = Hidden;
-		    else
-			Elts.erase(Elts.begin());
-		    Ty = FunctionType::get(RetTy, Elts, false);
-		    break;
-		}
-	    case DPointerType:
-		if (!PointerType::isValidElementType(Elts[0]))
-		    Ty = PointerType::getUnqual(Type::getInt8Ty(Context));
-		else
-		    Ty = PointerType::getUnqual(Elts[0]);
-		break;
-	    case DStructType:
-	    case DPackedStructType:
-		Ty = StructType::get(Context, Elts, type->kind == DPackedStructType);
-		break;
-	    case DArrayType:
-		Ty = ArrayType::get(Elts[0], type->numElements);
-		break;
-	    default:
-		llvm_unreachable("type->kind");
-	}
-	return Ty;
+        std::vector<constType *> Elts;
+        unsigned n = type->kind == DArrayType ? 1 : type->numElements;
+        for (unsigned j = 0; j < n; j++) {
+            Elts.push_back(get(type->containedTypes[j], types, Hidden));
+        }
+        constType *Ty;
+        switch (type->kind) {
+            case DFunctionType: {
+                assert(Elts.size() > 0 && "Function with no return type?");
+                constType *RetTy = Elts[0];
+                if (Hidden)
+                    Elts[0] = Hidden;
+                else
+                    Elts.erase(Elts.begin());
+                Ty = FunctionType::get(RetTy, Elts, false);
+                break;
+            }
+            case DPointerType:
+                if (!PointerType::isValidElementType(Elts[0]))
+                    Ty = PointerType::getUnqual(Type::getInt8Ty(Context));
+                else
+                    Ty = PointerType::getUnqual(Elts[0]);
+                break;
+            case DStructType:
+            case DPackedStructType:
+                Ty = StructType::get(Context, Elts, type->kind == DPackedStructType);
+                break;
+            case DArrayType:
+                Ty = ArrayType::get(Elts[0], type->numElements);
+                break;
+            default:
+                llvm_unreachable("type->kind");
+        }
+        return Ty;
     }
 
     constType *get(uint16_t ty, const struct cli_bc_type *types, constType *Hidden)
     {
-	ty &= 0x7fff;
-	if (ty < 69)
-	    return getStatic(ty);
-	ty -= 69;
-	assert(ty < numTypes && "TypeID out of range");
+        ty &= 0x7fff;
+        if (ty < 69)
+            return getStatic(ty);
+        ty -= 69;
+        assert(ty < numTypes && "TypeID out of range");
 #if LLVM_VERSION < 30
-	return TypeMap[ty].get();
+        return TypeMap[ty].get();
 #else
-	Type *Ty = TypeMap[ty];
-	if (Ty)
-	    return Ty;
-	assert(types && Hidden || "accessing not-yet-built type");
-	Ty = buildType(&types[ty], types, Hidden, 1);
-	TypeMap[ty] = Ty;
-	return Ty;
+        Type *Ty = TypeMap[ty];
+        if (Ty)
+            return Ty;
+        assert(types && Hidden || "accessing not-yet-built type");
+        Ty          = buildType(&types[ty], types, Hidden, 1);
+        TypeMap[ty] = Ty;
+        return Ty;
 #endif
     }
 };
@@ -639,129 +657,134 @@ static const unsigned LoopThreshold = 1000;
 // after every N API calls we need timeout check
 static const unsigned ApiThreshold = 100;
 
-class RuntimeLimits : public FunctionPass {
-    typedef SmallVector<std::pair<const BasicBlock*, const BasicBlock*>, 16>
-	BBPairVectorTy;
-    typedef SmallSet<BasicBlock*, 16> BBSetTy;
-    typedef DenseMap<const BasicBlock*, unsigned> BBMapTy;
-    bool loopNeedsTimeoutCheck(ScalarEvolution &SE, const Loop *L, BBMapTy &Map) {
-	// This BB is a loop header, if trip count is small enough
-	// no timeout checks are needed here.
-	const SCEV *S = SE.getMaxBackedgeTakenCount(L);
-	if (isa<SCEVCouldNotCompute>(S))
-	    return true;
-	DEBUG(errs() << "Found loop trip count" << *S << "\n");
-	ConstantRange CR = SE.getUnsignedRange(S);
-	uint64_t max = CR.getUnsignedMax().getLimitedValue();
-	DEBUG(errs() << "Found max trip count " << max << "\n");
-	if (max > LoopThreshold)
-	    return true;
-	unsigned apicalls = 0;
-	for (Loop::block_iterator J=L->block_begin(),JE=L->block_end();
-	     J != JE; ++J) {
-	    apicalls += Map[*J];
-	}
-	apicalls *= max;
-	if (apicalls > ApiThreshold) {
-	    DEBUG(errs() << "apicall threshold exceeded: " << apicalls << "\n");
-	    return true;
-	}
-	Map[L->getHeader()] = apicalls;
-	return false;
+class RuntimeLimits : public FunctionPass
+{
+    typedef SmallVector<std::pair<const BasicBlock *, const BasicBlock *>, 16>
+        BBPairVectorTy;
+    typedef SmallSet<BasicBlock *, 16> BBSetTy;
+    typedef DenseMap<const BasicBlock *, unsigned> BBMapTy;
+    bool loopNeedsTimeoutCheck(ScalarEvolution &SE, const Loop *L, BBMapTy &Map)
+    {
+        // This BB is a loop header, if trip count is small enough
+        // no timeout checks are needed here.
+        const SCEV *S = SE.getMaxBackedgeTakenCount(L);
+        if (isa<SCEVCouldNotCompute>(S))
+            return true;
+        DEBUG(errs() << "Found loop trip count" << *S << "\n");
+        ConstantRange CR = SE.getUnsignedRange(S);
+        uint64_t max     = CR.getUnsignedMax().getLimitedValue();
+        DEBUG(errs() << "Found max trip count " << max << "\n");
+        if (max > LoopThreshold)
+            return true;
+        unsigned apicalls = 0;
+        for (Loop::block_iterator J = L->block_begin(), JE = L->block_end();
+             J != JE; ++J) {
+            apicalls += Map[*J];
+        }
+        apicalls *= max;
+        if (apicalls > ApiThreshold) {
+            DEBUG(errs() << "apicall threshold exceeded: " << apicalls << "\n");
+            return true;
+        }
+        Map[L->getHeader()] = apicalls;
+        return false;
     }
 
-public:
+  public:
     static char ID;
-    DEFINEPASS(RuntimeLimits) {
+    DEFINEPASS(RuntimeLimits)
+    {
 #if LLVM_VERSION >= 29
-	PassRegistry &Registry = *PassRegistry::getPassRegistry();
-	initializeRuntimeLimitsPass(Registry);
+        PassRegistry &Registry = *PassRegistry::getPassRegistry();
+        initializeRuntimeLimitsPass(Registry);
 #endif
     }
 
-    virtual bool runOnFunction(Function &F) {
-	BBSetTy BackedgeTargets;
-	if (!F.isDeclaration()) {
-	    // Get the common backedge targets.
-	    // Note that we don't rely on LoopInfo here, since
-	    // it is possible to construct a CFG that doesn't have natural loops,
-	    // yet it does have backedges, and thus can lead to unbounded/high
-	    // execution time.
-	    BBPairVectorTy V;
-	    FindFunctionBackedges(F, V);
-	    for (BBPairVectorTy::iterator I=V.begin(),E=V.end();I != E; ++I) {
-		BackedgeTargets.insert(const_cast<BasicBlock*>(I->second));
-	    }
-	}
-	BBSetTy  needsTimeoutCheck;
-	BBMapTy BBMap;
+    virtual bool runOnFunction(Function &F)
+    {
+        BBSetTy BackedgeTargets;
+        if (!F.isDeclaration()) {
+            // Get the common backedge targets.
+            // Note that we don't rely on LoopInfo here, since
+            // it is possible to construct a CFG that doesn't have natural loops,
+            // yet it does have backedges, and thus can lead to unbounded/high
+            // execution time.
+            BBPairVectorTy V;
+            FindFunctionBackedges(F, V);
+            for (BBPairVectorTy::iterator I = V.begin(), E = V.end(); I != E; ++I) {
+                BackedgeTargets.insert(const_cast<BasicBlock *>(I->second));
+            }
+        }
+        BBSetTy needsTimeoutCheck;
+        BBMapTy BBMap;
 #if LLVM_VERSION < 35
-	DominatorTree &DT = getAnalysis<DominatorTree>();
+        DominatorTree &DT = getAnalysis<DominatorTree>();
 #else
-	DominatorTree &DT = getAnalysis<DominatorTreeWrapperPass>().getDomTree();
+        DominatorTree &DT = getAnalysis<DominatorTreeWrapperPass>().getDomTree();
 #endif
-	for (Function::iterator I=F.begin(),E=F.end(); I != E; ++I) {
-	    BasicBlock *BB = &*I;
-	    unsigned apicalls = 0;
-	    for (BasicBlock::const_iterator J=BB->begin(),JE=BB->end();
-		 J != JE; ++J) {
-		if (const CallInst *CI = dyn_cast<CallInst>(J)) {
-		    Function *F = CI->getCalledFunction();
-		    if (!F || F->isDeclaration())
-			apicalls++;
-		}
-	    }
-	    if (apicalls > ApiThreshold) {
-		DEBUG(errs() << "apicall threshold exceeded: " << apicalls << "\n");
-		needsTimeoutCheck.insert(BB);
-		apicalls = 0;
-	    }
-	    BBMap[BB] = apicalls;
-	}
-	if (!BackedgeTargets.empty()) {
-	    LoopInfo &LI = getAnalysis<LoopInfo>();
-	    ScalarEvolution &SE = getAnalysis<ScalarEvolution>();
+        for (Function::iterator I = F.begin(), E = F.end(); I != E; ++I) {
+            BasicBlock *BB    = &*I;
+            unsigned apicalls = 0;
+            for (BasicBlock::const_iterator J = BB->begin(), JE = BB->end();
+                 J != JE; ++J) {
+                if (const CallInst *CI = dyn_cast<CallInst>(J)) {
+                    Function *F = CI->getCalledFunction();
+                    if (!F || F->isDeclaration())
+                        apicalls++;
+                }
+            }
+            if (apicalls > ApiThreshold) {
+                DEBUG(errs() << "apicall threshold exceeded: " << apicalls << "\n");
+                needsTimeoutCheck.insert(BB);
+                apicalls = 0;
+            }
+            BBMap[BB] = apicalls;
+        }
+        if (!BackedgeTargets.empty()) {
+            LoopInfo &LI        = getAnalysis<LoopInfo>();
+            ScalarEvolution &SE = getAnalysis<ScalarEvolution>();
 
-	    // Now check whether any of these backedge targets are part of a loop
-	    // with a small constant trip count
-	    for (BBSetTy::iterator I=BackedgeTargets.begin(),E=BackedgeTargets.end();
-		 I != E; ++I) {
-		const Loop *L = LI.getLoopFor(*I);
-		if (L && L->getHeader() == *I &&
-		    !loopNeedsTimeoutCheck(SE, L, BBMap))
-		    continue;
-		needsTimeoutCheck.insert(*I);
-		BBMap[*I] = 0;
-	    }
-	}
-	// Estimate number of apicalls by walking dominator-tree bottom-up.
-	// BBs that have timeout checks are considered to have 0 APIcalls
-	// (since we already checked for timeout).
-	for (po_iterator<DomTreeNode*> I = po_begin(DT.getRootNode()),
-	     E = po_end(DT.getRootNode()); I != E; ++I) {
-	    if (needsTimeoutCheck.count(I->getBlock()))
-		continue;
-	    unsigned apicalls = BBMap[I->getBlock()];
-	    for (DomTreeNode::iterator J=I->begin(),JE=I->end();
-		 J != JE; ++J) {
-		apicalls += BBMap[(*J)->getBlock()];
-	    }
-	    if (apicalls > ApiThreshold) {
-		needsTimeoutCheck.insert(I->getBlock());
-		apicalls = 0;
-	    }
-	    BBMap[I->getBlock()] = apicalls;
-	}
-	if (needsTimeoutCheck.empty())
-	    return false;
-	DEBUG(errs() << "needs timeoutcheck:\n");
-	std::vector<constType*>args;
-	FunctionType* abrtTy = FunctionType::get(
-	    Type::getVoidTy(F.getContext()),args,false);
-	Constant *func_abort =
-	    F.getParent()->getOrInsertFunction("abort", abrtTy);
-	BasicBlock *AbrtBB = BasicBlock::Create(F.getContext(), "", &F);
-        CallInst* AbrtC = CallInst::Create(func_abort, "", AbrtBB);
+            // Now check whether any of these backedge targets are part of a loop
+            // with a small constant trip count
+            for (BBSetTy::iterator I = BackedgeTargets.begin(), E = BackedgeTargets.end();
+                 I != E; ++I) {
+                const Loop *L = LI.getLoopFor(*I);
+                if (L && L->getHeader() == *I &&
+                    !loopNeedsTimeoutCheck(SE, L, BBMap))
+                    continue;
+                needsTimeoutCheck.insert(*I);
+                BBMap[*I] = 0;
+            }
+        }
+        // Estimate number of apicalls by walking dominator-tree bottom-up.
+        // BBs that have timeout checks are considered to have 0 APIcalls
+        // (since we already checked for timeout).
+        for (po_iterator<DomTreeNode *> I = po_begin(DT.getRootNode()),
+                                        E = po_end(DT.getRootNode());
+             I != E; ++I) {
+            if (needsTimeoutCheck.count(I->getBlock()))
+                continue;
+            unsigned apicalls = BBMap[I->getBlock()];
+            for (DomTreeNode::iterator J = I->begin(), JE = I->end();
+                 J != JE; ++J) {
+                apicalls += BBMap[(*J)->getBlock()];
+            }
+            if (apicalls > ApiThreshold) {
+                needsTimeoutCheck.insert(I->getBlock());
+                apicalls = 0;
+            }
+            BBMap[I->getBlock()] = apicalls;
+        }
+        if (needsTimeoutCheck.empty())
+            return false;
+        DEBUG(errs() << "needs timeoutcheck:\n");
+        std::vector<constType *> args;
+        FunctionType *abrtTy = FunctionType::get(
+            Type::getVoidTy(F.getContext()), args, false);
+        Constant *func_abort =
+            F.getParent()->getOrInsertFunction("abort", abrtTy);
+        BasicBlock *AbrtBB = BasicBlock::Create(F.getContext(), "", &F);
+        CallInst *AbrtC    = CallInst::Create(func_abort, "", AbrtBB);
         AbrtC->setCallingConv(CallingConv::C);
         AbrtC->setTailCall(true);
 #if LLVM_VERSION < 32
@@ -772,64 +795,65 @@ public:
         AbrtC->setDoesNotThrow();
 #endif
         new UnreachableInst(F.getContext(), AbrtBB);
-	IRBuilder<false> Builder(F.getContext());
+        IRBuilder<false> Builder(F.getContext());
 
-	Value *Flag = F.arg_begin();
+        Value *Flag = F.arg_begin();
 #if LLVM_VERSION < 30
-	Function *LSBarrier = Intrinsic::getDeclaration(F.getParent(),
-							Intrinsic::memory_barrier);
-	Value *MBArgs[] = {
-	    ConstantInt::getFalse(F.getContext()),
-	    ConstantInt::getFalse(F.getContext()),
-	    ConstantInt::getTrue(F.getContext()),
-	    ConstantInt::getFalse(F.getContext()),
-	    ConstantInt::getFalse(F.getContext())
-	};
+        Function *LSBarrier = Intrinsic::getDeclaration(F.getParent(),
+                                                        Intrinsic::memory_barrier);
+        Value *MBArgs[]     = {
+            ConstantInt::getFalse(F.getContext()),
+            ConstantInt::getFalse(F.getContext()),
+            ConstantInt::getTrue(F.getContext()),
+            ConstantInt::getFalse(F.getContext()),
+            ConstantInt::getFalse(F.getContext())};
 #endif
-	verifyFunction(F);
-	BasicBlock *BB = &F.getEntryBlock();
-	Builder.SetInsertPoint(BB, BB->getTerminator());
-	Flag = Builder.CreatePointerCast(Flag, PointerType::getUnqual(
-		Type::getInt1Ty(F.getContext())));
-	for (BBSetTy::iterator I=needsTimeoutCheck.begin(),
-	     E=needsTimeoutCheck.end(); I != E; ++I) {
-	    BasicBlock *BB = *I;
-	    Builder.SetInsertPoint(BB, BB->getTerminator());
+        verifyFunction(F);
+        BasicBlock *BB = &F.getEntryBlock();
+        Builder.SetInsertPoint(BB, BB->getTerminator());
+        Flag = Builder.CreatePointerCast(Flag, PointerType::getUnqual(
+                                                   Type::getInt1Ty(F.getContext())));
+        for (BBSetTy::iterator I = needsTimeoutCheck.begin(),
+                               E = needsTimeoutCheck.end();
+             I != E; ++I) {
+            BasicBlock *BB = *I;
+            Builder.SetInsertPoint(BB, BB->getTerminator());
 #if LLVM_VERSION < 30
-	    // store-load barrier: will be a no-op on x86 but not other arches
-	    Builder.CreateCall(LSBarrier, ARRAYREF(Value*, MBArgs, MBArgs+5));
+            // store-load barrier: will be a no-op on x86 but not other arches
+            Builder.CreateCall(LSBarrier, ARRAYREF(Value *, MBArgs, MBArgs + 5));
 #else
-	    Builder.CreateFence(Release);
+            Builder.CreateFence(Release);
 #endif
-	    // Load Flag that tells us we timed out (first byte in bc_ctx)
-	    Value *Cond = Builder.CreateLoad(Flag, true);
-	    BasicBlock *newBB = SplitBlock(BB, BB->getTerminator(), this);
-	    TerminatorInst *TI = BB->getTerminator();
-	    BranchInst::Create(AbrtBB, newBB, Cond, TI);
-	    TI->eraseFromParent();
-	    // Update dominator info
-	    DomTreeNode *N = DT.getNode(AbrtBB);
-	    if (!N) {
-		DT.addNewBlock(AbrtBB, BB);
-	    } else {
-		BasicBlock *DomBB = DT.findNearestCommonDominator(BB,
-								  N->getIDom()->getBlock());
-		DT.changeImmediateDominator(AbrtBB, DomBB);
-	    }
-	    DEBUG(errs() << *I << "\n");
-	}
-	//verifyFunction(F);
-	return true;
+            // Load Flag that tells us we timed out (first byte in bc_ctx)
+            Value *Cond        = Builder.CreateLoad(Flag, true);
+            BasicBlock *newBB  = SplitBlock(BB, BB->getTerminator(), this);
+            TerminatorInst *TI = BB->getTerminator();
+            BranchInst::Create(AbrtBB, newBB, Cond, TI);
+            TI->eraseFromParent();
+            // Update dominator info
+            DomTreeNode *N = DT.getNode(AbrtBB);
+            if (!N) {
+                DT.addNewBlock(AbrtBB, BB);
+            } else {
+                BasicBlock *DomBB = DT.findNearestCommonDominator(BB,
+                                                                  N->getIDom()->getBlock());
+                DT.changeImmediateDominator(AbrtBB, DomBB);
+            }
+            DEBUG(errs() << *I << "\n");
+        }
+        //verifyFunction(F);
+        return true;
     }
 
-    virtual void getAnalysisUsage(AnalysisUsage &AU) const {
-      AU.setPreservesAll();
-      AU.addRequired<LoopInfo>();
-      AU.addRequired<ScalarEvolution>();
+    virtual void getAnalysisUsage(AnalysisUsage &AU) const
+    {
+        AU.setPreservesAll();
+        AU.addRequired<LoopInfo>();
+        AU.addRequired<ScalarEvolution>();
 #if LLVM_VERSION < 35
-      AU.addRequired<DominatorTree>();
+        AU.addRequired<DominatorTree>();
 #else
-      AU.addRequired<DominatorTreeWrapperPass>();
+        AU.addRequired<DominatorTreeWrapperPass>();
 #endif
     }
 };
@@ -837,51 +861,53 @@ char RuntimeLimits::ID;
 
 // select i1 false ... which instcombine would simplify but we don't run
 // instcombine.
-class BrSimplifier : public FunctionPass {
-public:
+class BrSimplifier : public FunctionPass
+{
+  public:
     static char ID;
     DEFINEPASS(BrSimplifier) {}
 
-    virtual bool runOnFunction(Function &F) {
-	bool Changed = false;
-	for (Function::iterator I=F.begin(),E=F.end(); I != E; ++I) {
-	    if (BranchInst *BI = dyn_cast<BranchInst>(I->getTerminator())) {
-		if (BI->isUnconditional())
-		    continue;
-		Value *V = BI->getCondition();
-		if (ConstantInt *CI = dyn_cast<ConstantInt>(V)) {
-		    BasicBlock *Other;
-		    if (CI->isOne()) {
-			BranchInst::Create(BI->getSuccessor(0), &*I);
-			Other = BI->getSuccessor(1);
-		    } else {
-			BranchInst::Create(BI->getSuccessor(1), &*I);
-			Other = BI->getSuccessor(0);
-		    }
-		    Other->removePredecessor(&*I);
-		    BI->eraseFromParent();
-		    Changed = true;
-		}
-	    }
-	    for (BasicBlock::iterator J=I->begin(),JE=I->end();
-		 J != JE;) {
-		SelectInst *SI = dyn_cast<SelectInst>(J);
-		++J;
-		if (!SI)
-		    continue;
-		ConstantInt *CI = dyn_cast<ConstantInt>(SI->getCondition());
-		if (!CI)
-		    continue;
-		if (CI->isOne())
-		    SI->replaceAllUsesWith(SI->getTrueValue());
-		else
-		    SI->replaceAllUsesWith(SI->getFalseValue());
-		SI->eraseFromParent();
-		Changed = true;
-	    }
-	}
+    virtual bool runOnFunction(Function &F)
+    {
+        bool Changed = false;
+        for (Function::iterator I = F.begin(), E = F.end(); I != E; ++I) {
+            if (BranchInst *BI = dyn_cast<BranchInst>(I->getTerminator())) {
+                if (BI->isUnconditional())
+                    continue;
+                Value *V = BI->getCondition();
+                if (ConstantInt *CI = dyn_cast<ConstantInt>(V)) {
+                    BasicBlock *Other;
+                    if (CI->isOne()) {
+                        BranchInst::Create(BI->getSuccessor(0), &*I);
+                        Other = BI->getSuccessor(1);
+                    } else {
+                        BranchInst::Create(BI->getSuccessor(1), &*I);
+                        Other = BI->getSuccessor(0);
+                    }
+                    Other->removePredecessor(&*I);
+                    BI->eraseFromParent();
+                    Changed = true;
+                }
+            }
+            for (BasicBlock::iterator J = I->begin(), JE = I->end();
+                 J != JE;) {
+                SelectInst *SI = dyn_cast<SelectInst>(J);
+                ++J;
+                if (!SI)
+                    continue;
+                ConstantInt *CI = dyn_cast<ConstantInt>(SI->getCondition());
+                if (!CI)
+                    continue;
+                if (CI->isOne())
+                    SI->replaceAllUsesWith(SI->getTrueValue());
+                else
+                    SI->replaceAllUsesWith(SI->getFalseValue());
+                SI->eraseFromParent();
+                Changed = true;
+            }
+        }
 
-	return Changed;
+        return Changed;
     }
 };
 char BrSimplifier::ID;
@@ -911,8 +937,9 @@ public:
 };
 char SimpleGlobalDCE::ID;
 */
-class LLVMCodegen {
-private:
+class LLVMCodegen
+{
+  private:
     const struct cli_bc *bc;
     Module *M;
     LLVMContext &Context;
@@ -928,1103 +955,1078 @@ private:
     TargetFolder Folder;
     IRBuilder<false, TargetFolder> Builder;
 
-    std::vector<Value*> globals;
+    std::vector<Value *> globals;
     DenseMap<unsigned, unsigned> GVoffsetMap;
-    DenseMap<unsigned, constType*> GVtypeMap;
+    DenseMap<unsigned, constType *> GVtypeMap;
     Value **Values;
     unsigned numLocals;
     unsigned numArgs;
-    std::vector<MDNode*> mdnodes;
+    std::vector<MDNode *> mdnodes;
 
     struct CommonFunctions *CF;
 
     Value *getOperand(const struct cli_bc_func *func, constType *Ty, operand_t operand)
     {
-	unsigned map[] = {0, 1, 2, 3, 3, 4, 4, 4, 4};
-	if (operand < func->numValues)
-	    return Values[operand];
-	unsigned w = Ty->getPrimitiveSizeInBits();
-	if (w > 1)
-	    w = (w+7)/8;
-	else
-	    w = 0;
-	return convertOperand(func, map[w], operand);
+        unsigned map[] = {0, 1, 2, 3, 3, 4, 4, 4, 4};
+        if (operand < func->numValues)
+            return Values[operand];
+        unsigned w = Ty->getPrimitiveSizeInBits();
+        if (w > 1)
+            w = (w + 7) / 8;
+        else
+            w = 0;
+        return convertOperand(func, map[w], operand);
     }
 
     Value *convertOperand(const struct cli_bc_func *func, constType *Ty, operand_t operand)
     {
-	unsigned map[] = {0, 1, 2, 3, 3, 4, 4, 4, 4};
-	if (operand < func->numArgs)
-	    return Values[operand];
-	if (operand < func->numValues) {
-	    Value *V = Values[operand];
-	    if (func->types[operand]&0x8000 && V->getType() == Ty) {
-		return V;
-	    }
-	    V = Builder.CreateLoad(V);
-	    if (V->getType() != Ty &&
-		isa<PointerType>(V->getType()) &&
-		isa<PointerType>(Ty))
-		V = Builder.CreateBitCast(V, Ty);
-	    if (V->getType() != Ty) {
-		if (cli_debug_flag) {
-		    std::string str;
-		    raw_string_ostream ostr(str);
-		    ostr << operand << " " ;
-		    V->print(ostr);
-		    Ty->print(ostr);
-		    M->dump();
-		    cli_dbgmsg_internal("[Bytecode JIT]: operand %d: %s\n", operand,ostr.str().c_str());
-		}
-		llvm_report_error("(libclamav) Type mismatch converting operand");
-	    }
-	    return V;
-	}
-	unsigned w = Ty->getPrimitiveSizeInBits();
-	if (w > 1)
-	    w = (w+7)/8;
-	else
-	    w = 0;
-	return convertOperand(func, map[w], operand);
+        unsigned map[] = {0, 1, 2, 3, 3, 4, 4, 4, 4};
+        if (operand < func->numArgs)
+            return Values[operand];
+        if (operand < func->numValues) {
+            Value *V = Values[operand];
+            if (func->types[operand] & 0x8000 && V->getType() == Ty) {
+                return V;
+            }
+            V = Builder.CreateLoad(V);
+            if (V->getType() != Ty &&
+                isa<PointerType>(V->getType()) &&
+                isa<PointerType>(Ty))
+                V = Builder.CreateBitCast(V, Ty);
+            if (V->getType() != Ty) {
+                if (cli_debug_flag) {
+                    std::string str;
+                    raw_string_ostream ostr(str);
+                    ostr << operand << " ";
+                    V->print(ostr);
+                    Ty->print(ostr);
+                    M->dump();
+                    cli_dbgmsg_internal("[Bytecode JIT]: operand %d: %s\n", operand, ostr.str().c_str());
+                }
+                llvm_report_error("(libclamav) Type mismatch converting operand");
+            }
+            return V;
+        }
+        unsigned w = Ty->getPrimitiveSizeInBits();
+        if (w > 1)
+            w = (w + 7) / 8;
+        else
+            w = 0;
+        return convertOperand(func, map[w], operand);
     }
 
     Value *convertOperand(const struct cli_bc_func *func,
-			  const struct cli_bc_inst *inst,  operand_t operand)
+                          const struct cli_bc_inst *inst, operand_t operand)
     {
-	return convertOperand(func, inst->interp_op%5, operand);
+        return convertOperand(func, inst->interp_op % 5, operand);
     }
 
     Value *convertOperand(const struct cli_bc_func *func,
-			  unsigned w, operand_t operand) {
-	if (operand < func->numArgs)
-	    return Values[operand];
-	if (operand < func->numValues) {
-	    if (func->types[operand]&0x8000)
-		return Values[operand];
-	    return Builder.CreateLoad(Values[operand]);
-	}
+                          unsigned w, operand_t operand)
+    {
+        if (operand < func->numArgs)
+            return Values[operand];
+        if (operand < func->numValues) {
+            if (func->types[operand] & 0x8000)
+                return Values[operand];
+            return Builder.CreateLoad(Values[operand]);
+        }
 
-	if (operand & 0x80000000) {
-	    operand &= 0x7fffffff;
-	    assert(operand < globals.size() && "Global index out of range");
-	    // Global
-	    if (!operand)
-		return ConstantPointerNull::get(PointerType::getUnqual(Type::getInt8Ty(Context)));
-	    assert(globals[operand]);
-	    if (GlobalVariable *GV = dyn_cast<GlobalVariable>(globals[operand])) {
-		if (ConstantExpr *CE = dyn_cast<ConstantExpr>(GV->getInitializer())) {
-		    return CE;
-		}
-		return GV;
-	    }
-	    return globals[operand];
-	}
-	// Constant
-	operand -= func->numValues;
-	// This was already validated by libclamav.
-	assert(operand < func->numConstants && "Constant out of range");
-	uint64_t *c = &func->constants[operand];
-	uint64_t v;
-	constType *Ty;
-	switch (w) {
-	    case 0:
-	    case 1:
-		Ty = w ? Type::getInt8Ty(Context) :
-		    Type::getInt1Ty(Context);
-		v = *(uint8_t*)c;
-		break;
-	    case 2:
-		Ty = Type::getInt16Ty(Context);
-		v = *(uint16_t*)c;
-		break;
-	    case 3:
-		Ty = Type::getInt32Ty(Context);
-		v = *(uint32_t*)c;
-		break;
-	    case 4:
-		Ty = Type::getInt64Ty(Context);
-		v = *(uint64_t*)c;
-		break;
-	    default:
-		llvm_unreachable("width");
-	}
-	return ConstantInt::get(Ty, v);
+        if (operand & 0x80000000) {
+            operand &= 0x7fffffff;
+            assert(operand < globals.size() && "Global index out of range");
+            // Global
+            if (!operand)
+                return ConstantPointerNull::get(PointerType::getUnqual(Type::getInt8Ty(Context)));
+            assert(globals[operand]);
+            if (GlobalVariable *GV = dyn_cast<GlobalVariable>(globals[operand])) {
+                if (ConstantExpr *CE = dyn_cast<ConstantExpr>(GV->getInitializer())) {
+                    return CE;
+                }
+                return GV;
+            }
+            return globals[operand];
+        }
+        // Constant
+        operand -= func->numValues;
+        // This was already validated by libclamav.
+        assert(operand < func->numConstants && "Constant out of range");
+        uint64_t *c = &func->constants[operand];
+        uint64_t v;
+        constType *Ty;
+        switch (w) {
+            case 0:
+            case 1:
+                Ty = w ? Type::getInt8Ty(Context) : Type::getInt1Ty(Context);
+                v  = *(uint8_t *)c;
+                break;
+            case 2:
+                Ty = Type::getInt16Ty(Context);
+                v  = *(uint16_t *)c;
+                break;
+            case 3:
+                Ty = Type::getInt32Ty(Context);
+                v  = *(uint32_t *)c;
+                break;
+            case 4:
+                Ty = Type::getInt64Ty(Context);
+                v  = *(uint64_t *)c;
+                break;
+            default:
+                llvm_unreachable("width");
+        }
+        return ConstantInt::get(Ty, v);
     }
 
     void Store(uint16_t dest, Value *V)
     {
-	assert(dest >= numArgs && dest < numLocals+numArgs && "Instruction destination out of range");
-	Builder.CreateStore(V, Values[dest]);
+        assert(dest >= numArgs && dest < numLocals + numArgs && "Instruction destination out of range");
+        Builder.CreateStore(V, Values[dest]);
     }
 
     // Insert code that calls \arg CF->FHandler if \arg FailCond is true.
     void InsertVerify(Value *FailCond, BasicBlock *&Fail, Function *FHandler,
-		      Function *F) {
-	if (!Fail) {
-	    Fail = BasicBlock::Create(Context, "fail", F);
-	    CallInst::Create(FHandler,"",Fail);
-	    new UnreachableInst(Context, Fail);
-	}
-	BasicBlock *OkBB = BasicBlock::Create(Context, "", F);
-	Builder.CreateCondBr(FailCond, Fail, OkBB);
-	Builder.SetInsertPoint(OkBB);
+                      Function *F)
+    {
+        if (!Fail) {
+            Fail = BasicBlock::Create(Context, "fail", F);
+            CallInst::Create(FHandler, "", Fail);
+            new UnreachableInst(Context, Fail);
+        }
+        BasicBlock *OkBB = BasicBlock::Create(Context, "", F);
+        Builder.CreateCondBr(FailCond, Fail, OkBB);
+        Builder.SetInsertPoint(OkBB);
     }
 
-    constType* mapType(uint16_t typeID)
+    constType *mapType(uint16_t typeID)
     {
-	return TypeMap->get(typeID&0x7fffffff, NULL, NULL);
+        return TypeMap->get(typeID & 0x7fffffff, NULL, NULL);
     }
 
     Constant *buildConstant(constType *Ty, uint64_t *components, unsigned &c)
     {
         if (constPointerType *PTy = dyn_cast<PointerType>(Ty)) {
-          Value *idxs[1] = {
-	      ConstantInt::get(Type::getInt64Ty(Context), components[c++])
-	  };
-	  unsigned idx = components[c++];
-	  if (!idx)
-	      return ConstantPointerNull::get(PTy);
-	  assert(idx < globals.size());
-	  GlobalVariable *GV = cast<GlobalVariable>(globals[idx]);
-	  Type *IP8Ty = PointerType::getUnqual(Type::getInt8Ty(Ty->getContext()));
-	  Constant *C = ConstantExpr::getPointerCast(GV, IP8Ty);
-	  //TODO: check constant bounds here
-	  return ConstantExpr::getPointerCast(
-	      ConstantExpr::getInBoundsGetElementPtr(C, ARRAYREF(Value*, idxs, 1)),
-	      PTy);
+            Value *idxs[1] = {
+                ConstantInt::get(Type::getInt64Ty(Context), components[c++])};
+            unsigned idx = components[c++];
+            if (!idx)
+                return ConstantPointerNull::get(PTy);
+            assert(idx < globals.size());
+            GlobalVariable *GV = cast<GlobalVariable>(globals[idx]);
+            Type *IP8Ty        = PointerType::getUnqual(Type::getInt8Ty(Ty->getContext()));
+            Constant *C        = ConstantExpr::getPointerCast(GV, IP8Ty);
+            //TODO: check constant bounds here
+            return ConstantExpr::getPointerCast(
+                ConstantExpr::getInBoundsGetElementPtr(C, ARRAYREF(Value *, idxs, 1)),
+                PTy);
         }
-	if (isa<IntegerType>(Ty)) {
-	    return ConstantInt::get(Ty, components[c++]);
-	}
-	if (constArrayType *ATy = dyn_cast<ArrayType>(Ty)) {
-	   std::vector<Constant*> elements;
-	   elements.reserve(ATy->getNumElements());
-	   for (unsigned i=0;i<ATy->getNumElements();i++) {
-	       elements.push_back(buildConstant(ATy->getElementType(), components, c));
-	   }
-	   return ConstantArray::get(ATy, elements);
-	}
-	if (constStructType *STy = dyn_cast<StructType>(Ty)) {
-	   std::vector<Constant*> elements;
-	   elements.reserve(STy->getNumElements());
-	   for (unsigned i=0;i<STy->getNumElements();i++) {
-	       elements.push_back(buildConstant(STy->getElementType(i), components, c));
-	   }
-	   return ConstantStruct::get(STy, elements);
-	}
-	Ty->dump();
-	llvm_unreachable("invalid type");
-	return 0;
+        if (isa<IntegerType>(Ty)) {
+            return ConstantInt::get(Ty, components[c++]);
+        }
+        if (constArrayType *ATy = dyn_cast<ArrayType>(Ty)) {
+            std::vector<Constant *> elements;
+            elements.reserve(ATy->getNumElements());
+            for (unsigned i = 0; i < ATy->getNumElements(); i++) {
+                elements.push_back(buildConstant(ATy->getElementType(), components, c));
+            }
+            return ConstantArray::get(ATy, elements);
+        }
+        if (constStructType *STy = dyn_cast<StructType>(Ty)) {
+            std::vector<Constant *> elements;
+            elements.reserve(STy->getNumElements());
+            for (unsigned i = 0; i < STy->getNumElements(); i++) {
+                elements.push_back(buildConstant(STy->getElementType(i), components, c));
+            }
+            return ConstantStruct::get(STy, elements);
+        }
+        Ty->dump();
+        llvm_unreachable("invalid type");
+        return 0;
     }
 
-public:
+  public:
     LLVMCodegen(const struct cli_bc *bc, Module *M, struct CommonFunctions *CF, FunctionMapTy &cFuncs,
-		ExecutionEngine *EE, FunctionPassManager &PM, FunctionPassManager &PMUnsigned,
-		Function **apiFuncs, LLVMTypeMapper &apiMap)
-	: bc(bc), M(M), Context(M->getContext()), EE(EE),
-	PM(PM),PMUnsigned(PMUnsigned), TypeMap(), apiFuncs(apiFuncs),apiMap(apiMap),
-	compiledFunctions(cFuncs), BytecodeID("bc"+Twine(bc->id)),
+                ExecutionEngine *EE, FunctionPassManager &PM, FunctionPassManager &PMUnsigned,
+                Function **apiFuncs, LLVMTypeMapper &apiMap)
+        : bc(bc), M(M), Context(M->getContext()), EE(EE),
+          PM(PM), PMUnsigned(PMUnsigned), TypeMap(), apiFuncs(apiFuncs), apiMap(apiMap),
+          compiledFunctions(cFuncs), BytecodeID("bc" + Twine(bc->id)),
 #if LLVM_VERSION < 32
-	Folder(EE->getTargetData()), Builder(Context, Folder), Values(), CF(CF) {
+          Folder(EE->getTargetData()), Builder(Context, Folder), Values(), CF(CF)
+    {
 #else
-	Folder(EE->getDataLayout()), Builder(Context, Folder), Values(), CF(CF) {
+          Folder(EE->getDataLayout()), Builder(Context, Folder), Values(), CF(CF)
+    {
 #endif
 
-	for (unsigned i=0;i<cli_apicall_maxglobal - _FIRST_GLOBAL;i++) {
-	    unsigned id = cli_globals[i].globalid;
-	    GVoffsetMap[id] = cli_globals[i].offset;
-	}
-	numLocals = 0;
-	numArgs = 0;
+        for (unsigned i = 0; i < cli_apicall_maxglobal - _FIRST_GLOBAL; i++) {
+            unsigned id     = cli_globals[i].globalid;
+            GVoffsetMap[id] = cli_globals[i].offset;
+        }
+        numLocals = 0;
+        numArgs   = 0;
     }
 
 #if LLVM_VERSION < 30
     template <typename InputIterator>
 #endif
-    Value* createGEP(Value *Base, constType *ETy, ARRAYREFPARAM(Value*,InputIterator Start,InputIterator End,ARef)) {
-	constType *Ty = GetElementPtrInst::getIndexedType(Base->getType(),ARRAYREFP(Start,End,ARef));
-	if (!Ty || (ETy && (Ty != ETy && (!isa<IntegerType>(Ty) || !isa<IntegerType>(ETy))))) {
-	    if (cli_debug_flag) {
-		std::string str;
-		raw_string_ostream ostr(str);
+    Value *createGEP(Value *Base, constType *ETy, ARRAYREFPARAM(Value *, InputIterator Start, InputIterator End, ARef))
+    {
+        constType *Ty = GetElementPtrInst::getIndexedType(Base->getType(), ARRAYREFP(Start, End, ARef));
+        if (!Ty || (ETy && (Ty != ETy && (!isa<IntegerType>(Ty) || !isa<IntegerType>(ETy))))) {
+            if (cli_debug_flag) {
+                std::string str;
+                raw_string_ostream ostr(str);
 
-		ostr << "Wrong indices for GEP opcode: "
-		    << " expected type: " << *ETy;
-		if (Ty)
-		    ostr << " actual type: " << *Ty;
-		ostr << " base: " << *Base << ";";
-		Base->getType()->print(ostr);
-		ostr << "\n indices: ";
+                ostr << "Wrong indices for GEP opcode: "
+                     << " expected type: " << *ETy;
+                if (Ty)
+                    ostr << " actual type: " << *Ty;
+                ostr << " base: " << *Base << ";";
+                Base->getType()->print(ostr);
+                ostr << "\n indices: ";
 #if LLVM_VERSION < 30
-		for (InputIterator I=Start; I != End; I++) {
+                for (InputIterator I = Start; I != End; I++) {
 #else
-		for (ArrayRef<Value*>::iterator I=ARef.begin(); I != ARef.end(); I++) {
+                for (ArrayRef<Value *>::iterator I = ARef.begin(); I != ARef.end(); I++) {
 #endif
-		    ostr << **I << ", ";
-		}
-		ostr << "\n";
-		cli_dbgmsg_internal("[Bytecode JIT]: %s\n", ostr.str().c_str());
-	    } else {
-		cli_warnmsg("[Bytecode JIT]: Wrong indices for GEP opcode\n");
-	    }
-	    return 0;
-	}
-	return Builder.CreateGEP(Base,ARRAYREFP(Start,End,ARef));
-    }
+                    ostr << **I << ", ";
+                }
+                ostr << "\n";
+                cli_dbgmsg_internal("[Bytecode JIT]: %s\n", ostr.str().c_str());
+            } else {
+                cli_warnmsg("[Bytecode JIT]: Wrong indices for GEP opcode\n");
+            }
+            return 0;
+        }
+        return Builder.CreateGEP(Base, ARRAYREFP(Start, End, ARef));
+    } // namespace
 
 #if LLVM_VERSION < 30
     template <typename InputIterator>
 #endif
-    bool createGEP(unsigned dest, Value *Base, ARRAYREFPARAM(Value*,InputIterator Start,InputIterator End,ARef)) {
-	assert(dest >= numArgs && dest < numLocals+numArgs && "Instruction destination out of range");
-	constType *ETy = cast<PointerType>(cast<PointerType>(Values[dest]->getType())->getElementType())->getElementType();
-	Value *V = createGEP(Base, ETy, ARRAYREFP(Start,End,ARef));
-	if (!V) {
-	    if (cli_debug_flag)
-		cli_dbgmsg_internal("[Bytecode JIT] @%d\n", dest);
-	    return false;
-	}
-	V = Builder.CreateBitCast(V, PointerType::getUnqual(ETy));
-	Store(dest, V);
-	return true;
+    bool createGEP(unsigned dest, Value *Base, ARRAYREFPARAM(Value *, InputIterator Start, InputIterator End, ARef))
+    {
+        assert(dest >= numArgs && dest < numLocals + numArgs && "Instruction destination out of range");
+        constType *ETy = cast<PointerType>(cast<PointerType>(Values[dest]->getType())->getElementType())->getElementType();
+        Value *V       = createGEP(Base, ETy, ARRAYREFP(Start, End, ARef));
+        if (!V) {
+            if (cli_debug_flag)
+                cli_dbgmsg_internal("[Bytecode JIT] @%d\n", dest);
+            return false;
+        }
+        V = Builder.CreateBitCast(V, PointerType::getUnqual(ETy));
+        Store(dest, V);
+        return true;
     }
 
-    MDNode *convertMDNode(unsigned i) {
-	if (i < mdnodes.size()) {
-	    if (mdnodes[i])
-		return mdnodes[i];
-	} else
-	    mdnodes.resize(i+1);
-	assert(i < mdnodes.size());
-	const struct cli_bc_dbgnode *node = &bc->dbgnodes[i];
+    MDNode *convertMDNode(unsigned i)
+    {
+        if (i < mdnodes.size()) {
+            if (mdnodes[i])
+                return mdnodes[i];
+        } else
+            mdnodes.resize(i + 1);
+        assert(i < mdnodes.size());
+        const struct cli_bc_dbgnode *node = &bc->dbgnodes[i];
 #if LLVM_VERSION < 36
-	Value **Vals = new Value*[node->numelements];
+        Value **Vals = new Value *[node->numelements];
 #else
-	Metadata **Vals = new Metadata*[node->numelements];
+        Metadata **Vals = new Metadata *[node->numelements];
 #endif
-	for (unsigned j=0;j<node->numelements;j++) {
-	    const struct cli_bc_dbgnode_element* el = &node->elements[j];
+        for (unsigned j = 0; j < node->numelements; j++) {
+            const struct cli_bc_dbgnode_element *el = &node->elements[j];
 #if LLVM_VERSION < 36
-	    Value *V;
+            Value *V;
 #else
-	    Metadata *V;
+            Metadata *V;
 #endif
-	    if (!el->len) {
-		if (el->nodeid == ~0u)
-		    V = 0;
-		else if (el->nodeid)
-		    V = convertMDNode(el->nodeid);
-		else
-		    V = MDString::get(Context, "");
-	    } else if (el->string) {
-		V = MDString::get(Context, StringRef(el->string, el->len));
-	    } else {
+            if (!el->len) {
+                if (el->nodeid == ~0u)
+                    V = 0;
+                else if (el->nodeid)
+                    V = convertMDNode(el->nodeid);
+                else
+                    V = MDString::get(Context, "");
+            } else if (el->string) {
+                V = MDString::get(Context, StringRef(el->string, el->len));
+            } else {
 #if LLVM_VERSION < 36
-		V = ConstantInt::get(IntegerType::get(Context, el->len),
-				     el->constant);
+                V = ConstantInt::get(IntegerType::get(Context, el->len),
+                                     el->constant);
 #else
-		V = ConstantAsMetadata::get(ConstantInt::get(IntegerType::get(Context, el->len),
-				     el->constant));
+                V = ConstantAsMetadata::get(ConstantInt::get(IntegerType::get(Context, el->len),
+                                                             el->constant));
 #endif
-	    }
-	    Vals[j] = V;
-	}
+            }
+            Vals[j] = V;
+        }
 #if LLVM_VERSION < 36
-	MDNode *N = MDNode::get(Context, ARRAYREF(Value*,Vals, node->numelements));
+        MDNode *N = MDNode::get(Context, ARRAYREF(Value *, Vals, node->numelements));
 #else
-	MDNode *N = MDNode::get(Context, ARRAYREF(Metadata*,Vals, node->numelements));
+        MDNode *N = MDNode::get(Context, ARRAYREF(Metadata *, Vals, node->numelements));
 #endif
-	delete[] Vals;
-	mdnodes[i] = N;
-	return N;
+        delete[] Vals;
+        mdnodes[i] = N;
+        return N;
     }
 
     void AddStackProtect(Function *F)
     {
-	BasicBlock &BB = F->getEntryBlock();
-	if (isa<AllocaInst>(BB.begin())) {
-	    // Have an alloca -> some instruction uses its address otherwise
-	    // mem2reg would have converted it to an SSA register.
-	    // Enable stack protector for this function.
+        BasicBlock &BB = F->getEntryBlock();
+        if (isa<AllocaInst>(BB.begin())) {
+            // Have an alloca -> some instruction uses its address otherwise
+            // mem2reg would have converted it to an SSA register.
+            // Enable stack protector for this function.
 #if LLVM_VERSION < 29
-	    // LLVM 2.9 has broken SSP, it does a 'mov 0x28, $rax', which tries
-	    // to read from the address 0x28 and crashes
-	    F->addFnAttr(Attribute::StackProtectReq);
+            // LLVM 2.9 has broken SSP, it does a 'mov 0x28, $rax', which tries
+            // to read from the address 0x28 and crashes
+            F->addFnAttr(Attribute::StackProtectReq);
 #endif
-	}
-	// always add stackprotect attribute (bb #2239), so we know this
-	// function was verified. If there is no alloca it won't actually add
-	// stack protector in emitted code so this won't slow down the app.
+        }
+        // always add stackprotect attribute (bb #2239), so we know this
+        // function was verified. If there is no alloca it won't actually add
+        // stack protector in emitted code so this won't slow down the app.
 #if LLVM_VERSION < 29
-	F->addFnAttr(Attribute::StackProtect);
+        F->addFnAttr(Attribute::StackProtect);
 #endif
     }
 
-    Value *GEPOperand(Value *V) {
-	if (LoadInst *LI = dyn_cast<LoadInst>(V)) {
-	    Value *VI = LI->getOperand(0);
-	    StoreInst *SI = 0;
-	    for (Value::use_iterator I=VI->use_begin(),
-		 E=VI->use_end(); I != E; ++I) {
-		Value *I_V = *I;
-		if (StoreInst *S = dyn_cast<StoreInst>(I_V)) {
-		    if (SI)
-			return V;
-		    SI = S;
-		} else if (!isa<LoadInst>(I_V))
-		    return V;
-	    }
-	    V = SI->getOperand(0);
-	}
+    Value *GEPOperand(Value *V)
+    {
+        if (LoadInst *LI = dyn_cast<LoadInst>(V)) {
+            Value *VI     = LI->getOperand(0);
+            StoreInst *SI = 0;
+            for (Value::use_iterator I = VI->use_begin(),
+                                     E = VI->use_end();
+                 I != E; ++I) {
+                Value *I_V = *I;
+                if (StoreInst *S = dyn_cast<StoreInst>(I_V)) {
+                    if (SI)
+                        return V;
+                    SI = S;
+                } else if (!isa<LoadInst>(I_V))
+                    return V;
+            }
+            V = SI->getOperand(0);
+        }
 #if LLVM_VERSION < 32
-	if (EE->getTargetData()->getPointerSize() == 8) {
+        if (EE->getTargetData()->getPointerSize() == 8) {
 #else
-	if (EE->getDataLayout()->getPointerSize() == 8) {
+        if (EE->getDataLayout()->getPointerSize() == 8) {
 #endif
-	    // eliminate useless trunc, GEP can take i64 too
-	    if (TruncInst *I = dyn_cast<TruncInst>(V)) {
-		Value *Src = I->getOperand(0);
-		if (Src->getType() == Type::getInt64Ty(Context) &&
-		    I->getType() == Type::getInt32Ty(Context))
-		    return Src;
-	    }
-	}
-	return V;
+            // eliminate useless trunc, GEP can take i64 too
+            if (TruncInst *I = dyn_cast<TruncInst>(V)) {
+                Value *Src = I->getOperand(0);
+                if (Src->getType() == Type::getInt64Ty(Context) &&
+                    I->getType() == Type::getInt32Ty(Context))
+                    return Src;
+            }
+        }
+        return V;
     }
 
-   Function* generate() {
+    Function *generate()
+    {
         PrettyStackTraceString CrashInfo("Generate LLVM IR functions");
-	apiMap.irgenTimer.startTimer();
-	TypeMap = new LLVMTypeMapper(Context, bc->types + 4, bc->num_types - 5);
-	for (unsigned i=0;i<bc->dbgnode_cnt;i++) {
-	    mdnodes.push_back(convertMDNode(i));
-	}
+        apiMap.irgenTimer.startTimer();
+        TypeMap = new LLVMTypeMapper(Context, bc->types + 4, bc->num_types - 5);
+        for (unsigned i = 0; i < bc->dbgnode_cnt; i++) {
+            mdnodes.push_back(convertMDNode(i));
+        }
 
-	for (unsigned i=0;i<cli_apicall_maxglobal - _FIRST_GLOBAL;i++) {
-	    unsigned id = cli_globals[i].globalid;
-	    constType *Ty = apiMap.get(cli_globals[i].type, NULL, NULL);
-	    /*if (const ArrayType *ATy = dyn_cast<ArrayType>(Ty))
+        for (unsigned i = 0; i < cli_apicall_maxglobal - _FIRST_GLOBAL; i++) {
+            unsigned id   = cli_globals[i].globalid;
+            constType *Ty = apiMap.get(cli_globals[i].type, NULL, NULL);
+            /*if (const ArrayType *ATy = dyn_cast<ArrayType>(Ty))
 		Ty = PointerType::getUnqual(ATy->getElementType());*/
-	    GVtypeMap[id] = Ty;
-	}
+            GVtypeMap[id] = Ty;
+        }
 
-	// The hidden ctx param to all functions
-	unsigned maxh = cli_globals[0].offset + sizeof(struct cli_bc_hooks);
-	constType *HiddenCtx = PointerType::getUnqual(ArrayType::get(Type::getInt8Ty(Context), maxh));
+        // The hidden ctx param to all functions
+        unsigned maxh        = cli_globals[0].offset + sizeof(struct cli_bc_hooks);
+        constType *HiddenCtx = PointerType::getUnqual(ArrayType::get(Type::getInt8Ty(Context), maxh));
 
-	globals.reserve(bc->num_globals);
-	BitVector FakeGVs;
-	FakeGVs.resize(bc->num_globals);
-	globals.push_back(0);
-	for (unsigned i=1;i<bc->num_globals;i++) {
-	    constType *Ty = mapType(bc->globaltys[i]);
+        globals.reserve(bc->num_globals);
+        BitVector FakeGVs;
+        FakeGVs.resize(bc->num_globals);
+        globals.push_back(0);
+        for (unsigned i = 1; i < bc->num_globals; i++) {
+            constType *Ty = mapType(bc->globaltys[i]);
 
-	    // TODO: validate number of components against type_components
-	    unsigned c = 0;
-	    GlobalVariable *GV;
-	    if (isa<PointerType>(Ty)) {
-		unsigned g = bc->globals[i][1];
-		if (GVoffsetMap.count(g)) {
-		    FakeGVs.set(i);
-		    globals.push_back(0);
-		    continue;
-		}
-	    }
-	    Constant *C = buildConstant(Ty, bc->globals[i], c);
-	    GV = new GlobalVariable(*M, Ty, true,
-				    GlobalValue::InternalLinkage,
-				    C, "glob"+Twine(i));
-	    globals.push_back(GV);
-	}
-	Function **Functions = new Function*[bc->num_func];
-	for (unsigned j=0;j<bc->num_func;j++) {
-	    // Create LLVM IR Function
-	    const struct cli_bc_func *func = &bc->funcs[j];
-	    std::vector<constType*> argTypes;
-	    argTypes.push_back(HiddenCtx);
-	    for (unsigned a=0;a<func->numArgs;a++) {
-		argTypes.push_back(mapType(func->types[a]));
-	    }
-	    constType *RetTy = mapType(func->returnType);
-	    FunctionType *FTy =  FunctionType::get(RetTy, argTypes,
-							 false);
-	    Functions[j] = Function::Create(FTy, Function::InternalLinkage,
-					   BytecodeID+"f"+Twine(j), M);
-	    Functions[j]->setDoesNotThrow();
-	    Functions[j]->setCallingConv(CallingConv::Fast);
-	    Functions[j]->setLinkage(GlobalValue::InternalLinkage);
+            // TODO: validate number of components against type_components
+            unsigned c = 0;
+            GlobalVariable *GV;
+            if (isa<PointerType>(Ty)) {
+                unsigned g = bc->globals[i][1];
+                if (GVoffsetMap.count(g)) {
+                    FakeGVs.set(i);
+                    globals.push_back(0);
+                    continue;
+                }
+            }
+            Constant *C = buildConstant(Ty, bc->globals[i], c);
+            GV          = new GlobalVariable(*M, Ty, true,
+                                    GlobalValue::InternalLinkage,
+                                    C, "glob" + Twine(i));
+            globals.push_back(GV);
+        }
+        Function **Functions = new Function *[bc->num_func];
+        for (unsigned j = 0; j < bc->num_func; j++) {
+            // Create LLVM IR Function
+            const struct cli_bc_func *func = &bc->funcs[j];
+            std::vector<constType *> argTypes;
+            argTypes.push_back(HiddenCtx);
+            for (unsigned a = 0; a < func->numArgs; a++) {
+                argTypes.push_back(mapType(func->types[a]));
+            }
+            constType *RetTy  = mapType(func->returnType);
+            FunctionType *FTy = FunctionType::get(RetTy, argTypes,
+                                                  false);
+            Functions[j]      = Function::Create(FTy, Function::InternalLinkage,
+                                            BytecodeID + "f" + Twine(j), M);
+            Functions[j]->setDoesNotThrow();
+            Functions[j]->setCallingConv(CallingConv::Fast);
+            Functions[j]->setLinkage(GlobalValue::InternalLinkage);
 #ifdef C_LINUX
-	    /* bb #2270, this should really be fixed either by LLVM or GCC.*/
+            /* bb #2270, this should really be fixed either by LLVM or GCC.*/
 #if LLVM_VERSION < 32
-	    Functions[j]->addFnAttr(Attribute::constructStackAlignmentFromInt(16));
+            Functions[j]->addFnAttr(Attribute::constructStackAlignmentFromInt(16));
 #else
-	// TODO: How does this translate?
+            // TODO: How does this translate?
 //	    Functions[j]->addFnAttr(Attribute::StackAlignment);
 #endif
 #endif
-	}
-	constType *I32Ty = Type::getInt32Ty(Context);
-	for (unsigned j=0;j<bc->num_func;j++) {
-	    PrettyStackTraceString CrashInfo("Generate LLVM IR");
-	    const struct cli_bc_func *func = &bc->funcs[j];
-	    bool broken = false;
+        }
+        constType *I32Ty = Type::getInt32Ty(Context);
+        for (unsigned j = 0; j < bc->num_func; j++) {
+            PrettyStackTraceString CrashInfo("Generate LLVM IR");
+            const struct cli_bc_func *func = &bc->funcs[j];
+            bool broken                    = false;
 
-	    // Create all BasicBlocks
-	    Function *F = Functions[j];
-	    BasicBlock **BB = new BasicBlock*[func->numBB];
-	    for (unsigned i=0;i<func->numBB;i++) {
-		BB[i] = BasicBlock::Create(Context, "", F);
-	    }
+            // Create all BasicBlocks
+            Function *F     = Functions[j];
+            BasicBlock **BB = new BasicBlock *[func->numBB];
+            for (unsigned i = 0; i < func->numBB; i++) {
+                BB[i] = BasicBlock::Create(Context, "", F);
+            }
 
-	    BasicBlock *Fail = 0;
-	    Values = new Value*[func->numValues];
-	    Builder.SetInsertPoint(BB[0]);
-	    Function::arg_iterator I = F->arg_begin();
-	    assert(F->arg_size() == (unsigned)(func->numArgs + 1) && "Mismatched args");
-	    ++I;
-	    for (unsigned i=0;i<func->numArgs; i++) {
-		assert(I != F->arg_end());
-		Values[i] = &*I;
-		++I;
-	    }
-	    for (unsigned i=func->numArgs;i<func->numValues;i++) {
-		if (!func->types[i]) {
-		    //instructions without return value, like store
-		    Values[i] = 0;
-		    continue;
-		}
-		Values[i] = Builder.CreateAlloca(mapType(func->types[i]));
-	    }
-	    numLocals = func->numLocals;
-	    numArgs = func->numArgs;
+            BasicBlock *Fail = 0;
+            Values           = new Value *[func->numValues];
+            Builder.SetInsertPoint(BB[0]);
+            Function::arg_iterator I = F->arg_begin();
+            assert(F->arg_size() == (unsigned)(func->numArgs + 1) && "Mismatched args");
+            ++I;
+            for (unsigned i = 0; i < func->numArgs; i++) {
+                assert(I != F->arg_end());
+                Values[i] = &*I;
+                ++I;
+            }
+            for (unsigned i = func->numArgs; i < func->numValues; i++) {
+                if (!func->types[i]) {
+                    //instructions without return value, like store
+                    Values[i] = 0;
+                    continue;
+                }
+                Values[i] = Builder.CreateAlloca(mapType(func->types[i]));
+            }
+            numLocals = func->numLocals;
+            numArgs   = func->numArgs;
 
-	    if (FakeGVs.any()) {
-		Argument *Ctx = F->arg_begin();
-		for (unsigned i=0;i<bc->num_globals;i++) {
-		    if (!FakeGVs[i])
-			continue;
-		    unsigned g = bc->globals[i][1];
-		    unsigned offset = GVoffsetMap[g];
+            if (FakeGVs.any()) {
+                Argument *Ctx = F->arg_begin();
+                for (unsigned i = 0; i < bc->num_globals; i++) {
+                    if (!FakeGVs[i])
+                        continue;
+                    unsigned g      = bc->globals[i][1];
+                    unsigned offset = GVoffsetMap[g];
 
-		    Constant *Idx = ConstantInt::get(Type::getInt32Ty(Context),
-						     offset);
-		    Value *Idxs[2] = {
-			ConstantInt::get(Type::getInt32Ty(Context), 0),
-			Idx
-		    };
-		    Value *GEP = Builder.CreateInBoundsGEP(Ctx, ARRAYREF(Value*, Idxs, Idxs+2));
-		    constType *Ty = GVtypeMap[g];
-		    Ty = PointerType::getUnqual(PointerType::getUnqual(Ty));
-		    Value *Cast = Builder.CreateBitCast(GEP, Ty);
-		    Value *SpecialGV = Builder.CreateLoad(Cast);
-		    constType *IP8Ty = Type::getInt8Ty(Context);
-		    IP8Ty = PointerType::getUnqual(IP8Ty);
-		    SpecialGV = Builder.CreateBitCast(SpecialGV, IP8Ty);
-		    SpecialGV->setName("g"+Twine(g-_FIRST_GLOBAL)+"_");
-		    Value *C[] = {
-			ConstantInt::get(Type::getInt32Ty(Context), bc->globals[i][0])
-		    };
-		    globals[i] = createGEP(SpecialGV, 0, ARRAYREF(Value*,C, C+1));
-		    if (!globals[i]) {
-			if (cli_debug_flag) {
-			    std::string str;
-			    raw_string_ostream ostr(str);
-			    ostr << i << ":" << g << ":" << bc->globals[i][0] <<"\n";
-			    Ty->print(ostr);
-			    cli_dbgmsg_internal("[Bytecode JIT]: %s\n", ostr.str().c_str());
-			}
-			llvm_report_error("(libclamav) unable to create fake global");
-		    }
-		    globals[i] = Builder.CreateBitCast(globals[i], Ty);
-		    if(GetElementPtrInst *GI = dyn_cast<GetElementPtrInst>(globals[i])) {
-			GI->setIsInBounds(true);
-			GI->setName("geped"+Twine(i)+"_");
-		    }
-		}
-	    }
+                    Constant *Idx  = ConstantInt::get(Type::getInt32Ty(Context),
+                                                     offset);
+                    Value *Idxs[2] = {
+                        ConstantInt::get(Type::getInt32Ty(Context), 0),
+                        Idx};
+                    Value *GEP       = Builder.CreateInBoundsGEP(Ctx, ARRAYREF(Value *, Idxs, Idxs + 2));
+                    constType *Ty    = GVtypeMap[g];
+                    Ty               = PointerType::getUnqual(PointerType::getUnqual(Ty));
+                    Value *Cast      = Builder.CreateBitCast(GEP, Ty);
+                    Value *SpecialGV = Builder.CreateLoad(Cast);
+                    constType *IP8Ty = Type::getInt8Ty(Context);
+                    IP8Ty            = PointerType::getUnqual(IP8Ty);
+                    SpecialGV        = Builder.CreateBitCast(SpecialGV, IP8Ty);
+                    SpecialGV->setName("g" + Twine(g - _FIRST_GLOBAL) + "_");
+                    Value *C[] = {
+                        ConstantInt::get(Type::getInt32Ty(Context), bc->globals[i][0])};
+                    globals[i] = createGEP(SpecialGV, 0, ARRAYREF(Value *, C, C + 1));
+                    if (!globals[i]) {
+                        if (cli_debug_flag) {
+                            std::string str;
+                            raw_string_ostream ostr(str);
+                            ostr << i << ":" << g << ":" << bc->globals[i][0] << "\n";
+                            Ty->print(ostr);
+                            cli_dbgmsg_internal("[Bytecode JIT]: %s\n", ostr.str().c_str());
+                        }
+                        llvm_report_error("(libclamav) unable to create fake global");
+                    }
+                    globals[i] = Builder.CreateBitCast(globals[i], Ty);
+                    if (GetElementPtrInst *GI = dyn_cast<GetElementPtrInst>(globals[i])) {
+                        GI->setIsInBounds(true);
+                        GI->setName("geped" + Twine(i) + "_");
+                    }
+                }
+            }
 
-	    // Generate LLVM IR for each BB
-	    for (unsigned i=0;i<func->numBB && !broken;i++) {
-		bool unreachable = false;
-		const struct cli_bc_bb *bb = &func->BB[i];
-		Builder.SetInsertPoint(BB[i]);
-		unsigned c = 0;
-		for (unsigned j=0;j<bb->numInsts && !broken;j++) {
-		    const struct cli_bc_inst *inst = &bb->insts[j];
-		    Value *Op0=0, *Op1=0, *Op2=0;
-		    // libclamav has already validated this.
-		    assert(inst->opcode < OP_BC_INVALID && "Invalid opcode");
-		    if (func->dbgnodes) {
-			if (func->dbgnodes[c] != ~0u) {
-			unsigned j = func->dbgnodes[c];
-			assert(j < mdnodes.size());
-			Builder.SetCurrentDebugLocation(mdnodes[j]);
-			} else
-			    Builder.SetCurrentDebugLocation(0);
-		    }
-		    c++;
-		    switch (inst->opcode) {
-			case OP_BC_JMP:
-			case OP_BC_BRANCH:
-			case OP_BC_CALL_API:
-			case OP_BC_CALL_DIRECT:
-			case OP_BC_ZEXT:
-			case OP_BC_SEXT:
-			case OP_BC_TRUNC:
-			case OP_BC_GEP1:
-			case OP_BC_GEPZ:
-			case OP_BC_GEPN:
-			case OP_BC_STORE:
-			case OP_BC_COPY:
-			case OP_BC_RET:
-			case OP_BC_PTRDIFF32:
-			case OP_BC_PTRTOINT64:
-			    // these instructions represents operands differently
-			    break;
-			default:
-			    switch (operand_counts[inst->opcode]) {
-				case 1:
-				    Op0 = convertOperand(func, inst, inst->u.unaryop);
-				    break;
-				case 2:
-				    Op0 = convertOperand(func, inst, inst->u.binop[0]);
-				    Op1 = convertOperand(func, inst, inst->u.binop[1]);
-				    if (Op0->getType() != Op1->getType()) {
-					Op0->dump();
-					Op1->dump();
-					llvm_report_error("(libclamav) binop type mismatch");
-				    }
-				    break;
-				case 3:
-				    Op0 = convertOperand(func, inst, inst->u.three[0]);
-				    Op1 = convertOperand(func, inst, inst->u.three[1]);
-				    Op2 = convertOperand(func, inst, inst->u.three[2]);
-				    break;
-			    }
-		    }
+            // Generate LLVM IR for each BB
+            for (unsigned i = 0; i < func->numBB && !broken; i++) {
+                bool unreachable           = false;
+                const struct cli_bc_bb *bb = &func->BB[i];
+                Builder.SetInsertPoint(BB[i]);
+                unsigned c = 0;
+                for (unsigned j = 0; j < bb->numInsts && !broken; j++) {
+                    const struct cli_bc_inst *inst = &bb->insts[j];
+                    Value *Op0 = 0, *Op1 = 0, *Op2 = 0;
+                    // libclamav has already validated this.
+                    assert(inst->opcode < OP_BC_INVALID && "Invalid opcode");
+                    if (func->dbgnodes) {
+                        if (func->dbgnodes[c] != ~0u) {
+                            unsigned j = func->dbgnodes[c];
+                            assert(j < mdnodes.size());
+                            Builder.SetCurrentDebugLocation(mdnodes[j]);
+                        } else
+                            Builder.SetCurrentDebugLocation(0);
+                    }
+                    c++;
+                    switch (inst->opcode) {
+                        case OP_BC_JMP:
+                        case OP_BC_BRANCH:
+                        case OP_BC_CALL_API:
+                        case OP_BC_CALL_DIRECT:
+                        case OP_BC_ZEXT:
+                        case OP_BC_SEXT:
+                        case OP_BC_TRUNC:
+                        case OP_BC_GEP1:
+                        case OP_BC_GEPZ:
+                        case OP_BC_GEPN:
+                        case OP_BC_STORE:
+                        case OP_BC_COPY:
+                        case OP_BC_RET:
+                        case OP_BC_PTRDIFF32:
+                        case OP_BC_PTRTOINT64:
+                            // these instructions represents operands differently
+                            break;
+                        default:
+                            switch (operand_counts[inst->opcode]) {
+                                case 1:
+                                    Op0 = convertOperand(func, inst, inst->u.unaryop);
+                                    break;
+                                case 2:
+                                    Op0 = convertOperand(func, inst, inst->u.binop[0]);
+                                    Op1 = convertOperand(func, inst, inst->u.binop[1]);
+                                    if (Op0->getType() != Op1->getType()) {
+                                        Op0->dump();
+                                        Op1->dump();
+                                        llvm_report_error("(libclamav) binop type mismatch");
+                                    }
+                                    break;
+                                case 3:
+                                    Op0 = convertOperand(func, inst, inst->u.three[0]);
+                                    Op1 = convertOperand(func, inst, inst->u.three[1]);
+                                    Op2 = convertOperand(func, inst, inst->u.three[2]);
+                                    break;
+                            }
+                    }
 
-		    switch (inst->opcode) {
-			case OP_BC_ADD:
-			    Store(inst->dest, Builder.CreateAdd(Op0, Op1));
-			    break;
-			case OP_BC_SUB:
-			    Store(inst->dest, Builder.CreateSub(Op0, Op1));
-			    break;
-			case OP_BC_MUL:
-			    Store(inst->dest, Builder.CreateMul(Op0, Op1));
-			    break;
-			case OP_BC_UDIV:
-			{
-			    Value *Bad = Builder.CreateICmpEQ(Op1, ConstantInt::get(Op1->getType(), 0));
-			    InsertVerify(Bad, Fail, CF->FHandler, F);
-			    Store(inst->dest, Builder.CreateUDiv(Op0, Op1));
-			    break;
-			}
-			case OP_BC_SDIV:
-			{
-			    //TODO: also verify Op0 == -1 && Op1 = INT_MIN
-			    Value *Bad = Builder.CreateICmpEQ(Op1, ConstantInt::get(Op1->getType(), 0));
-			    InsertVerify(Bad, Fail, CF->FHandler, F);
-			    Store(inst->dest, Builder.CreateSDiv(Op0, Op1));
-			    break;
-			}
-			case OP_BC_UREM:
-			{
-			    Value *Bad = Builder.CreateICmpEQ(Op1, ConstantInt::get(Op1->getType(), 0));
-			    InsertVerify(Bad, Fail, CF->FHandler, F);
-			    Store(inst->dest, Builder.CreateURem(Op0, Op1));
-			    break;
-			}
-			case OP_BC_SREM:
-			{
-			    //TODO: also verify Op0 == -1 && Op1 = INT_MIN
-			    Value *Bad = Builder.CreateICmpEQ(Op1, ConstantInt::get(Op1->getType(), 0));
-			    InsertVerify(Bad, Fail, CF->FHandler, F);
-			    Store(inst->dest, Builder.CreateSRem(Op0, Op1));
-			    break;
-			}
-			case OP_BC_SHL:
-			    Store(inst->dest, Builder.CreateShl(Op0, Op1));
-			    break;
-			case OP_BC_LSHR:
-			    Store(inst->dest, Builder.CreateLShr(Op0, Op1));
-			    break;
-			case OP_BC_ASHR:
-			    Store(inst->dest, Builder.CreateAShr(Op0, Op1));
-			    break;
-			case OP_BC_AND:
-			    Store(inst->dest, Builder.CreateAnd(Op0, Op1));
-			    break;
-			case OP_BC_OR:
-			    Store(inst->dest, Builder.CreateOr(Op0, Op1));
-			    break;
-			case OP_BC_XOR:
-			    Store(inst->dest, Builder.CreateXor(Op0, Op1));
-			    break;
-			case OP_BC_TRUNC:
-			{
-			    Value *Src = convertOperand(func, inst, inst->u.cast.source);
-			    constType *Ty = mapType(func->types[inst->dest]);
-			    Store(inst->dest, Builder.CreateTrunc(Src,  Ty));
-			    break;
-			}
-			case OP_BC_ZEXT:
-			{
-			    Value *Src = convertOperand(func, inst, inst->u.cast.source);
-			    constType *Ty = mapType(func->types[inst->dest]);
-			    Store(inst->dest, Builder.CreateZExt(Src,  Ty));
-			    break;
-			}
-			case OP_BC_SEXT:
-			{
-			    Value *Src = convertOperand(func, inst, inst->u.cast.source);
-			    constType *Ty = mapType(func->types[inst->dest]);
-			    Store(inst->dest, Builder.CreateSExt(Src,  Ty));
-			    break;
-			}
-			case OP_BC_BRANCH:
-			{
-			    Value *Cond = convertOperand(func, inst, inst->u.branch.condition);
-			    BasicBlock *True = BB[inst->u.branch.br_true];
-			    BasicBlock *False = BB[inst->u.branch.br_false];
-			    if (Cond->getType() != Type::getInt1Ty(Context)) {
-				cli_warnmsg("[Bytecode JIT]: type mismatch in condition");
-				broken = true;
-				break;
-			    }
-			    Builder.CreateCondBr(Cond, True, False);
-			    break;
-			}
-			case OP_BC_JMP:
-			{
-			    BasicBlock *Jmp = BB[inst->u.jump];
-			    Builder.CreateBr(Jmp);
-			    break;
-			}
-			case OP_BC_RET:
-			{
-			    Op0 = convertOperand(func, F->getReturnType(), inst->u.unaryop);
-			    Builder.CreateRet(Op0);
-			    break;
-			}
-			case OP_BC_RET_VOID:
-			    Builder.CreateRetVoid();
-			    break;
-			case OP_BC_ICMP_EQ:
-			    Store(inst->dest, Builder.CreateICmpEQ(Op0, Op1));
-			    break;
-			case OP_BC_ICMP_NE:
-			    Store(inst->dest, Builder.CreateICmpNE(Op0, Op1));
-			    break;
-			case OP_BC_ICMP_UGT:
-			    Store(inst->dest, Builder.CreateICmpUGT(Op0, Op1));
-			    break;
-			case OP_BC_ICMP_UGE:
-			    Store(inst->dest, Builder.CreateICmpUGE(Op0, Op1));
-			    break;
-			case OP_BC_ICMP_ULT:
-			    Store(inst->dest, Builder.CreateICmpULT(Op0, Op1));
-			    break;
-			case OP_BC_ICMP_ULE:
-			    Store(inst->dest, Builder.CreateICmpULE(Op0, Op1));
-			    break;
-			case OP_BC_ICMP_SGT:
-			    Store(inst->dest, Builder.CreateICmpSGT(Op0, Op1));
-			    break;
-			case OP_BC_ICMP_SGE:
-			    Store(inst->dest, Builder.CreateICmpSGE(Op0, Op1));
-			    break;
-			case OP_BC_ICMP_SLT:
-			    Store(inst->dest, Builder.CreateICmpSLT(Op0, Op1));
-			    break;
-			case OP_BC_ICMP_SLE:
-			    Store(inst->dest, Builder.CreateICmpSLE(Op0, Op1));
-			    break;
-			case OP_BC_SELECT:
-			    Store(inst->dest, Builder.CreateSelect(Op0, Op1, Op2));
-			    break;
-			case OP_BC_COPY:
-			{
-			    Value *Dest = Values[inst->u.binop[1]];
-			    constPointerType *PTy = cast<PointerType>(Dest->getType());
-			    Op0 = convertOperand(func, PTy->getElementType(), inst->u.binop[0]);
-			    PTy = PointerType::getUnqual(Op0->getType());
-			    Dest = Builder.CreateBitCast(Dest, PTy);
-			    Builder.CreateStore(Op0, Dest);
-			    break;
-			}
-			case OP_BC_CALL_DIRECT:
-			{
-			    Function *DestF = Functions[inst->u.ops.funcid];
-			    SmallVector<Value*, 2> args;
-			    args.push_back(&*F->arg_begin()); // pass hidden arg
-			    for (unsigned a=0;a<inst->u.ops.numOps;a++) {
-				operand_t op = inst->u.ops.ops[a];
-				args.push_back(convertOperand(func, DestF->getFunctionType()->getParamType(a+1), op));
-			    }
-			    CallInst *CI = Builder.CreateCall(DestF, ARRAYREF(Value*, args.begin(), args.end()));
-			    CI->setCallingConv(CallingConv::Fast);
+                    switch (inst->opcode) {
+                        case OP_BC_ADD:
+                            Store(inst->dest, Builder.CreateAdd(Op0, Op1));
+                            break;
+                        case OP_BC_SUB:
+                            Store(inst->dest, Builder.CreateSub(Op0, Op1));
+                            break;
+                        case OP_BC_MUL:
+                            Store(inst->dest, Builder.CreateMul(Op0, Op1));
+                            break;
+                        case OP_BC_UDIV: {
+                            Value *Bad = Builder.CreateICmpEQ(Op1, ConstantInt::get(Op1->getType(), 0));
+                            InsertVerify(Bad, Fail, CF->FHandler, F);
+                            Store(inst->dest, Builder.CreateUDiv(Op0, Op1));
+                            break;
+                        }
+                        case OP_BC_SDIV: {
+                            //TODO: also verify Op0 == -1 && Op1 = INT_MIN
+                            Value *Bad = Builder.CreateICmpEQ(Op1, ConstantInt::get(Op1->getType(), 0));
+                            InsertVerify(Bad, Fail, CF->FHandler, F);
+                            Store(inst->dest, Builder.CreateSDiv(Op0, Op1));
+                            break;
+                        }
+                        case OP_BC_UREM: {
+                            Value *Bad = Builder.CreateICmpEQ(Op1, ConstantInt::get(Op1->getType(), 0));
+                            InsertVerify(Bad, Fail, CF->FHandler, F);
+                            Store(inst->dest, Builder.CreateURem(Op0, Op1));
+                            break;
+                        }
+                        case OP_BC_SREM: {
+                            //TODO: also verify Op0 == -1 && Op1 = INT_MIN
+                            Value *Bad = Builder.CreateICmpEQ(Op1, ConstantInt::get(Op1->getType(), 0));
+                            InsertVerify(Bad, Fail, CF->FHandler, F);
+                            Store(inst->dest, Builder.CreateSRem(Op0, Op1));
+                            break;
+                        }
+                        case OP_BC_SHL:
+                            Store(inst->dest, Builder.CreateShl(Op0, Op1));
+                            break;
+                        case OP_BC_LSHR:
+                            Store(inst->dest, Builder.CreateLShr(Op0, Op1));
+                            break;
+                        case OP_BC_ASHR:
+                            Store(inst->dest, Builder.CreateAShr(Op0, Op1));
+                            break;
+                        case OP_BC_AND:
+                            Store(inst->dest, Builder.CreateAnd(Op0, Op1));
+                            break;
+                        case OP_BC_OR:
+                            Store(inst->dest, Builder.CreateOr(Op0, Op1));
+                            break;
+                        case OP_BC_XOR:
+                            Store(inst->dest, Builder.CreateXor(Op0, Op1));
+                            break;
+                        case OP_BC_TRUNC: {
+                            Value *Src    = convertOperand(func, inst, inst->u.cast.source);
+                            constType *Ty = mapType(func->types[inst->dest]);
+                            Store(inst->dest, Builder.CreateTrunc(Src, Ty));
+                            break;
+                        }
+                        case OP_BC_ZEXT: {
+                            Value *Src    = convertOperand(func, inst, inst->u.cast.source);
+                            constType *Ty = mapType(func->types[inst->dest]);
+                            Store(inst->dest, Builder.CreateZExt(Src, Ty));
+                            break;
+                        }
+                        case OP_BC_SEXT: {
+                            Value *Src    = convertOperand(func, inst, inst->u.cast.source);
+                            constType *Ty = mapType(func->types[inst->dest]);
+                            Store(inst->dest, Builder.CreateSExt(Src, Ty));
+                            break;
+                        }
+                        case OP_BC_BRANCH: {
+                            Value *Cond       = convertOperand(func, inst, inst->u.branch.condition);
+                            BasicBlock *True  = BB[inst->u.branch.br_true];
+                            BasicBlock *False = BB[inst->u.branch.br_false];
+                            if (Cond->getType() != Type::getInt1Ty(Context)) {
+                                cli_warnmsg("[Bytecode JIT]: type mismatch in condition");
+                                broken = true;
+                                break;
+                            }
+                            Builder.CreateCondBr(Cond, True, False);
+                            break;
+                        }
+                        case OP_BC_JMP: {
+                            BasicBlock *Jmp = BB[inst->u.jump];
+                            Builder.CreateBr(Jmp);
+                            break;
+                        }
+                        case OP_BC_RET: {
+                            Op0 = convertOperand(func, F->getReturnType(), inst->u.unaryop);
+                            Builder.CreateRet(Op0);
+                            break;
+                        }
+                        case OP_BC_RET_VOID:
+                            Builder.CreateRetVoid();
+                            break;
+                        case OP_BC_ICMP_EQ:
+                            Store(inst->dest, Builder.CreateICmpEQ(Op0, Op1));
+                            break;
+                        case OP_BC_ICMP_NE:
+                            Store(inst->dest, Builder.CreateICmpNE(Op0, Op1));
+                            break;
+                        case OP_BC_ICMP_UGT:
+                            Store(inst->dest, Builder.CreateICmpUGT(Op0, Op1));
+                            break;
+                        case OP_BC_ICMP_UGE:
+                            Store(inst->dest, Builder.CreateICmpUGE(Op0, Op1));
+                            break;
+                        case OP_BC_ICMP_ULT:
+                            Store(inst->dest, Builder.CreateICmpULT(Op0, Op1));
+                            break;
+                        case OP_BC_ICMP_ULE:
+                            Store(inst->dest, Builder.CreateICmpULE(Op0, Op1));
+                            break;
+                        case OP_BC_ICMP_SGT:
+                            Store(inst->dest, Builder.CreateICmpSGT(Op0, Op1));
+                            break;
+                        case OP_BC_ICMP_SGE:
+                            Store(inst->dest, Builder.CreateICmpSGE(Op0, Op1));
+                            break;
+                        case OP_BC_ICMP_SLT:
+                            Store(inst->dest, Builder.CreateICmpSLT(Op0, Op1));
+                            break;
+                        case OP_BC_ICMP_SLE:
+                            Store(inst->dest, Builder.CreateICmpSLE(Op0, Op1));
+                            break;
+                        case OP_BC_SELECT:
+                            Store(inst->dest, Builder.CreateSelect(Op0, Op1, Op2));
+                            break;
+                        case OP_BC_COPY: {
+                            Value *Dest           = Values[inst->u.binop[1]];
+                            constPointerType *PTy = cast<PointerType>(Dest->getType());
+                            Op0                   = convertOperand(func, PTy->getElementType(), inst->u.binop[0]);
+                            PTy                   = PointerType::getUnqual(Op0->getType());
+                            Dest                  = Builder.CreateBitCast(Dest, PTy);
+                            Builder.CreateStore(Op0, Dest);
+                            break;
+                        }
+                        case OP_BC_CALL_DIRECT: {
+                            Function *DestF = Functions[inst->u.ops.funcid];
+                            SmallVector<Value *, 2> args;
+                            args.push_back(&*F->arg_begin()); // pass hidden arg
+                            for (unsigned a = 0; a < inst->u.ops.numOps; a++) {
+                                operand_t op = inst->u.ops.ops[a];
+                                args.push_back(convertOperand(func, DestF->getFunctionType()->getParamType(a + 1), op));
+                            }
+                            CallInst *CI = Builder.CreateCall(DestF, ARRAYREF(Value *, args.begin(), args.end()));
+                            CI->setCallingConv(CallingConv::Fast);
 #if LLVM_VERSION < 32
-			    CI->setDoesNotThrow(true);
+                            CI->setDoesNotThrow(true);
 #else
-			    CI->setDoesNotThrow();
+                            CI->setDoesNotThrow();
 #endif
-			    if (CI->getType()->getTypeID() != Type::VoidTyID)
-				Store(inst->dest, CI);
-			    break;
-			}
-			case OP_BC_CALL_API:
-			{
-			    assert(inst->u.ops.funcid < cli_apicall_maxapi && "APICall out of range");
-			    std::vector<Value*> args;
-			    Function *DestF = apiFuncs[inst->u.ops.funcid];
-			    if (!strcmp(cli_apicalls[inst->u.ops.funcid].name, "engine_functionality_level")) {
-				Store(inst->dest,
-				      ConstantInt::get(Type::getInt32Ty(Context),
-						       cl_retflevel()));
-			    } else {
-			    args.push_back(&*F->arg_begin()); // pass hidden arg
-			    for (unsigned a=0;a<inst->u.ops.numOps;a++) {
-				operand_t op = inst->u.ops.ops[a];
-				args.push_back(convertOperand(func, DestF->getFunctionType()->getParamType(a+1), op));
-			    }
-			    CallInst *CI = Builder.CreateCall(DestF, ARRAYREFVECTOR(Value*, args));
+                            if (CI->getType()->getTypeID() != Type::VoidTyID)
+                                Store(inst->dest, CI);
+                            break;
+                        }
+                        case OP_BC_CALL_API: {
+                            assert(inst->u.ops.funcid < cli_apicall_maxapi && "APICall out of range");
+                            std::vector<Value *> args;
+                            Function *DestF = apiFuncs[inst->u.ops.funcid];
+                            if (!strcmp(cli_apicalls[inst->u.ops.funcid].name, "engine_functionality_level")) {
+                                Store(inst->dest,
+                                      ConstantInt::get(Type::getInt32Ty(Context),
+                                                       cl_retflevel()));
+                            } else {
+                                args.push_back(&*F->arg_begin()); // pass hidden arg
+                                for (unsigned a = 0; a < inst->u.ops.numOps; a++) {
+                                    operand_t op = inst->u.ops.ops[a];
+                                    args.push_back(convertOperand(func, DestF->getFunctionType()->getParamType(a + 1), op));
+                                }
+                                CallInst *CI = Builder.CreateCall(DestF, ARRAYREFVECTOR(Value *, args));
 #if LLVM_VERSION < 32
-			    CI->setDoesNotThrow(true);
+                                CI->setDoesNotThrow(true);
 #else
-			    CI->setDoesNotThrow();
+                                CI->setDoesNotThrow();
 #endif
-			    Store(inst->dest, CI);
-			    }
-			    break;
-			}
-			case OP_BC_GEP1:
-			{
-			    constType *SrcTy = mapType(inst->u.three[0]);
-			    Value *V = convertOperand(func, SrcTy, inst->u.three[1]);
-			    Value *Op = convertOperand(func, I32Ty, inst->u.three[2]);
-			    Op = GEPOperand(Op);
-			    if (!createGEP(inst->dest, V, ARRAYREF(Value*, &Op, &Op+1))) {
-				cli_warnmsg("[Bytecode JIT]: OP_BC_GEP1 createGEP failed\n");
-				broken = true;
-			    }
-			    break;
-			}
-			case OP_BC_GEPZ:
-			{
-			    Value *Ops[2];
-			    Ops[0] = ConstantInt::get(Type::getInt32Ty(Context), 0);
-			    constType *SrcTy = mapType(inst->u.three[0]);
-			    Value *V = convertOperand(func, SrcTy, inst->u.three[1]);
-			    Ops[1] = convertOperand(func, I32Ty, inst->u.three[2]);
-			    Ops[1] = GEPOperand(Ops[1]);
-			    if (!createGEP(inst->dest, V, ARRAYREF(Value*, Ops, Ops+2))) {
-				cli_warnmsg("[Bytecode JIT]: OP_BC_GEPZ createGEP failed\n");
-				broken = true;
-			    }
-			    break;
-			}
-			case OP_BC_GEPN:
-			{
-			    std::vector<Value*> Idxs;
-			    assert(inst->u.ops.numOps > 2);
-			    constType *SrcTy = mapType(inst->u.ops.ops[0]);
-			    Value *V = convertOperand(func, SrcTy, inst->u.ops.ops[1]);
-			    for (unsigned a=2;a<inst->u.ops.numOps;a++) {
-				Value *Op = convertOperand(func, I32Ty, inst->u.ops.ops[a]);
-				Op = GEPOperand(Op);
-				Idxs.push_back(Op);
-			    }
-			    if (!createGEP(inst->dest, V, ARRAYREFVECTOR(Value*, Idxs))) {
-				cli_warnmsg("[Bytecode JIT]: OP_BC_GEPN createGEP failed\n");
-				broken = true;
-			    }
-			    break;
-			}
-			case OP_BC_STORE:
-			{
-			    Value *Dest = convertOperand(func, inst, inst->u.binop[1]);
-			    Value *V = convertOperand(func, inst, inst->u.binop[0]);
-			    constType *VPTy = PointerType::getUnqual(V->getType());
-			    if (VPTy != Dest->getType())
-				Dest = Builder.CreateBitCast(Dest, VPTy);
-			    Builder.CreateStore(V, Dest);
-			    break;
-			}
-			case OP_BC_LOAD:
-			{
-			    Op0 = Builder.CreateBitCast(Op0,
-							Values[inst->dest]->getType());
-			    Op0 = Builder.CreateLoad(Op0);
-			    Store(inst->dest, Op0);
-			    break;
-			}
-			case OP_BC_MEMSET:
-			{
-			    Value *Dst = convertOperand(func, inst, inst->u.three[0]);
-			    Dst = Builder.CreatePointerCast(Dst, PointerType::getUnqual(Type::getInt8Ty(Context)));
-			    Value *Val = convertOperand(func, Type::getInt8Ty(Context), inst->u.three[1]);
-			    Value *Len = convertOperand(func, Type::getInt32Ty(Context), inst->u.three[2]);
+                                Store(inst->dest, CI);
+                            }
+                            break;
+                        }
+                        case OP_BC_GEP1: {
+                            constType *SrcTy = mapType(inst->u.three[0]);
+                            Value *V         = convertOperand(func, SrcTy, inst->u.three[1]);
+                            Value *Op        = convertOperand(func, I32Ty, inst->u.three[2]);
+                            Op               = GEPOperand(Op);
+                            if (!createGEP(inst->dest, V, ARRAYREF(Value *, &Op, &Op + 1))) {
+                                cli_warnmsg("[Bytecode JIT]: OP_BC_GEP1 createGEP failed\n");
+                                broken = true;
+                            }
+                            break;
+                        }
+                        case OP_BC_GEPZ: {
+                            Value *Ops[2];
+                            Ops[0]           = ConstantInt::get(Type::getInt32Ty(Context), 0);
+                            constType *SrcTy = mapType(inst->u.three[0]);
+                            Value *V         = convertOperand(func, SrcTy, inst->u.three[1]);
+                            Ops[1]           = convertOperand(func, I32Ty, inst->u.three[2]);
+                            Ops[1]           = GEPOperand(Ops[1]);
+                            if (!createGEP(inst->dest, V, ARRAYREF(Value *, Ops, Ops + 2))) {
+                                cli_warnmsg("[Bytecode JIT]: OP_BC_GEPZ createGEP failed\n");
+                                broken = true;
+                            }
+                            break;
+                        }
+                        case OP_BC_GEPN: {
+                            std::vector<Value *> Idxs;
+                            assert(inst->u.ops.numOps > 2);
+                            constType *SrcTy = mapType(inst->u.ops.ops[0]);
+                            Value *V         = convertOperand(func, SrcTy, inst->u.ops.ops[1]);
+                            for (unsigned a = 2; a < inst->u.ops.numOps; a++) {
+                                Value *Op = convertOperand(func, I32Ty, inst->u.ops.ops[a]);
+                                Op        = GEPOperand(Op);
+                                Idxs.push_back(Op);
+                            }
+                            if (!createGEP(inst->dest, V, ARRAYREFVECTOR(Value *, Idxs))) {
+                                cli_warnmsg("[Bytecode JIT]: OP_BC_GEPN createGEP failed\n");
+                                broken = true;
+                            }
+                            break;
+                        }
+                        case OP_BC_STORE: {
+                            Value *Dest     = convertOperand(func, inst, inst->u.binop[1]);
+                            Value *V        = convertOperand(func, inst, inst->u.binop[0]);
+                            constType *VPTy = PointerType::getUnqual(V->getType());
+                            if (VPTy != Dest->getType())
+                                Dest = Builder.CreateBitCast(Dest, VPTy);
+                            Builder.CreateStore(V, Dest);
+                            break;
+                        }
+                        case OP_BC_LOAD: {
+                            Op0 = Builder.CreateBitCast(Op0,
+                                                        Values[inst->dest]->getType());
+                            Op0 = Builder.CreateLoad(Op0);
+                            Store(inst->dest, Op0);
+                            break;
+                        }
+                        case OP_BC_MEMSET: {
+                            Value *Dst = convertOperand(func, inst, inst->u.three[0]);
+                            Dst        = Builder.CreatePointerCast(Dst, PointerType::getUnqual(Type::getInt8Ty(Context)));
+                            Value *Val = convertOperand(func, Type::getInt8Ty(Context), inst->u.three[1]);
+                            Value *Len = convertOperand(func, Type::getInt32Ty(Context), inst->u.three[2]);
 #if LLVM_VERSION < 29
-			    CallInst *c = Builder.CreateCall4(CF->FMemset, Dst, Val, Len,
-								ConstantInt::get(Type::getInt32Ty(Context), 1));
+                            CallInst *c = Builder.CreateCall4(CF->FMemset, Dst, Val, Len,
+                                                              ConstantInt::get(Type::getInt32Ty(Context), 1));
 #else
-			    CallInst *c = Builder.CreateCall5(CF->FMemset, Dst, Val, Len,
-								ConstantInt::get(Type::getInt32Ty(Context), 1),
-								ConstantInt::get(Type::getInt1Ty(Context), 0)
-								);
+                            CallInst *c = Builder.CreateCall5(CF->FMemset, Dst, Val, Len,
+                                                              ConstantInt::get(Type::getInt32Ty(Context), 1),
+                                                              ConstantInt::get(Type::getInt1Ty(Context), 0));
 #endif
-			    c->setTailCall(true);
-			    c->setDoesNotThrow();
-			    UpgradeCall(c, CF->FMemset);
-			    break;
-			}
-			case OP_BC_MEMCPY:
-			{
-			    Value *Dst = convertOperand(func, inst, inst->u.three[0]);
-			    Dst = Builder.CreatePointerCast(Dst, PointerType::getUnqual(Type::getInt8Ty(Context)));
-			    Value *Src = convertOperand(func, inst, inst->u.three[1]);
-			    Src = Builder.CreatePointerCast(Src, PointerType::getUnqual(Type::getInt8Ty(Context)));
-			    Value *Len = convertOperand(func, Type::getInt32Ty(Context), inst->u.three[2]);
+                            c->setTailCall(true);
+                            c->setDoesNotThrow();
+                            UpgradeCall(c, CF->FMemset);
+                            break;
+                        }
+                        case OP_BC_MEMCPY: {
+                            Value *Dst = convertOperand(func, inst, inst->u.three[0]);
+                            Dst        = Builder.CreatePointerCast(Dst, PointerType::getUnqual(Type::getInt8Ty(Context)));
+                            Value *Src = convertOperand(func, inst, inst->u.three[1]);
+                            Src        = Builder.CreatePointerCast(Src, PointerType::getUnqual(Type::getInt8Ty(Context)));
+                            Value *Len = convertOperand(func, Type::getInt32Ty(Context), inst->u.three[2]);
 #if LLVM_VERSION < 29
-			    CallInst *c = Builder.CreateCall4(CF->FMemcpy, Dst, Src, Len,
-								ConstantInt::get(Type::getInt32Ty(Context), 1));
+                            CallInst *c = Builder.CreateCall4(CF->FMemcpy, Dst, Src, Len,
+                                                              ConstantInt::get(Type::getInt32Ty(Context), 1));
 #else
-			    CallInst *c = Builder.CreateCall5(CF->FMemcpy, Dst, Src, Len,
-								ConstantInt::get(Type::getInt32Ty(Context), 1),
-								ConstantInt::get(Type::getInt1Ty(Context), 0)
-								);
+                            CallInst *c = Builder.CreateCall5(CF->FMemcpy, Dst, Src, Len,
+                                                              ConstantInt::get(Type::getInt32Ty(Context), 1),
+                                                              ConstantInt::get(Type::getInt1Ty(Context), 0));
 #endif
-			    c->setTailCall(true);
-			    c->setDoesNotThrow();
-			    UpgradeCall(c, CF->FMemcpy);
-			    break;
-			}
-			case OP_BC_MEMMOVE:
-			{
-			    Value *Dst = convertOperand(func, inst, inst->u.three[0]);
-			    Dst = Builder.CreatePointerCast(Dst, PointerType::getUnqual(Type::getInt8Ty(Context)));
-			    Value *Src = convertOperand(func, inst, inst->u.three[1]);
-			    Src = Builder.CreatePointerCast(Src, PointerType::getUnqual(Type::getInt8Ty(Context)));
-			    Value *Len = convertOperand(func, Type::getInt32Ty(Context), inst->u.three[2]);
+                            c->setTailCall(true);
+                            c->setDoesNotThrow();
+                            UpgradeCall(c, CF->FMemcpy);
+                            break;
+                        }
+                        case OP_BC_MEMMOVE: {
+                            Value *Dst = convertOperand(func, inst, inst->u.three[0]);
+                            Dst        = Builder.CreatePointerCast(Dst, PointerType::getUnqual(Type::getInt8Ty(Context)));
+                            Value *Src = convertOperand(func, inst, inst->u.three[1]);
+                            Src        = Builder.CreatePointerCast(Src, PointerType::getUnqual(Type::getInt8Ty(Context)));
+                            Value *Len = convertOperand(func, Type::getInt32Ty(Context), inst->u.three[2]);
 #if LLVM_VERSION < 29
-			    CallInst *c = Builder.CreateCall4(CF->FMemmove, Dst, Src, Len,
-								ConstantInt::get(Type::getInt32Ty(Context), 1));
+                            CallInst *c = Builder.CreateCall4(CF->FMemmove, Dst, Src, Len,
+                                                              ConstantInt::get(Type::getInt32Ty(Context), 1));
 #else
-			    CallInst *c = Builder.CreateCall5(CF->FMemmove, Dst, Src, Len,
-								ConstantInt::get(Type::getInt32Ty(Context), 1),
-								ConstantInt::get(Type::getInt1Ty(Context), 0));
+                            CallInst *c = Builder.CreateCall5(CF->FMemmove, Dst, Src, Len,
+                                                              ConstantInt::get(Type::getInt32Ty(Context), 1),
+                                                              ConstantInt::get(Type::getInt1Ty(Context), 0));
 #endif
-			    c->setTailCall(true);
-			    c->setDoesNotThrow();
-			    UpgradeCall(c, CF->FMemmove);
-			    break;
-			}
-			case OP_BC_MEMCMP:
-			{
-			    Value *Dst = convertOperand(func, inst, inst->u.three[0]);
-			    Dst = Builder.CreatePointerCast(Dst, PointerType::getUnqual(Type::getInt8Ty(Context)));
-			    Value *Src = convertOperand(func, inst, inst->u.three[1]);
-			    Src = Builder.CreatePointerCast(Src, PointerType::getUnqual(Type::getInt8Ty(Context)));
+                            c->setTailCall(true);
+                            c->setDoesNotThrow();
+                            UpgradeCall(c, CF->FMemmove);
+                            break;
+                        }
+                        case OP_BC_MEMCMP: {
+                            Value *Dst = convertOperand(func, inst, inst->u.three[0]);
+                            Dst        = Builder.CreatePointerCast(Dst, PointerType::getUnqual(Type::getInt8Ty(Context)));
+                            Value *Src = convertOperand(func, inst, inst->u.three[1]);
+                            Src        = Builder.CreatePointerCast(Src, PointerType::getUnqual(Type::getInt8Ty(Context)));
 #if LLVM_VERSION < 32
-			    Value *Len = convertOperand(func, EE->getTargetData()->getIntPtrType(Context), inst->u.three[2]);
+                            Value *Len = convertOperand(func, EE->getTargetData()->getIntPtrType(Context), inst->u.three[2]);
 #else
-			    Value *Len = convertOperand(func, EE->getDataLayout()->getIntPtrType(Context), inst->u.three[2]);
+                            Value *Len  = convertOperand(func, EE->getDataLayout()->getIntPtrType(Context), inst->u.three[2]);
 #endif
-			    CallInst *c = Builder.CreateCall3(CF->FRealmemcmp, Dst, Src, Len);
-			    c->setTailCall(true);
-			    c->setDoesNotThrow();
-			    Store(inst->dest, c);
-			    break;
-			}
-			case OP_BC_ISBIGENDIAN:
-			    Store(inst->dest, WORDS_BIGENDIAN ?
-				  ConstantInt::getTrue(Context) :
-				  ConstantInt::getFalse(Context));
-			    break;
-			case OP_BC_ABORT:
-			    if (!unreachable) {
-				CallInst *CI = Builder.CreateCall(CF->FHandler);
-				CI->setDoesNotReturn();
-				CI->setDoesNotThrow();
-				Builder.CreateUnreachable();
-				unreachable = true;
-			    }
-			    break;
-			case OP_BC_BSWAP16:
-			    {
-				CallInst *C = Builder.CreateCall(CF->FBSwap16, convertOperand(func, inst, inst->u.unaryop));
-				C->setTailCall(true);
+                            CallInst *c = Builder.CreateCall3(CF->FRealmemcmp, Dst, Src, Len);
+                            c->setTailCall(true);
+                            c->setDoesNotThrow();
+                            Store(inst->dest, c);
+                            break;
+                        }
+                        case OP_BC_ISBIGENDIAN:
+                            Store(inst->dest, WORDS_BIGENDIAN ? ConstantInt::getTrue(Context) : ConstantInt::getFalse(Context));
+                            break;
+                        case OP_BC_ABORT:
+                            if (!unreachable) {
+                                CallInst *CI = Builder.CreateCall(CF->FHandler);
+                                CI->setDoesNotReturn();
+                                CI->setDoesNotThrow();
+                                Builder.CreateUnreachable();
+                                unreachable = true;
+                            }
+                            break;
+                        case OP_BC_BSWAP16: {
+                            CallInst *C = Builder.CreateCall(CF->FBSwap16, convertOperand(func, inst, inst->u.unaryop));
+                            C->setTailCall(true);
 #if LLVM_VERSION < 32
-				C->setDoesNotThrow(true);
+                            C->setDoesNotThrow(true);
 #else
-				C->setDoesNotThrow();
+                            C->setDoesNotThrow();
 #endif
-				Store(inst->dest, C);
-				break;
-			    }
-			case OP_BC_BSWAP32:
-			    {
-				CallInst *C = Builder.CreateCall(CF->FBSwap32, convertOperand(func, inst, inst->u.unaryop));
-				C->setTailCall(true);
+                            Store(inst->dest, C);
+                            break;
+                        }
+                        case OP_BC_BSWAP32: {
+                            CallInst *C = Builder.CreateCall(CF->FBSwap32, convertOperand(func, inst, inst->u.unaryop));
+                            C->setTailCall(true);
 #if LLVM_VERSION < 32
-				C->setDoesNotThrow(true);
+                            C->setDoesNotThrow(true);
 #else
-				C->setDoesNotThrow();
+                            C->setDoesNotThrow();
 #endif
-				Store(inst->dest, C);
-				break;
-			    }
-			case OP_BC_BSWAP64:
-			    {
-				CallInst *C = Builder.CreateCall(CF->FBSwap64, convertOperand(func, inst, inst->u.unaryop));
-				C->setTailCall(true);
+                            Store(inst->dest, C);
+                            break;
+                        }
+                        case OP_BC_BSWAP64: {
+                            CallInst *C = Builder.CreateCall(CF->FBSwap64, convertOperand(func, inst, inst->u.unaryop));
+                            C->setTailCall(true);
 #if LLVM_VERSION < 32
-				C->setDoesNotThrow(true);
+                            C->setDoesNotThrow(true);
 #else
-				C->setDoesNotThrow();
+                            C->setDoesNotThrow();
 #endif
-				Store(inst->dest, C);
-				break;
-			    }
-			case OP_BC_PTRDIFF32:
-			    {
-				Value *P1 = convertOperand(func, inst, inst->u.binop[0]);
-				Value *P2 = convertOperand(func, inst, inst->u.binop[1]);
-				P1 = Builder.CreatePtrToInt(P1, Type::getInt64Ty(Context));
-				P2 = Builder.CreatePtrToInt(P2, Type::getInt64Ty(Context));
-				Value *R = Builder.CreateSub(P1, P2);
-				R = Builder.CreateTrunc(R, Type::getInt32Ty(Context));
-				Store(inst->dest, R);
-				break;
-			    }
-			case OP_BC_PTRTOINT64:
-			    {
-				Value *P1 = convertOperand(func, inst, inst->u.unaryop);
-				P1 = Builder.CreatePtrToInt(P1, Type::getInt64Ty(Context));
-				Store(inst->dest, P1);
-				break;
-			    }
-			default:
-			    cli_warnmsg("[Bytecode JIT]: JIT doesn't implement opcode %d yet!\n",
-					inst->opcode);
-			    broken = true;
-			    break;
-		    }
-		}
-	    }
+                            Store(inst->dest, C);
+                            break;
+                        }
+                        case OP_BC_PTRDIFF32: {
+                            Value *P1 = convertOperand(func, inst, inst->u.binop[0]);
+                            Value *P2 = convertOperand(func, inst, inst->u.binop[1]);
+                            P1        = Builder.CreatePtrToInt(P1, Type::getInt64Ty(Context));
+                            P2        = Builder.CreatePtrToInt(P2, Type::getInt64Ty(Context));
+                            Value *R  = Builder.CreateSub(P1, P2);
+                            R         = Builder.CreateTrunc(R, Type::getInt32Ty(Context));
+                            Store(inst->dest, R);
+                            break;
+                        }
+                        case OP_BC_PTRTOINT64: {
+                            Value *P1 = convertOperand(func, inst, inst->u.unaryop);
+                            P1        = Builder.CreatePtrToInt(P1, Type::getInt64Ty(Context));
+                            Store(inst->dest, P1);
+                            break;
+                        }
+                        default:
+                            cli_warnmsg("[Bytecode JIT]: JIT doesn't implement opcode %d yet!\n",
+                                        inst->opcode);
+                            broken = true;
+                            break;
+                    }
+                }
+            }
 
-	    // If successful so far, run verifyFunction
-	    if (!broken) {
+            // If successful so far, run verifyFunction
+            if (!broken) {
 #if LLVM_VERSION < 35
-		if (verifyFunction(*F, PrintMessageAction)) {
+                if (verifyFunction(*F, PrintMessageAction)) {
 #else
-		if (verifyFunction(*F, &errs())) {
+                if (verifyFunction(*F, &errs())) {
 #endif
-		    // verification failed
-		    broken = true;
-		    cli_warnmsg("[Bytecode JIT]: Verification failed\n");
-		    if (cli_debug_flag) {
-			std::string str;
-			raw_string_ostream ostr(str);
-			F->print(ostr);
-			cli_dbgmsg_internal("[Bytecode JIT]: %s\n", ostr.str().c_str());
-		    }
-		}
-	    }
+                    // verification failed
+                    broken = true;
+                    cli_warnmsg("[Bytecode JIT]: Verification failed\n");
+                    if (cli_debug_flag) {
+                        std::string str;
+                        raw_string_ostream ostr(str);
+                        F->print(ostr);
+                        cli_dbgmsg_internal("[Bytecode JIT]: %s\n", ostr.str().c_str());
+                    }
+                }
+            }
 
-	    delete [] Values;
+            delete[] Values;
 
-	    // Cleanup after failure and return 0
-	    if (broken) {
-		for (unsigned z=0; z < func->numBB ; z++) {
-		    delete BB[z];
-		}
-		delete [] BB;
-		apiMap.irgenTimer.stopTimer();
-		delete TypeMap;
-		for (unsigned z=0; z < bc->num_func; z++) {
-		    delete Functions[z];
-		}
-		delete [] Functions;
-		return 0;
-	    }
+            // Cleanup after failure and return 0
+            if (broken) {
+                for (unsigned z = 0; z < func->numBB; z++) {
+                    delete BB[z];
+                }
+                delete[] BB;
+                apiMap.irgenTimer.stopTimer();
+                delete TypeMap;
+                for (unsigned z = 0; z < bc->num_func; z++) {
+                    delete Functions[z];
+                }
+                delete[] Functions;
+                return 0;
+            }
 
-	    delete [] BB;
-	    apiMap.irgenTimer.stopTimer();
-	    apiMap.pmTimer.startTimer();
-	    if (bc->trusted) {
-		PM.doInitialization();
-		PM.run(*F);
-		PM.doFinalization();
-	    }
-	    else {
-		PMUnsigned.doInitialization();
-		PMUnsigned.run(*F);
-		PMUnsigned.doFinalization();
-	    }
-	    apiMap.pmTimer.stopTimer();
-	    apiMap.irgenTimer.startTimer();
-	}
+            delete[] BB;
+            apiMap.irgenTimer.stopTimer();
+            apiMap.pmTimer.startTimer();
+            if (bc->trusted) {
+                PM.doInitialization();
+                PM.run(*F);
+                PM.doFinalization();
+            } else {
+                PMUnsigned.doInitialization();
+                PMUnsigned.run(*F);
+                PMUnsigned.doFinalization();
+            }
+            apiMap.pmTimer.stopTimer();
+            apiMap.irgenTimer.startTimer();
+        }
 
-	for (unsigned j=0;j<bc->num_func;j++) {
-	    Function *F = Functions[j];
-	    AddStackProtect(F);
-	}
-	delete TypeMap;
-	std::vector<constType*> args;
-	args.clear();
-	args.push_back(HiddenCtx);
-	FunctionType *Callable = FunctionType::get(Type::getInt32Ty(Context),
-						   args, false);
+        for (unsigned j = 0; j < bc->num_func; j++) {
+            Function *F = Functions[j];
+            AddStackProtect(F);
+        }
+        delete TypeMap;
+        std::vector<constType *> args;
+        args.clear();
+        args.push_back(HiddenCtx);
+        FunctionType *Callable = FunctionType::get(Type::getInt32Ty(Context),
+                                                   args, false);
 
-	// If prototype matches, add to callable functions
-	if (Functions[0]->getFunctionType() != Callable) {
-	    cli_warnmsg("[Bytecode JIT]: Wrong prototype for function 0 in bytecode %d\n",  bc->id);
-	    apiMap.irgenTimer.stopTimer();
-	    for (unsigned z=0; z < bc->num_func; z++) {
-		delete Functions[z];
-	    }
-	    delete [] Functions;
-	    return 0;
-	}
-	// All functions have the Fast calling convention, however
-	// entrypoint can only be C, emit wrapper
-	Function *F = Function::Create(Functions[0]->getFunctionType(),
-				       Function::ExternalLinkage,
+        // If prototype matches, add to callable functions
+        if (Functions[0]->getFunctionType() != Callable) {
+            cli_warnmsg("[Bytecode JIT]: Wrong prototype for function 0 in bytecode %d\n", bc->id);
+            apiMap.irgenTimer.stopTimer();
+            for (unsigned z = 0; z < bc->num_func; z++) {
+                delete Functions[z];
+            }
+            delete[] Functions;
+            return 0;
+        }
+        // All functions have the Fast calling convention, however
+        // entrypoint can only be C, emit wrapper
+        Function *F = Function::Create(Functions[0]->getFunctionType(),
+                                       Function::ExternalLinkage,
 #if LLVM_VERSION < 33
-				       Functions[0]->getName()+"_wrap", M);
+                                       Functions[0]->getName() + "_wrap", M);
 #else
-				       Functions[0]->getName().str()+"_wrap", M);
+                                       Functions[0]->getName().str() + "_wrap", M);
 #endif
-	F->setDoesNotThrow();
-	BasicBlock *BB = BasicBlock::Create(Context, "", F);
-	std::vector<Value*> Args;
-	for (Function::arg_iterator J=F->arg_begin(),
-	     JE=F->arg_end(); J != JE; ++JE) {
-	    Args.push_back(&*J);
-	}
-	CallInst *CI = CallInst::Create(Functions[0], ARRAYREFVECTOR(Value*, Args), "", BB);
-	CI->setCallingConv(CallingConv::Fast);
-	ReturnInst::Create(Context, CI, BB);
+        F->setDoesNotThrow();
+        BasicBlock *BB = BasicBlock::Create(Context, "", F);
+        std::vector<Value *> Args;
+        for (Function::arg_iterator J  = F->arg_begin(),
+                                    JE = F->arg_end();
+             J != JE; ++JE) {
+            Args.push_back(&*J);
+        }
+        CallInst *CI = CallInst::Create(Functions[0], ARRAYREFVECTOR(Value *, Args), "", BB);
+        CI->setCallingConv(CallingConv::Fast);
+        ReturnInst::Create(Context, CI, BB);
 
-	delete [] Functions;
+        delete[] Functions;
 #if LLVM_VERSION < 35
-	if (verifyFunction(*F, PrintMessageAction))
+        if (verifyFunction(*F, PrintMessageAction))
 #else
-	if (verifyFunction(*F, &errs()))
+        if (verifyFunction(*F, &errs()))
 #endif
-	    return 0;
+            return 0;
 
-/*			DEBUG(errs() << "Generating code\n");
+        /*			DEBUG(errs() << "Generating code\n");
 			// Codegen current function as executable machine code.
 			EE->getPointerToFunction(Functions[j]);
 			void *code = EE->getPointerToFunction(F);
 			DEBUG(errs() << "Code generation finished\n");*/
 
-//		compiledFunctions[func] = code;
-	apiMap.irgenTimer.stopTimer();
-	return F;
+        //		compiledFunctions[func] = code;
+        apiMap.irgenTimer.stopTimer();
+        return F;
     }
 };
 
@@ -2032,39 +2034,42 @@ static sys::Mutex llvm_api_lock;
 
 // This class automatically acquires the lock when instantiated,
 // and releases the lock when leaving scope.
-class LLVMApiScopedLock {
-    public:
-	// when multithreaded mode is false (no atomics available),
-	// we need to wrap all LLVM API calls with a giant mutex lock, but
-	// only then.
-	LLVMApiScopedLock() {
-	    // It is safer to just run all codegen under the mutex,
-	    // it is not like we are going to codegen from multiple threads
-	    // at a time anyway.
+class LLVMApiScopedLock
+{
+  public:
+    // when multithreaded mode is false (no atomics available),
+    // we need to wrap all LLVM API calls with a giant mutex lock, but
+    // only then.
+    LLVMApiScopedLock()
+    {
+        // It is safer to just run all codegen under the mutex,
+        // it is not like we are going to codegen from multiple threads
+        // at a time anyway.
 //	    if (!llvm_is_multithreaded())
 #if LLVM_VERSION < 36
-		llvm_api_lock.acquire();
+        llvm_api_lock.acquire();
 #else
-		llvm_api_lock.lock();
+        llvm_api_lock.lock();
 #endif
-	}
-	~LLVMApiScopedLock() {
+    }
+    ~LLVMApiScopedLock()
+    {
 //	    if (!llvm_is_multithreaded())
 #if LLVM_VERSION < 36
-		llvm_api_lock.release();
+        llvm_api_lock.release();
 #else
-		llvm_api_lock.unlock();
+        llvm_api_lock.unlock();
 #endif
-	}
+    }
 };
 
 static void addFunctionProtos(struct CommonFunctions *CF, ExecutionEngine *EE, Module *M)
 {
     LLVMContext &Context = M->getContext();
-    FunctionType *FTy = FunctionType::get(Type::getVoidTy(Context),
-					  false);
-    CF->FHandler = Function::Create(FTy, Function::ExternalLinkage,
-					  "clamjit.fail", M);
+    FunctionType *FTy    = FunctionType::get(Type::getVoidTy(Context),
+                                          false);
+    CF->FHandler         = Function::Create(FTy, Function::ExternalLinkage,
+                                    "clamjit.fail", M);
     CF->FHandler->setDoesNotReturn();
     CF->FHandler->setDoesNotThrow();
 #if LLVM_VERSION == 32
@@ -2074,14 +2079,14 @@ static void addFunctionProtos(struct CommonFunctions *CF, ExecutionEngine *EE, M
 #endif
 #if LLVM_VERSION < 36
     // addGlobalMapping still exists in LLVM 3.6, but it doesn't work with MCJIT, which now replaces the JIT implementation.
-    EE->addGlobalMapping(CF->FHandler, (void*)(intptr_t)jit_exception_handler);
+    EE->addGlobalMapping(CF->FHandler, (void *)(intptr_t)jit_exception_handler);
 #else
-    sys::DynamicLibrary::AddSymbol(CF->FHandler->getName(), (void*)(intptr_t)jit_exception_handler);
+    sys::DynamicLibrary::AddSymbol(CF->FHandler->getName(), (void *)(intptr_t)jit_exception_handler);
 #endif
     EE->InstallLazyFunctionCreator(noUnknownFunctions);
     EE->getPointerToFunction(CF->FHandler);
 
-    std::vector<constType*> args;
+    std::vector<constType *> args;
     args.push_back(PointerType::getUnqual(Type::getInt8Ty(Context)));
     args.push_back(Type::getInt8Ty(Context));
     args.push_back(Type::getInt32Ty(Context));
@@ -2089,9 +2094,9 @@ static void addFunctionProtos(struct CommonFunctions *CF, ExecutionEngine *EE, M
 #if LLVM_VERSION >= 29
     args.push_back(Type::getInt1Ty(Context));
 #endif
-    FunctionType* FuncTy_3 = FunctionType::get(Type::getVoidTy(Context),
-					       args, false);
-    CF->FMemset = Function::Create(FuncTy_3, GlobalValue::ExternalLinkage,
+    FunctionType *FuncTy_3 = FunctionType::get(Type::getVoidTy(Context),
+                                               args, false);
+    CF->FMemset            = Function::Create(FuncTy_3, GlobalValue::ExternalLinkage,
 #if LLVM_VERSION < 29
                                    "llvm.memset.i32",
 #else
@@ -2113,9 +2118,9 @@ static void addFunctionProtos(struct CommonFunctions *CF, ExecutionEngine *EE, M
 #if LLVM_VERSION >= 29
     args.push_back(Type::getInt1Ty(Context));
 #endif
-    FunctionType* FuncTy_4 = FunctionType::get(Type::getVoidTy(Context),
-					       args, false);
-    CF->FMemmove = Function::Create(FuncTy_4, GlobalValue::ExternalLinkage,
+    FunctionType *FuncTy_4 = FunctionType::get(Type::getVoidTy(Context),
+                                               args, false);
+    CF->FMemmove           = Function::Create(FuncTy_4, GlobalValue::ExternalLinkage,
 #if LLVM_VERSION < 29
                                     "llvm.memmove.i32",
 #else
@@ -2146,47 +2151,47 @@ static void addFunctionProtos(struct CommonFunctions *CF, ExecutionEngine *EE, M
     args.clear();
     args.push_back(Type::getInt16Ty(Context));
     FunctionType *FuncTy_5 = FunctionType::get(Type::getInt16Ty(Context), args, false);
-    CF->FBSwap16 = Function::Create(FuncTy_5, GlobalValue::ExternalLinkage,
-					  "llvm.bswap.i16", M);
+    CF->FBSwap16           = Function::Create(FuncTy_5, GlobalValue::ExternalLinkage,
+                                    "llvm.bswap.i16", M);
     CF->FBSwap16->setDoesNotThrow();
 
     args.clear();
     args.push_back(Type::getInt32Ty(Context));
     FunctionType *FuncTy_6 = FunctionType::get(Type::getInt32Ty(Context), args, false);
-    CF->FBSwap32 = Function::Create(FuncTy_6, GlobalValue::ExternalLinkage,
-					  "llvm.bswap.i32", M);
+    CF->FBSwap32           = Function::Create(FuncTy_6, GlobalValue::ExternalLinkage,
+                                    "llvm.bswap.i32", M);
     CF->FBSwap32->setDoesNotThrow();
 
     args.clear();
     args.push_back(Type::getInt64Ty(Context));
     FunctionType *FuncTy_7 = FunctionType::get(Type::getInt64Ty(Context), args, false);
-    CF->FBSwap64 = Function::Create(FuncTy_7, GlobalValue::ExternalLinkage,
-					  "llvm.bswap.i64", M);
+    CF->FBSwap64           = Function::Create(FuncTy_7, GlobalValue::ExternalLinkage,
+                                    "llvm.bswap.i64", M);
     CF->FBSwap64->setDoesNotThrow();
 
-    FunctionType* DummyTy = FunctionType::get(Type::getVoidTy(Context), false);
-    CF->FRealmemset = Function::Create(DummyTy, GlobalValue::ExternalLinkage,
-					     "memset", M);
+    FunctionType *DummyTy = FunctionType::get(Type::getVoidTy(Context), false);
+    CF->FRealmemset       = Function::Create(DummyTy, GlobalValue::ExternalLinkage,
+                                       "memset", M);
 #if LLVM_VERSION < 36
-    EE->addGlobalMapping(CF->FRealmemset, (void*)(intptr_t)memset);
+    EE->addGlobalMapping(CF->FRealmemset, (void *)(intptr_t)memset);
 #else
-    sys::DynamicLibrary::AddSymbol(CF->FRealmemset->getName(), (void*)(intptr_t)memset);
+    sys::DynamicLibrary::AddSymbol(CF->FRealmemset->getName(), (void *)(intptr_t)memset);
 #endif
     EE->getPointerToFunction(CF->FRealmemset);
     CF->FRealMemmove = Function::Create(DummyTy, GlobalValue::ExternalLinkage,
-					      "memmove", M);
+                                        "memmove", M);
 #if LLVM_VERSION < 36
-    EE->addGlobalMapping(CF->FRealMemmove, (void*)(intptr_t)memmove);
+    EE->addGlobalMapping(CF->FRealMemmove, (void *)(intptr_t)memmove);
 #else
-    sys::DynamicLibrary::AddSymbol(CF->FRealMemmove->getName(), (void*)(intptr_t)memmove);
+    sys::DynamicLibrary::AddSymbol(CF->FRealMemmove->getName(), (void *)(intptr_t)memmove);
 #endif
     EE->getPointerToFunction(CF->FRealMemmove);
     CF->FRealmemcpy = Function::Create(DummyTy, GlobalValue::ExternalLinkage,
-					     "memcpy", M);
+                                       "memcpy", M);
 #if LLVM_VERSION < 36
-    EE->addGlobalMapping(CF->FRealmemcpy, (void*)(intptr_t)memcpy);
+    EE->addGlobalMapping(CF->FRealmemcpy, (void *)(intptr_t)memcpy);
 #else
-    sys::DynamicLibrary::AddSymbol(CF->FRealmemcpy->getName(), (void*)(intptr_t)memcpy);
+    sys::DynamicLibrary::AddSymbol(CF->FRealmemcpy->getName(), (void *)(intptr_t)memcpy);
 #endif
     EE->getPointerToFunction(CF->FRealmemcpy);
 
@@ -2198,18 +2203,18 @@ static void addFunctionProtos(struct CommonFunctions *CF, ExecutionEngine *EE, M
 #else
     args.push_back(EE->getDataLayout()->getIntPtrType(Context));
 #endif
-    FuncTy_5 = FunctionType::get(Type::getInt32Ty(Context),
-				 args, false);
+    FuncTy_5        = FunctionType::get(Type::getInt32Ty(Context),
+                                 args, false);
     CF->FRealmemcmp = Function::Create(FuncTy_5, GlobalValue::ExternalLinkage, "memcmp", M);
 #if LLVM_VERSION < 36
-    EE->addGlobalMapping(CF->FRealmemcmp, (void*)(intptr_t)memcmp);
+    EE->addGlobalMapping(CF->FRealmemcmp, (void *)(intptr_t)memcmp);
 #else
-    sys::DynamicLibrary::AddSymbol(CF->FRealmemcmp->getName(), (void*)(intptr_t)memcmp);
+    sys::DynamicLibrary::AddSymbol(CF->FRealmemcmp->getName(), (void *)(intptr_t)memcmp);
 #endif
     EE->getPointerToFunction(CF->FRealmemcmp);
 }
 
-}
+} // namespace
 #if LLVM_VERSION >= 29
 INITIALIZE_PASS_BEGIN(RuntimeLimits, "rl", "Runtime Limits", false, false)
 INITIALIZE_PASS_DEPENDENCY(LoopInfo)
@@ -2219,25 +2224,25 @@ INITIALIZE_PASS_DEPENDENCY(DominatorTree)
 #else
 INITIALIZE_PASS_DEPENDENCY(DominatorTreeWrapperPass)
 #endif
-INITIALIZE_PASS_END(RuntimeLimits, "rl" ,"Runtime Limits", false, false)
+INITIALIZE_PASS_END(RuntimeLimits, "rl", "Runtime Limits", false, false)
 #endif
 
 static pthread_mutex_t watchdog_mutex = PTHREAD_MUTEX_INITIALIZER;
-static pthread_cond_t watchdog_cond = PTHREAD_COND_INITIALIZER;
-static pthread_cond_t watchdog_cond2 = PTHREAD_COND_INITIALIZER;
-static int watchdog_running = 0;
+static pthread_cond_t watchdog_cond   = PTHREAD_COND_INITIALIZER;
+static pthread_cond_t watchdog_cond2  = PTHREAD_COND_INITIALIZER;
+static int watchdog_running           = 0;
 
 struct watchdog_item {
-    volatile uint8_t* timeout;
+    volatile uint8_t *timeout;
     struct timespec abstimeout;
     struct watchdog_item *next;
     int in_use;
 };
 
-static struct watchdog_item* watchdog_head = NULL;
-static struct watchdog_item* watchdog_tail = NULL;
+static struct watchdog_item *watchdog_head = NULL;
+static struct watchdog_item *watchdog_tail = NULL;
 
-extern "C" const char *cli_strerror(int errnum, char* buf, size_t len);
+extern "C" const char *cli_strerror(int errnum, char *buf, size_t len);
 #define WATCHDOG_IDLE 10
 static void *bytecode_watchdog(void *arg)
 {
@@ -2247,54 +2252,54 @@ static void *bytecode_watchdog(void *arg)
     char err[128];
     pthread_mutex_lock(&watchdog_mutex);
     if (cli_debug_flag)
-	cli_dbgmsg_internal("bytecode watchdog is running\n");
+        cli_dbgmsg_internal("bytecode watchdog is running\n");
     do {
-	struct watchdog_item *item;
-	gettimeofday(&tv, NULL);
-	out.tv_sec = tv.tv_sec + WATCHDOG_IDLE;
-	out.tv_nsec = tv.tv_usec*1000;
-	/* wait for some work, up to WATCHDOG_IDLE time */
-	while (watchdog_head == NULL) {
-	    ret = pthread_cond_timedwait(&watchdog_cond, &watchdog_mutex,
-					 &out);
-	    if (ret == ETIMEDOUT)
-		break;
-	    if (ret) {
-		cli_warnmsg("bytecode_watchdog: cond_timedwait(1) failed: %s\n",
-			    cli_strerror(ret, err, sizeof(err)));
-		break;
-	    }
-	}
-	if (watchdog_head == NULL)
-	    break;
-	/* wait till timeout is reached on this item */
-	item = watchdog_head;
-	while (item == watchdog_head) {
-	    item->in_use = 1;
-	    ret = pthread_cond_timedwait(&watchdog_cond, &watchdog_mutex,
-					 &item->abstimeout);
-	    if (ret == ETIMEDOUT)
-		break;
-	    if (ret) {
-		cli_warnmsg("bytecode_watchdog: cond_timedwait(2) failed: %s\n",
-			    cli_strerror(ret, err, sizeof(err)));
-		break;
-	    }
-	}
-	item->in_use = 0;
-	pthread_cond_signal(&watchdog_cond2);
-	if (item != watchdog_head)
-	    continue;/* got removed meanwhile */
-	/* timeout reached, signal it to bytecode */
-	*item->timeout = 1;
-	cli_warnmsg("[Bytecode JIT]: Bytecode run timed out, timeout flag set\n");
-	watchdog_head = item->next;
-	if (!watchdog_head)
-	    watchdog_tail = NULL;
+        struct watchdog_item *item;
+        gettimeofday(&tv, NULL);
+        out.tv_sec  = tv.tv_sec + WATCHDOG_IDLE;
+        out.tv_nsec = tv.tv_usec * 1000;
+        /* wait for some work, up to WATCHDOG_IDLE time */
+        while (watchdog_head == NULL) {
+            ret = pthread_cond_timedwait(&watchdog_cond, &watchdog_mutex,
+                                         &out);
+            if (ret == ETIMEDOUT)
+                break;
+            if (ret) {
+                cli_warnmsg("bytecode_watchdog: cond_timedwait(1) failed: %s\n",
+                            cli_strerror(ret, err, sizeof(err)));
+                break;
+            }
+        }
+        if (watchdog_head == NULL)
+            break;
+        /* wait till timeout is reached on this item */
+        item = watchdog_head;
+        while (item == watchdog_head) {
+            item->in_use = 1;
+            ret          = pthread_cond_timedwait(&watchdog_cond, &watchdog_mutex,
+                                         &item->abstimeout);
+            if (ret == ETIMEDOUT)
+                break;
+            if (ret) {
+                cli_warnmsg("bytecode_watchdog: cond_timedwait(2) failed: %s\n",
+                            cli_strerror(ret, err, sizeof(err)));
+                break;
+            }
+        }
+        item->in_use = 0;
+        pthread_cond_signal(&watchdog_cond2);
+        if (item != watchdog_head)
+            continue; /* got removed meanwhile */
+        /* timeout reached, signal it to bytecode */
+        *item->timeout = 1;
+        cli_warnmsg("[Bytecode JIT]: Bytecode run timed out, timeout flag set\n");
+        watchdog_head = item->next;
+        if (!watchdog_head)
+            watchdog_tail = NULL;
     } while (1);
     watchdog_running = 0;
     if (cli_debug_flag)
-	cli_dbgmsg_internal("bytecode watchdog quiting\n");
+        cli_dbgmsg_internal("bytecode watchdog quiting\n");
     pthread_mutex_unlock(&watchdog_mutex);
     return NULL;
 }
@@ -2303,22 +2308,23 @@ static void watchdog_disarm(struct watchdog_item *item)
 {
     struct watchdog_item *q, *p = NULL;
     if (!item)
-	return;
+        return;
     pthread_mutex_lock(&watchdog_mutex);
-    for (q=watchdog_head;q && q != item;p = q, q = q->next) {}
+    for (q = watchdog_head; q && q != item; p = q, q = q->next) {
+    }
     if (q == item) {
-	if (p)
-	    p->next = q->next;
-	if (q == watchdog_head)
-	    watchdog_head = q->next;
-	if (q == watchdog_tail)
-	    watchdog_tail = p;
+        if (p)
+            p->next = q->next;
+        if (q == watchdog_head)
+            watchdog_head = q->next;
+        if (q == watchdog_tail)
+            watchdog_tail = p;
     }
     /* don't remove the item from the list until the watchdog is sleeping on
      * item, or it'll wake up on uninit data */
     while (item->in_use) {
-	pthread_cond_signal(&watchdog_cond);
-	pthread_cond_wait(&watchdog_cond2, &watchdog_mutex);
+        pthread_cond_signal(&watchdog_cond);
+        pthread_cond_wait(&watchdog_cond2, &watchdog_mutex);
     }
     pthread_mutex_unlock(&watchdog_mutex);
 }
@@ -2328,37 +2334,37 @@ static int watchdog_arm(struct watchdog_item *item, int ms, volatile uint8_t *ti
     int rc = 0;
     struct timeval tv0;
 
-    *timeout = 0;
+    *timeout      = 0;
     item->timeout = timeout;
-    item->next = NULL;
-    item->in_use = 0;
+    item->next    = NULL;
+    item->in_use  = 0;
 
     gettimeofday(&tv0, NULL);
     tv0.tv_usec += ms * 1000;
-    item->abstimeout.tv_sec = tv0.tv_sec + tv0.tv_usec/1000000;
-    item->abstimeout.tv_nsec = (tv0.tv_usec%1000000)*1000;
+    item->abstimeout.tv_sec  = tv0.tv_sec + tv0.tv_usec / 1000000;
+    item->abstimeout.tv_nsec = (tv0.tv_usec % 1000000) * 1000;
 
     pthread_mutex_lock(&watchdog_mutex);
     if (!watchdog_running) {
-	pthread_t thread;
-	pthread_attr_t attr;
-	pthread_attr_init(&attr);
-	pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
+        pthread_t thread;
+        pthread_attr_t attr;
+        pthread_attr_init(&attr);
+        pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
 
-	if ((rc = pthread_create(&thread, &attr, bytecode_watchdog, NULL))) {
-	    char buf[256];
-	    cli_errmsg("(watchdog) pthread_create failed: %s\n", cli_strerror(rc, buf, sizeof(buf)));
-	}
-	if (!rc)
-	    watchdog_running = 1;
-	pthread_attr_destroy(&attr);
+        if ((rc = pthread_create(&thread, &attr, bytecode_watchdog, NULL))) {
+            char buf[256];
+            cli_errmsg("(watchdog) pthread_create failed: %s\n", cli_strerror(rc, buf, sizeof(buf)));
+        }
+        if (!rc)
+            watchdog_running = 1;
+        pthread_attr_destroy(&attr);
     }
     if (!rc) {
-	if (watchdog_tail)
-	    watchdog_tail->next = item;
-	watchdog_tail = item;
-	if (!watchdog_head)
-	    watchdog_head = item;
+        if (watchdog_tail)
+            watchdog_tail->next = item;
+        watchdog_tail = item;
+        if (!watchdog_head)
+            watchdog_head = item;
     }
     pthread_cond_signal(&watchdog_cond);
     pthread_mutex_unlock(&watchdog_mutex);
@@ -2369,11 +2375,12 @@ static int bytecode_execute(intptr_t code, struct cli_bc_ctx *ctx)
 {
     ScopedExceptionHandler handler;
     // execute;
-    HANDLER_TRY(handler) {
-	// setup exception handler to longjmp back here
-	uint32_t result = ((uint32_t (*)(struct cli_bc_ctx *))(intptr_t)code)(ctx);
-	*(uint32_t*)ctx->values = result;
-	return 0;
+    HANDLER_TRY(handler)
+    {
+        // setup exception handler to longjmp back here
+        uint32_t result          = ((uint32_t(*)(struct cli_bc_ctx *))(intptr_t)code)(ctx);
+        *(uint32_t *)ctx->values = result;
+        return 0;
     }
     HANDLER_END(handler);
     cli_warnmsg("[Bytecode JIT]: JITed code intercepted runtime error!\n");
@@ -2381,7 +2388,7 @@ static int bytecode_execute(intptr_t code, struct cli_bc_ctx *ctx)
 }
 
 int cli_vm_execute_jit(const struct cli_all_bc *bcs, struct cli_bc_ctx *ctx,
-		       const struct cli_bc_func *func)
+                       const struct cli_bc_func *func)
 {
     int ret;
     struct timeval tv0, tv1;
@@ -2390,56 +2397,56 @@ int cli_vm_execute_jit(const struct cli_all_bc *bcs, struct cli_bc_ctx *ctx,
     // if needed.
     void *code = bcs->engine->compiledFunctions[func];
     if (!code) {
-	cli_warnmsg("[Bytecode JIT]: Unable to find compiled function\n");
-	if (func->numArgs)
-	    cli_warnmsg("[Bytecode JIT] Function has %d arguments, it must have 0 to be called as entrypoint\n",
-			func->numArgs);
-	return CL_EBYTECODE;
+        cli_warnmsg("[Bytecode JIT]: Unable to find compiled function\n");
+        if (func->numArgs)
+            cli_warnmsg("[Bytecode JIT] Function has %d arguments, it must have 0 to be called as entrypoint\n",
+                        func->numArgs);
+        return CL_EBYTECODE;
     }
     if (cli_debug_flag)
-	gettimeofday(&tv0, NULL);
+        gettimeofday(&tv0, NULL);
 
     if (ctx->bytecode_timeout) {
-	/* only spawn if timeout is set.
+        /* only spawn if timeout is set.
 	 * we don't set timeout for selfcheck (see bb #2235) */
-	if (watchdog_arm(&witem, ctx->bytecode_timeout, &ctx->timeout))
-	    return CL_EBYTECODE;
+        if (watchdog_arm(&witem, ctx->bytecode_timeout, &ctx->timeout))
+            return CL_EBYTECODE;
     }
 
     ret = bytecode_execute((intptr_t)code, ctx);
 
     if (ctx->bytecode_timeout)
-	watchdog_disarm(&witem);
+        watchdog_disarm(&witem);
 
     if (cli_debug_flag) {
-	long diff;
-	gettimeofday(&tv1, NULL);
-	tv1.tv_sec -= tv0.tv_sec;
-	tv1.tv_usec -= tv0.tv_usec;
-	diff = tv1.tv_sec*1000000 + tv1.tv_usec;
-	cli_dbgmsg_internal("bytecode finished in %ld us\n", diff);
+        long diff;
+        gettimeofday(&tv1, NULL);
+        tv1.tv_sec -= tv0.tv_sec;
+        tv1.tv_usec -= tv0.tv_usec;
+        diff = tv1.tv_sec * 1000000 + tv1.tv_usec;
+        cli_dbgmsg_internal("bytecode finished in %ld us\n", diff);
     }
     return ctx->timeout ? CL_ETIMEOUT : ret;
 }
 
-static unsigned char name_salt[16] = { 16, 38, 97, 12, 8, 4, 72, 196, 217, 144, 33, 124, 18, 11, 17, 253 };
-static void setGuard(unsigned char* guardbuf)
+static unsigned char name_salt[16] = {16, 38, 97, 12, 8, 4, 72, 196, 217, 144, 33, 124, 18, 11, 17, 253};
+static void setGuard(unsigned char *guardbuf)
 {
     char salt[48];
     memcpy(salt, name_salt, 16);
-    for(unsigned i = 16; i < 48; i++)
-	salt[i] = cli_rndnum(255);
+    for (unsigned i = 16; i < 48; i++)
+        salt[i] = cli_rndnum(255);
 
-    cl_hash_data((char*)"md5", salt, 48, guardbuf, NULL);
+    cl_hash_data((char *)"md5", salt, 48, guardbuf, NULL);
 }
 #if LLVM_VERSION < 32
 static void addFPasses(FunctionPassManager &FPM, bool trusted, const TargetData *TD)
 #elif LLVM_VERSION < 35
 static void addFPasses(FunctionPassManager &FPM, bool trusted, const DataLayout *TD)
 #elif LLVM_VERSION < 36
-static void addFPasses(FunctionPassManager &FPM, bool trusted, const Module *M)
+        static void addFPasses(FunctionPassManager &FPM, bool trusted, const Module *M)
 #else
-static void addFPasses(FunctionPassManager &FPM, bool trusted, Module *M)
+        static void addFPasses(FunctionPassManager &FPM, bool trusted, Module *M)
 #endif
 {
     // Set up the optimizer pipeline.  Start with registering info about how
@@ -2449,11 +2456,11 @@ static void addFPasses(FunctionPassManager &FPM, bool trusted, Module *M)
 #elif LLVM_VERSION < 35
     FPM.add(new DataLayout(*TD));
 #elif LLVM_VERSION < 36
-    FPM.add(new DataLayoutPass(M));
+            FPM.add(new DataLayoutPass(M));
 #else
-    DataLayoutPass *DLP = new DataLayoutPass();
-    DLP->doInitialization(*M);
-    FPM.add(DLP);
+            DataLayoutPass *DLP = new DataLayoutPass();
+            DLP->doInitialization(*M);
+            FPM.add(DLP);
 #endif
     // Promote allocas to registers.
     FPM.add(createPromoteMemoryToRegisterPass());
@@ -2463,287 +2470,288 @@ static void addFPasses(FunctionPassManager &FPM, bool trusted, Module *M)
 
 int cli_bytecode_prepare_jit(struct cli_all_bc *bcs)
 {
-  if (!bcs->engine)
-      return CL_EBYTECODE;
-  ScopedExceptionHandler handler;
-  LLVMApiScopedLock scopedLock;
-  // setup exception handler to longjmp back here
-  HANDLER_TRY(handler) {
-  // LLVM itself never throws exceptions, but operator new may throw bad_alloc
-  try {
-    Module *M = new Module("ClamAV jit module", bcs->engine->Context);
+    if (!bcs->engine)
+        return CL_EBYTECODE;
+    ScopedExceptionHandler handler;
+    LLVMApiScopedLock scopedLock;
+    // setup exception handler to longjmp back here
+    HANDLER_TRY(handler)
     {
-	// Create the JIT.
-	std::string ErrorMsg;
+        // LLVM itself never throws exceptions, but operator new may throw bad_alloc
+        try {
+            Module *M = new Module("ClamAV jit module", bcs->engine->Context);
+            {
+                // Create the JIT.
+                std::string ErrorMsg;
 #if LLVM_VERSION < 36
-	EngineBuilder builder(M);
+                EngineBuilder builder(M);
 #else
-	EngineBuilder builder(std::move(std::unique_ptr<Module>(M)));
+                EngineBuilder builder(std::move(std::unique_ptr<Module>(M)));
 #endif
 
 #if LLVM_VERSION >= 31
-	TargetOptions Options;
+                TargetOptions Options;
 #ifdef CL_DEBUG
-	//disable this for now, it leaks
-	Options.JITEmitDebugInfo = false;
+                //disable this for now, it leaks
+                Options.JITEmitDebugInfo = false;
 //	Options.JITEmitDebugInfo = true;
 #else
-	Options.JITEmitDebugInfo = false;
+                Options.JITEmitDebugInfo = false;
 #endif
 #if LLVM_VERSION < 34
-	Options.DwarfExceptionHandling = false;
+                Options.DwarfExceptionHandling = false;
 #else
-	// TODO: How to do this now?
+                // TODO: How to do this now?
 #endif
-	builder.setTargetOptions(Options);
+                builder.setTargetOptions(Options);
 #endif
 
-	builder.setErrorStr(&ErrorMsg);
-	builder.setEngineKind(EngineKind::JIT);
-	builder.setOptLevel(CodeGenOpt::Default);
-	ExecutionEngine *EE = bcs->engine->EE = builder.create();
-	if (!EE) {
-	    if (!ErrorMsg.empty())
-		cli_errmsg("[Bytecode JIT]: error creating execution engine: %s\n",
-			   ErrorMsg.c_str());
-	    else
-		cli_errmsg("[Bytecode JIT]: JIT not registered?\n");
-	    return CL_EBYTECODE;
-	}
-	bcs->engine->Listener  = new NotifyListener();
-	EE->RegisterJITEventListener(bcs->engine->Listener);
-//	EE->RegisterJITEventListener(createOProfileJITEventListener());
-	// Due to LLVM PR4816 only X86 supports non-lazy compilation, disable
-	// for now.
-	EE->DisableLazyCompilation();
+                builder.setErrorStr(&ErrorMsg);
+                builder.setEngineKind(EngineKind::JIT);
+                builder.setOptLevel(CodeGenOpt::Default);
+                ExecutionEngine *EE = bcs->engine->EE = builder.create();
+                if (!EE) {
+                    if (!ErrorMsg.empty())
+                        cli_errmsg("[Bytecode JIT]: error creating execution engine: %s\n",
+                                   ErrorMsg.c_str());
+                    else
+                        cli_errmsg("[Bytecode JIT]: JIT not registered?\n");
+                    return CL_EBYTECODE;
+                }
+                bcs->engine->Listener = new NotifyListener();
+                EE->RegisterJITEventListener(bcs->engine->Listener);
+                //	EE->RegisterJITEventListener(createOProfileJITEventListener());
+                // Due to LLVM PR4816 only X86 supports non-lazy compilation, disable
+                // for now.
+                EE->DisableLazyCompilation();
 #if LLVM_VERSION < 36
-	EE->DisableSymbolSearching();
+                EE->DisableSymbolSearching();
 #else
-	// This must be enabled for AddSymbol to work.
-	EE->DisableSymbolSearching(false);
+                // This must be enabled for AddSymbol to work.
+                EE->DisableSymbolSearching(false);
 #endif
 
-	struct CommonFunctions CF;
-	addFunctionProtos(&CF, EE, M);
+                struct CommonFunctions CF;
+                addFunctionProtos(&CF, EE, M);
 
-	FunctionPassManager OurFPM(M), OurFPMUnsigned(M);
+                FunctionPassManager OurFPM(M), OurFPMUnsigned(M);
 #if LLVM_VERSION < 32
-	M->setDataLayout(EE->getTargetData()->getStringRepresentation());
+                M->setDataLayout(EE->getTargetData()->getStringRepresentation());
 #else
-	M->setDataLayout(EE->getDataLayout()->getStringRepresentation());
+                M->setDataLayout(EE->getDataLayout()->getStringRepresentation());
 #endif
 #if LLVM_VERSION < 31
-	M->setTargetTriple(sys::getHostTriple());
+                M->setTargetTriple(sys::getHostTriple());
 #else
-	M->setTargetTriple(sys::getDefaultTargetTriple());
+                M->setTargetTriple(sys::getDefaultTargetTriple());
 #endif
 #if LLVM_VERSION < 32
-	addFPasses(OurFPM, true, EE->getTargetData());
-	addFPasses(OurFPMUnsigned, false, EE->getTargetData());
+                addFPasses(OurFPM, true, EE->getTargetData());
+                addFPasses(OurFPMUnsigned, false, EE->getTargetData());
 #elif LLVM_VERSION < 35
-	addFPasses(OurFPM, true, EE->getDataLayout());
-	addFPasses(OurFPMUnsigned, false, EE->getDataLayout());
+                addFPasses(OurFPM, true, EE->getDataLayout());
+                addFPasses(OurFPMUnsigned, false, EE->getDataLayout());
 #else
-	addFPasses(OurFPM, true, M);
-	addFPasses(OurFPMUnsigned, false, M);
+                        addFPasses(OurFPM, true, M);
+                        addFPasses(OurFPMUnsigned, false, M);
 #endif
 
+                //TODO: create a wrapper that calls pthread_getspecific
+                unsigned maxh        = cli_globals[0].offset + sizeof(struct cli_bc_hooks);
+                constType *HiddenCtx = PointerType::getUnqual(ArrayType::get(Type::getInt8Ty(bcs->engine->Context), maxh));
 
-	//TODO: create a wrapper that calls pthread_getspecific
-	unsigned maxh = cli_globals[0].offset + sizeof(struct cli_bc_hooks);
-	constType *HiddenCtx = PointerType::getUnqual(ArrayType::get(Type::getInt8Ty(bcs->engine->Context), maxh));
-
-	LLVMTypeMapper apiMap(bcs->engine->Context, cli_apicall_types, cli_apicall_maxtypes, HiddenCtx);
-	Function **apiFuncs = new Function *[cli_apicall_maxapi];
-	for (unsigned i=0;i<cli_apicall_maxapi;i++) {
-	    const struct cli_apicall *api = &cli_apicalls[i];
-	    constFunctionType *FTy = cast<FunctionType>(apiMap.get(69+api->type, NULL, NULL));
-	    Function *F = Function::Create(FTy, Function::ExternalLinkage,
-					   api->name, M);
-	    void *dest;
-	    switch (api->kind) {
-		case 0:
-		    dest = (void*)(intptr_t)cli_apicalls0[api->idx];
-		    break;
-		case 1:
-		    dest = (void*)(intptr_t)cli_apicalls1[api->idx];
-		    break;
-		case 2:
-		    dest = (void*)(intptr_t)cli_apicalls2[api->idx];
-		    break;
-		case 3:
-		    dest = (void*)(intptr_t)cli_apicalls3[api->idx];
-		    break;
-		case 4:
-		    dest = (void*)(intptr_t)cli_apicalls4[api->idx];
-		    break;
-		case 5:
-		    dest = (void*)(intptr_t)cli_apicalls5[api->idx];
-		    break;
-		case 6:
-		    dest = (void*)(intptr_t)cli_apicalls6[api->idx];
-		    break;
-		case 7:
-		    dest = (void*)(intptr_t)cli_apicalls7[api->idx];
-		    break;
-		case 8:
-		    dest = (void*)(intptr_t)cli_apicalls8[api->idx];
-		    break;
-		case 9:
-		    dest = (void*)(intptr_t)cli_apicalls9[api->idx];
-		    break;
-		default:
-		    llvm_unreachable("invalid api type");
-	    }
-	    if (!dest) {
-		std::string reason((Twine("No mapping for builtin api ")+api->name).str());
-		llvm_error_handler(0, reason);
-	    }
+                LLVMTypeMapper apiMap(bcs->engine->Context, cli_apicall_types, cli_apicall_maxtypes, HiddenCtx);
+                Function **apiFuncs = new Function *[cli_apicall_maxapi];
+                for (unsigned i = 0; i < cli_apicall_maxapi; i++) {
+                    const struct cli_apicall *api = &cli_apicalls[i];
+                    constFunctionType *FTy        = cast<FunctionType>(apiMap.get(69 + api->type, NULL, NULL));
+                    Function *F                   = Function::Create(FTy, Function::ExternalLinkage,
+                                                   api->name, M);
+                    void *dest;
+                    switch (api->kind) {
+                        case 0:
+                            dest = (void *)(intptr_t)cli_apicalls0[api->idx];
+                            break;
+                        case 1:
+                            dest = (void *)(intptr_t)cli_apicalls1[api->idx];
+                            break;
+                        case 2:
+                            dest = (void *)(intptr_t)cli_apicalls2[api->idx];
+                            break;
+                        case 3:
+                            dest = (void *)(intptr_t)cli_apicalls3[api->idx];
+                            break;
+                        case 4:
+                            dest = (void *)(intptr_t)cli_apicalls4[api->idx];
+                            break;
+                        case 5:
+                            dest = (void *)(intptr_t)cli_apicalls5[api->idx];
+                            break;
+                        case 6:
+                            dest = (void *)(intptr_t)cli_apicalls6[api->idx];
+                            break;
+                        case 7:
+                            dest = (void *)(intptr_t)cli_apicalls7[api->idx];
+                            break;
+                        case 8:
+                            dest = (void *)(intptr_t)cli_apicalls8[api->idx];
+                            break;
+                        case 9:
+                            dest = (void *)(intptr_t)cli_apicalls9[api->idx];
+                            break;
+                        default:
+                            llvm_unreachable("invalid api type");
+                    }
+                    if (!dest) {
+                        std::string reason((Twine("No mapping for builtin api ") + api->name).str());
+                        llvm_error_handler(0, reason);
+                    }
 #if LLVM_VERSION < 36
-	    EE->addGlobalMapping(F, dest);
+                    EE->addGlobalMapping(F, dest);
 #else
-    // addGlobalMapping doesn't work with MCJIT, so use symbol searching instead.
-    sys::DynamicLibrary::AddSymbol(F->getName(), dest);
+                    // addGlobalMapping doesn't work with MCJIT, so use symbol searching instead.
+                    sys::DynamicLibrary::AddSymbol(F->getName(), dest);
 #endif
-	    EE->getPointerToFunction(F);
-	    apiFuncs[i] = F;
-	}
+                    EE->getPointerToFunction(F);
+                    apiFuncs[i] = F;
+                }
 
-	// stack protector
-	FunctionType *FTy = FunctionType::get(Type::getVoidTy(M->getContext()),
-						    false);
-	GlobalVariable *Guard = new GlobalVariable(*M, PointerType::getUnqual(Type::getInt8Ty(M->getContext())),
-						    true, GlobalValue::ExternalLinkage, 0, "__stack_chk_guard");
-	unsigned plus = 0;
-	if (2*sizeof(void*) <= 16 && cli_rndnum(2)==2) {
-	    plus = sizeof(void*);
-	}
+                // stack protector
+                FunctionType *FTy     = FunctionType::get(Type::getVoidTy(M->getContext()),
+                                                      false);
+                GlobalVariable *Guard = new GlobalVariable(*M, PointerType::getUnqual(Type::getInt8Ty(M->getContext())),
+                                                           true, GlobalValue::ExternalLinkage, 0, "__stack_chk_guard");
+                unsigned plus         = 0;
+                if (2 * sizeof(void *) <= 16 && cli_rndnum(2) == 2) {
+                    plus = sizeof(void *);
+                }
 #if LLVM_VERSION < 36
-	EE->addGlobalMapping(Guard, (void*)(&bcs->engine->guard.b[plus]));
+                EE->addGlobalMapping(Guard, (void *)(&bcs->engine->guard.b[plus]));
 #else
-    sys::DynamicLibrary::AddSymbol(Guard->getName(), (void*)(&bcs->engine->guard.b[plus]));
+                sys::DynamicLibrary::AddSymbol(Guard->getName(), (void *)(&bcs->engine->guard.b[plus]));
 #endif
-	setGuard(bcs->engine->guard.b);
-	bcs->engine->guard.b[plus+sizeof(void*)-1] = 0x00;
-//	printf("%p\n", *(void**)(&bcs->engine->guard.b[plus]));
-	Function *SFail = Function::Create(FTy, Function::ExternalLinkage,
-					      "__stack_chk_fail", M);
+                setGuard(bcs->engine->guard.b);
+                bcs->engine->guard.b[plus + sizeof(void *) - 1] = 0x00;
+                //	printf("%p\n", *(void**)(&bcs->engine->guard.b[plus]));
+                Function *SFail = Function::Create(FTy, Function::ExternalLinkage,
+                                                   "__stack_chk_fail", M);
 #if LLVM_VERSION < 36
-	EE->addGlobalMapping(SFail, (void*)(intptr_t)jit_ssp_handler);
+                EE->addGlobalMapping(SFail, (void *)(intptr_t)jit_ssp_handler);
 #else
-    sys::DynamicLibrary::AddSymbol(SFail->getName(), (void*)(intptr_t)jit_ssp_handler);
+                sys::DynamicLibrary::AddSymbol(SFail->getName(), (void *)(intptr_t)jit_ssp_handler);
 #endif
-        EE->getPointerToFunction(SFail);
+                EE->getPointerToFunction(SFail);
 
-	llvm::Function **Functions = new Function*[bcs->count];
-	for (unsigned i=0;i<bcs->count;i++) {
-	    const struct cli_bc *bc = &bcs->all_bcs[i];
-	    if (bc->state == bc_skip || bc->state == bc_interp) {
-		Functions[i] = 0;
-		continue;
-	    }
-	    LLVMCodegen Codegen(bc, M, &CF, bcs->engine->compiledFunctions, EE,
-				OurFPM, OurFPMUnsigned, apiFuncs, apiMap);
-	    Function *F = Codegen.generate();
-	    if (!F) {
-		cli_errmsg("[Bytecode JIT]: JIT codegen failed\n");
-		delete [] apiFuncs;
-		for (unsigned z=0; z < i; z++) {
-		    delete Functions[z];
-		}
-		delete [] Functions;
-		return CL_EBYTECODE;
-	    }
-	    Functions[i] = F;
-	}
-	delete [] apiFuncs;
+                llvm::Function **Functions = new Function *[bcs->count];
+                for (unsigned i = 0; i < bcs->count; i++) {
+                    const struct cli_bc *bc = &bcs->all_bcs[i];
+                    if (bc->state == bc_skip || bc->state == bc_interp) {
+                        Functions[i] = 0;
+                        continue;
+                    }
+                    LLVMCodegen Codegen(bc, M, &CF, bcs->engine->compiledFunctions, EE,
+                                        OurFPM, OurFPMUnsigned, apiFuncs, apiMap);
+                    Function *F = Codegen.generate();
+                    if (!F) {
+                        cli_errmsg("[Bytecode JIT]: JIT codegen failed\n");
+                        delete[] apiFuncs;
+                        for (unsigned z = 0; z < i; z++) {
+                            delete Functions[z];
+                        }
+                        delete[] Functions;
+                        return CL_EBYTECODE;
+                    }
+                    Functions[i] = F;
+                }
+                delete[] apiFuncs;
 
-	bool has_untrusted = false;
+                bool has_untrusted = false;
 
-	for (unsigned i=0;i<bcs->count;i++) {
-	    if (!bcs->all_bcs[i].trusted) {
-		has_untrusted = true;
-		break;
-	    }
-	}
-	PassManager PM;
+                for (unsigned i = 0; i < bcs->count; i++) {
+                    if (!bcs->all_bcs[i].trusted) {
+                        has_untrusted = true;
+                        break;
+                    }
+                }
+                PassManager PM;
 #if LLVM_VERSION < 32
-	PM.add(new TargetData(*EE->getTargetData()));
+                PM.add(new TargetData(*EE->getTargetData()));
 #elif LLVM_VERSION < 35
-	PM.add(new DataLayout(*EE->getDataLayout()));
+                PM.add(new DataLayout(*EE->getDataLayout()));
 #elif LLVM_VERSION < 36
-	PM.add(new DataLayoutPass(M));
+                        PM.add(new DataLayoutPass(M));
 #else
-    DataLayoutPass *DLP = new DataLayoutPass();
-    DLP->doInitialization(*M);
-    PM.add(DLP);
+                        DataLayoutPass *DLP = new DataLayoutPass();
+                        DLP->doInitialization(*M);
+                        PM.add(DLP);
 #endif
-	// TODO: only run this on the untrusted bytecodes, not all of them...
-	if (has_untrusted)
-	    PM.add(createClamBCRTChecks());
+                // TODO: only run this on the untrusted bytecodes, not all of them...
+                if (has_untrusted)
+                    PM.add(createClamBCRTChecks());
 #if LLVM_VERSION >= 36
-	// With LLVM 3.6 (MCJIT) this Pass is required to work around
-	// a crash in LLVM caused by the SCCP Pass:
-	// Pass 'Sparse Conditional Constant Propagation' is not initialized.
-	// Verify if there is a pass dependency cycle.
-	// Required Passes:
-	//
-	// Program received signal SIGSEGV, Segmentation fault.
-	PM.add(createGVNPass());
+                // With LLVM 3.6 (MCJIT) this Pass is required to work around
+                // a crash in LLVM caused by the SCCP Pass:
+                // Pass 'Sparse Conditional Constant Propagation' is not initialized.
+                // Verify if there is a pass dependency cycle.
+                // Required Passes:
+                //
+                // Program received signal SIGSEGV, Segmentation fault.
+                PM.add(createGVNPass());
 #endif
-	PM.add(createSCCPPass());
-	PM.add(createCFGSimplificationPass());
-	PM.add(createGlobalOptimizerPass());
-	PM.add(createConstantMergePass());
+                PM.add(createSCCPPass());
+                PM.add(createCFGSimplificationPass());
+                PM.add(createGlobalOptimizerPass());
+                PM.add(createConstantMergePass());
 
-	RuntimeLimits *RL = new RuntimeLimits();
-	PM.add(RL);
-	TimerWrapper pmTimer2("Transform passes");
-	pmTimer2.startTimer();
-	PM.run(*M);
-	pmTimer2.stopTimer();
-	DEBUG(M->dump());
+                RuntimeLimits *RL = new RuntimeLimits();
+                PM.add(RL);
+                TimerWrapper pmTimer2("Transform passes");
+                pmTimer2.startTimer();
+                PM.run(*M);
+                pmTimer2.stopTimer();
+                DEBUG(M->dump());
 
 #if LLVM_VERSION >= 36
-	EE->finalizeObject();
+                EE->finalizeObject();
 #endif
 
-	{
-	    PrettyStackTraceString CrashInfo2("Native machine codegen");
-	    TimerWrapper codegenTimer("Native codegen");
-	    codegenTimer.startTimer();
-	    // compile all functions now, not lazily!
-	    for (Module::iterator I = M->begin(), E = M->end(); I != E; ++I) {
-		Function *Fn = &*I;
-		if (!Fn->isDeclaration()) {
-		    EE->getPointerToFunction(Fn);
-		}
-	    }
-	    codegenTimer.stopTimer();
-	}
+                {
+                    PrettyStackTraceString CrashInfo2("Native machine codegen");
+                    TimerWrapper codegenTimer("Native codegen");
+                    codegenTimer.startTimer();
+                    // compile all functions now, not lazily!
+                    for (Module::iterator I = M->begin(), E = M->end(); I != E; ++I) {
+                        Function *Fn = &*I;
+                        if (!Fn->isDeclaration()) {
+                            EE->getPointerToFunction(Fn);
+                        }
+                    }
+                    codegenTimer.stopTimer();
+                }
 
-	for (unsigned i=0;i<bcs->count;i++) {
-	    const struct cli_bc_func *func = &bcs->all_bcs[i].funcs[0];
-	    if (!Functions[i])
-		continue;// not JITed
-	    bcs->engine->compiledFunctions[func] = EE->getPointerToFunction(Functions[i]);
-	    bcs->all_bcs[i].state = bc_jit;
-	}
-	delete [] Functions;
+                for (unsigned i = 0; i < bcs->count; i++) {
+                    const struct cli_bc_func *func = &bcs->all_bcs[i].funcs[0];
+                    if (!Functions[i])
+                        continue; // not JITed
+                    bcs->engine->compiledFunctions[func] = EE->getPointerToFunction(Functions[i]);
+                    bcs->all_bcs[i].state                = bc_jit;
+                }
+                delete[] Functions;
+            }
+            return CL_SUCCESS;
+        } catch (std::bad_alloc &badalloc) {
+            cli_errmsg("[Bytecode JIT]: bad_alloc: %s\n",
+                       badalloc.what());
+            return CL_EMEM;
+        } catch (...) {
+            cli_errmsg("[Bytecode JIT]: Unexpected unknown exception occurred\n");
+            return CL_EBYTECODE;
+        }
+        return 0;
     }
-    return CL_SUCCESS;
-  } catch (std::bad_alloc &badalloc) {
-      cli_errmsg("[Bytecode JIT]: bad_alloc: %s\n",
-		 badalloc.what());
-      return CL_EMEM;
-  } catch (...) {
-      cli_errmsg("[Bytecode JIT]: Unexpected unknown exception occurred\n");
-      return CL_EBYTECODE;
-  }
-  return 0;
-  } HANDLER_END(handler);
-  cli_errmsg("[Bytecode JIT] *** FATAL error encountered during bytecode generation\n");
-  return CL_EBYTECODE;
+    HANDLER_END(handler);
+    cli_errmsg("[Bytecode JIT] *** FATAL error encountered during bytecode generation\n");
+    return CL_EBYTECODE;
 }
 
 int bytecode_init(void)
@@ -2751,8 +2759,8 @@ int bytecode_init(void)
     // If already initialized return
 #if LLVM_VERSION < 35
     if (llvm_is_multithreaded()) {
-	cli_warnmsg("bytecode_init: already initialized\n");
-	return CL_EARG;
+        cli_warnmsg("bytecode_init: already initialized\n");
+        return CL_EARG;
     }
 #else
     if (!LLVMIsMultithreaded()) {
@@ -2809,9 +2817,9 @@ int bytecode_init(void)
 #else
     if (!LLVMIsMultithreaded()) {
 #endif
-	//TODO:cli_dbgmsg
-	DEBUG(errs() << "WARNING: ClamAV JIT built w/o atomic builtins\n"
-	      << "On x86 for best performance ClamAV should be built for i686, not i386!\n");
+        //TODO:cli_dbgmsg
+        DEBUG(errs() << "WARNING: ClamAV JIT built w/o atomic builtins\n"
+                     << "On x86 for best performance ClamAV should be built for i686, not i386!\n");
     }
     return 0;
 }
@@ -2820,10 +2828,10 @@ int bytecode_init(void)
 int cli_bytecode_init_jit(struct cli_all_bc *bcs, unsigned dconfmask)
 {
     LLVMApiScopedLock scopedLock;
-    bcs->engine = new(std::nothrow) cli_bcengine;
+    bcs->engine = new (std::nothrow) cli_bcengine;
     if (!bcs->engine)
-	return CL_EMEM;
-    bcs->engine->EE = 0;
+        return CL_EMEM;
+    bcs->engine->EE       = 0;
     bcs->engine->Listener = 0;
     return 0;
 }
@@ -2832,118 +2840,117 @@ int cli_bytecode_done_jit(struct cli_all_bc *bcs, int partial)
 {
     LLVMApiScopedLock scopedLock;
     if (bcs->engine) {
-	if (bcs->engine->EE) {
-	    if (bcs->engine->Listener)
-		bcs->engine->EE->UnregisterJITEventListener(bcs->engine->Listener);
-	    delete bcs->engine->EE;
-	    bcs->engine->EE = 0;
-	}
-	delete bcs->engine->Listener;
-	bcs->engine->Listener = 0;
-	if (!partial) {
-	    delete bcs->engine;
-	    bcs->engine = 0;
-	}
+        if (bcs->engine->EE) {
+            if (bcs->engine->Listener)
+                bcs->engine->EE->UnregisterJITEventListener(bcs->engine->Listener);
+            delete bcs->engine->EE;
+            bcs->engine->EE = 0;
+        }
+        delete bcs->engine->Listener;
+        bcs->engine->Listener = 0;
+        if (!partial) {
+            delete bcs->engine;
+            bcs->engine = 0;
+        }
     }
     return 0;
 }
 
 void cli_bytecode_debug(int argc, char **argv)
 {
-  cl::ParseCommandLineOptions(argc, argv);
+    cl::ParseCommandLineOptions(argc, argv);
 }
 
 typedef struct lines {
     MemoryBuffer *buffer;
-    std::vector<const char*> linev;
+    std::vector<const char *> linev;
 } linesTy;
 
 static struct lineprinter {
-    StringMap<linesTy*> files;
+    StringMap<linesTy *> files;
 } LinePrinter;
 
 void cli_bytecode_debug_printsrc(const struct cli_bc_ctx *ctx)
 {
     if (!ctx->file || !ctx->directory || !ctx->line) {
-	errs() << (ctx->directory ? "d":"null") << ":" << (ctx->file ? "f" : "null")<< ":" << ctx->line << "\n";
-	return;
+        errs() << (ctx->directory ? "d" : "null") << ":" << (ctx->file ? "f" : "null") << ":" << ctx->line << "\n";
+        return;
     }
     // acquire a mutex here
     sys::Mutex mtx(false);
     sys::SmartScopedLock<false> lock(mtx);
 
-    std::string path = std::string(ctx->directory) + "/" + std::string(ctx->file);
-    StringMap<linesTy*>::iterator I = LinePrinter.files.find(path);
+    std::string path                 = std::string(ctx->directory) + "/" + std::string(ctx->file);
+    StringMap<linesTy *>::iterator I = LinePrinter.files.find(path);
     linesTy *lines;
     if (I == LinePrinter.files.end()) {
-	lines = new linesTy;
-	std::string ErrorMessage;
+        lines = new linesTy;
+        std::string ErrorMessage;
 #if LLVM_VERSION < 29
-	lines->buffer = MemoryBuffer::getFile(path, &ErrorMessage);
+        lines->buffer = MemoryBuffer::getFile(path, &ErrorMessage);
 #elif LLVM_VERSION < 35
-	OwningPtr<MemoryBuffer> File;
-	error_code ec = MemoryBuffer::getFile(path, File);
-	if (ec) {
-	    ErrorMessage = ec.message();
-	    lines->buffer = 0;
-	} else
-	    lines->buffer = File.take();
+        OwningPtr<MemoryBuffer> File;
+        error_code ec = MemoryBuffer::getFile(path, File);
+        if (ec) {
+            ErrorMessage  = ec.message();
+            lines->buffer = 0;
+        } else
+            lines->buffer = File.take();
 #else
-	ErrorOr<std::unique_ptr<MemoryBuffer>> FileOrErr = MemoryBuffer::getFile(path);
-	if (!FileOrErr) {
-		// TODO: How to handle ErrorMessage?
-		lines->buffer = 0;
-	}
-	else {
-		lines->buffer = FileOrErr.get().release();
-	}
+                ErrorOr<std::unique_ptr<MemoryBuffer>> FileOrErr = MemoryBuffer::getFile(path);
+                if (!FileOrErr) {
+                    // TODO: How to handle ErrorMessage?
+                    lines->buffer = 0;
+                } else {
+                    lines->buffer = FileOrErr.get().release();
+                }
 #endif
-	if (!lines->buffer) {
-	    errs() << "Unable to open file '" << path << "'\n";
-	    delete lines;
-	    return ;
-	}
-	LinePrinter.files[path] = lines;
+        if (!lines->buffer) {
+            errs() << "Unable to open file '" << path << "'\n";
+            delete lines;
+            return;
+        }
+        LinePrinter.files[path] = lines;
     } else {
-	lines = I->getValue();
+        lines = I->getValue();
     }
-    while (lines->linev.size() <= ctx->line+1) {
-	const char *p;
-	if (lines->linev.empty()) {
-	    p = lines->buffer->getBufferStart();
-	    lines->linev.push_back(p);
-	} else {
-	    p = lines->linev.back();
-	    if (p == lines->buffer->getBufferEnd())
-		break;
-	    p = strchr(p, '\n');
-	    if (!p) {
-		p = lines->buffer->getBufferEnd();
-		lines->linev.push_back(p);
-	    } else
-		lines->linev.push_back(p+1);
-	}
+    while (lines->linev.size() <= ctx->line + 1) {
+        const char *p;
+        if (lines->linev.empty()) {
+            p = lines->buffer->getBufferStart();
+            lines->linev.push_back(p);
+        } else {
+            p = lines->linev.back();
+            if (p == lines->buffer->getBufferEnd())
+                break;
+            p = strchr(p, '\n');
+            if (!p) {
+                p = lines->buffer->getBufferEnd();
+                lines->linev.push_back(p);
+            } else
+                lines->linev.push_back(p + 1);
+        }
     }
     if (ctx->line >= lines->linev.size()) {
-	errs() << "Line number " << ctx->line << "out of file\n";
-	return;
+        errs() << "Line number " << ctx->line << "out of file\n";
+        return;
     }
     assert(ctx->line < lines->linev.size());
 
 #if LLVM_VERSION < 28
     int line = (int)ctx->line ? (int)ctx->line : -1;
-    int col = (int)ctx->col ? (int)ctx->col : -1;
+    int col  = (int)ctx->col ? (int)ctx->col : -1;
     //TODO: print this ourselves, instead of using SMDiagnostic
     SMDiagnostic diag(ctx->file, line, col,
-		 "", std::string(lines->linev[ctx->line-1], lines->linev[ctx->line]-1));
+                      "", std::string(lines->linev[ctx->line - 1], lines->linev[ctx->line] - 1));
     diag.Print("[trace]", errs());
 #endif
 }
 
-int have_clamjit=1;
+int have_clamjit = 1;
 void cli_bytecode_printversion()
 {
-  cl::PrintVersionMessage();
+    cl::PrintVersionMessage();
 }
 
 void cli_printcxxver()
@@ -2951,7 +2958,7 @@ void cli_printcxxver()
     /* Try to print information about some commonly used compilers */
 #ifdef __GNUC__
     printf("GNU C++: %s (%u.%u.%u)\n", __VERSION__, __GNUC__, __GNUC_MINOR__,
-	   __GNUC_PATCHLEVEL__);
+           __GNUC_PATCHLEVEL__);
 #endif
 #ifdef __INTEL_COMPILER
     printf("Intel Compiler C++ %u\n", __INTEL_COMPILER);
@@ -2961,210 +2968,219 @@ void cli_printcxxver()
 #endif
 }
 
-namespace ClamBCModule {
-void stop(const char *msg, llvm::Function* F, llvm::Instruction* I)
+namespace ClamBCModule
+{
+void stop(const char *msg, llvm::Function *F, llvm::Instruction *I)
 {
     if (F && F->hasName()) {
 #if LLVM_VERSION < 31
-	cli_warnmsg("[Bytecode JIT] in function %s: %s", F->getNameStr().c_str(), msg);
+        cli_warnmsg("[Bytecode JIT] in function %s: %s", F->getNameStr().c_str(), msg);
 #else
-	cli_warnmsg("[Bytecode JIT] in function %s: %s", F->getName().str().c_str(), msg);
+        cli_warnmsg("[Bytecode JIT] in function %s: %s", F->getName().str().c_str(), msg);
 #endif
     } else {
-	cli_warnmsg("[Bytecode JIT] %s", msg);
+        cli_warnmsg("[Bytecode JIT] %s", msg);
     }
 }
-}
+} // namespace ClamBCModule
 
 #if LLVM_VERSION >= 29
 #if LLVM_VERSION < 36
-static Value *findDbgGlobalDeclare(GlobalVariable *V) {
+static Value *findDbgGlobalDeclare(GlobalVariable *V)
+{
 #else
-static Metadata *findDbgGlobalDeclare(GlobalVariable *V) {
+static Metadata *findDbgGlobalDeclare(GlobalVariable *V)
+{
 #endif
-  const Module *M = V->getParent();
-  NamedMDNode *NMD = M->getNamedMetadata("llvm.dbg.gv");
-  if (!NMD)
-    return 0;
+    const Module *M  = V->getParent();
+    NamedMDNode *NMD = M->getNamedMetadata("llvm.dbg.gv");
+    if (!NMD)
+        return 0;
 
-  for (unsigned i = 0, e = NMD->getNumOperands(); i != e; ++i) {
-    DIDescriptor DIG(cast<MDNode>(NMD->getOperand(i)));
-    if (!DIG.isGlobalVariable())
-      continue;
-    if (DIGlobalVariable(DIG).getGlobal() == V)
-      return DIG;
-  }
-  return 0;
+    for (unsigned i = 0, e = NMD->getNumOperands(); i != e; ++i) {
+        DIDescriptor DIG(cast<MDNode>(NMD->getOperand(i)));
+        if (!DIG.isGlobalVariable())
+            continue;
+        if (DIGlobalVariable(DIG).getGlobal() == V)
+            return DIG;
+    }
+    return 0;
 }
 
 /// Find the debug info descriptor corresponding to this function.
 #if LLVM_VERSION < 36
-static Value *findDbgSubprogramDeclare(Function *V) {
+static Value *findDbgSubprogramDeclare(Function *V)
+{
 #else
-static Metadata *findDbgSubprogramDeclare(Function *V) {
+static Metadata *findDbgSubprogramDeclare(Function *V)
+{
 #endif
-  const Module *M = V->getParent();
-  NamedMDNode *NMD = M->getNamedMetadata("llvm.dbg.sp");
-  if (!NMD)
-    return 0;
+    const Module *M  = V->getParent();
+    NamedMDNode *NMD = M->getNamedMetadata("llvm.dbg.sp");
+    if (!NMD)
+        return 0;
 
-  for (unsigned i = 0, e = NMD->getNumOperands(); i != e; ++i) {
-    DIDescriptor DIG(cast<MDNode>(NMD->getOperand(i)));
-    if (!DIG.isSubprogram())
-      continue;
-    if (DISubprogram(DIG).getFunction() == V)
-      return DIG;
-  }
-  return 0;
+    for (unsigned i = 0, e = NMD->getNumOperands(); i != e; ++i) {
+        DIDescriptor DIG(cast<MDNode>(NMD->getOperand(i)));
+        if (!DIG.isSubprogram())
+            continue;
+        if (DISubprogram(DIG).getFunction() == V)
+            return DIG;
+    }
+    return 0;
 }
 
 /// Finds the llvm.dbg.declare intrinsic corresponding to this value if any.
 /// It looks through pointer casts too.
-static const DbgDeclareInst *findDbgDeclare(const Value *V) {
-  V = V->stripPointerCasts();
+static const DbgDeclareInst *findDbgDeclare(const Value *V)
+{
+    V = V->stripPointerCasts();
 
-  if (!isa<Instruction>(V) && !isa<Argument>(V))
+    if (!isa<Instruction>(V) && !isa<Argument>(V))
+        return 0;
+
+    const Function *F = NULL;
+    if (const Instruction *I = dyn_cast<Instruction>(V))
+        F = I->getParent()->getParent();
+    else if (const Argument *A = dyn_cast<Argument>(V))
+        F = A->getParent();
+
+    for (Function::const_iterator FI = F->begin(), FE = F->end(); FI != FE; ++FI)
+        for (BasicBlock::const_iterator BI = (*FI).begin(), BE = (*FI).end();
+             BI != BE; ++BI)
+            if (const DbgDeclareInst *DDI = dyn_cast<DbgDeclareInst>(BI))
+                if (DDI->getAddress() == V)
+                    return DDI;
+
     return 0;
-
-  const Function *F = NULL;
-  if (const Instruction *I = dyn_cast<Instruction>(V))
-    F = I->getParent()->getParent();
-  else if (const Argument *A = dyn_cast<Argument>(V))
-    F = A->getParent();
-
-  for (Function::const_iterator FI = F->begin(), FE = F->end(); FI != FE; ++FI)
-    for (BasicBlock::const_iterator BI = (*FI).begin(), BE = (*FI).end();
-         BI != BE; ++BI)
-      if (const DbgDeclareInst *DDI = dyn_cast<DbgDeclareInst>(BI))
-        if (DDI->getAddress() == V)
-          return DDI;
-
-  return 0;
 }
 static bool getLocationInfo(const Value *V, std::string &DisplayName,
                             std::string &Type, unsigned &LineNo,
-                            std::string &File, std::string &Dir) {
+                            std::string &File, std::string &Dir)
+{
 #if LLVM_VERSION < 33
-  DICompileUnit Unit;
+    DICompileUnit Unit;
 #else
-  StringRef G;
-  StringRef H;
+    StringRef G;
+    StringRef H;
 #endif
 #if LLVM_VERSION < 35
-  DIType TypeD;
+    DIType TypeD;
 #endif
-  StringRef T;
+    StringRef T;
 
-  if (GlobalVariable *GV = dyn_cast<GlobalVariable>(const_cast<Value*>(V))) {
+    if (GlobalVariable *GV = dyn_cast<GlobalVariable>(const_cast<Value *>(V))) {
 #if LLVM_VERSION < 36
-    Value *DIGV = findDbgGlobalDeclare(GV);
+        Value *DIGV = findDbgGlobalDeclare(GV);
 #else
-    Metadata *DIGV = findDbgGlobalDeclare(GV);
+        Metadata *DIGV = findDbgGlobalDeclare(GV);
 #endif
-    if (!DIGV) return false;
-    DIGlobalVariable Var(cast<MDNode>(DIGV));
+        if (!DIGV) return false;
+        DIGlobalVariable Var(cast<MDNode>(DIGV));
 
-    StringRef D = Var.getDisplayName();
-    if (!D.empty())
-      DisplayName = D;
-    LineNo = Var.getLineNumber();
+        StringRef D = Var.getDisplayName();
+        if (!D.empty())
+            DisplayName = D;
+        LineNo = Var.getLineNumber();
 #if LLVM_VERSION < 33
-    Unit = Var.getCompileUnit();
+        Unit = Var.getCompileUnit();
 #else
-    G = Var.getFilename();
-    H = Var.getDirectory();
+        G              = Var.getFilename();
+        H              = Var.getDirectory();
 #endif
 #if LLVM_VERSION < 35
-    TypeD = Var.getType();
+        TypeD = Var.getType();
 #else
-    T = Var.getType().getName();
+        T              = Var.getType().getName();
 #endif
-  } else if (Function *F = dyn_cast<Function>(const_cast<Value*>(V))){
+    } else if (Function *F = dyn_cast<Function>(const_cast<Value *>(V))) {
 #if LLVM_VERSION < 36
-    Value *DIF = findDbgSubprogramDeclare(F);
+        Value *DIF = findDbgSubprogramDeclare(F);
 #else
-    Metadata *DIF = findDbgSubprogramDeclare(F);
+        Metadata *DIF  = findDbgSubprogramDeclare(F);
 #endif
-    if (!DIF) return false;
-    DISubprogram Var(cast<MDNode>(DIF));
+        if (!DIF) return false;
+        DISubprogram Var(cast<MDNode>(DIF));
 
-    StringRef D = Var.getDisplayName();
-    if (!D.empty())
-      DisplayName = D;
-    LineNo = Var.getLineNumber();
+        StringRef D = Var.getDisplayName();
+        if (!D.empty())
+            DisplayName = D;
+        LineNo = Var.getLineNumber();
 #if LLVM_VERSION < 33
-    Unit = Var.getCompileUnit();
+        Unit = Var.getCompileUnit();
 #else
-    G = Var.getFilename();
-    H = Var.getDirectory();
+        G              = Var.getFilename();
+        H              = Var.getDirectory();
 #endif
 #if LLVM_VERSION < 35
-    TypeD = Var.getType();
+        TypeD = Var.getType();
 #else
-    T = Var.getType().getName();
+        T              = Var.getType().getName();
 #endif
-  } else {
-    const DbgDeclareInst *DDI = findDbgDeclare(V);
-    if (!DDI) return false;
-    DIVariable Var(cast<MDNode>(DDI->getVariable()));
+    } else {
+        const DbgDeclareInst *DDI = findDbgDeclare(V);
+        if (!DDI) return false;
+        DIVariable Var(cast<MDNode>(DDI->getVariable()));
 
-    StringRef D = Var.getName();
-    if (!D.empty())
-      DisplayName = D;
-    LineNo = Var.getLineNumber();
+        StringRef D = Var.getName();
+        if (!D.empty())
+            DisplayName = D;
+        LineNo = Var.getLineNumber();
 #if LLVM_VERSION < 33
-    Unit = Var.getCompileUnit();
+        Unit = Var.getCompileUnit();
 #else
-    // getFilename and getDirectory are not defined
-    G = StringRef();
-    H = StringRef();
+        // getFilename and getDirectory are not defined
+        G = StringRef();
+        H = StringRef();
 #endif
 #if LLVM_VERSION < 35
-    TypeD = Var.getType();
+        TypeD = Var.getType();
 #else
-    T = Var.getType().getName();
+        T = Var.getType().getName();
 #endif
-  }
+    }
 
 #if LLVM_VERSION < 35
-  T = TypeD.getName();
+    T = TypeD.getName();
 #endif
-  if (!T.empty())
-    Type = T;
+    if (!T.empty())
+        Type = T;
 #if LLVM_VERSION < 33
-  StringRef G = Unit.getFilename();
-  StringRef H = Unit.getDirectory();
+    StringRef G = Unit.getFilename();
+    StringRef H = Unit.getDirectory();
 #endif
-  if (!G.empty())
-    File = G;
-  if (!H.empty())
-    Dir = H;
-  return true;
+    if (!G.empty())
+        File = G;
+    if (!H.empty())
+        Dir = H;
+    return true;
 }
 #endif
 
-void printValue(llvm::Value *V, bool a, bool b) {
+void printValue(llvm::Value *V, bool a, bool b)
+{
     std::string DisplayName;
     std::string Type;
     unsigned Line;
     std::string File;
     std::string Dir;
     if (!getLocationInfo(V, DisplayName, Type, Line, File, Dir)) {
-	errs() << *V << "\n";
-	return;
+        errs() << *V << "\n";
+        return;
     }
     errs() << "'" << DisplayName << "' (" << File << ":" << Line << ")";
 }
 
-void printLocation(llvm::Instruction *I, bool a, bool b) {
+void printLocation(llvm::Instruction *I, bool a, bool b)
+{
     if (MDNode *N = I->getMetadata("dbg")) {
-	DILocation Loc(N);
-	errs() << Loc.getFilename() << ":" << Loc.getLineNumber();
-	if (unsigned Col = Loc.getColumnNumber()) {
-  	    errs() << ":" << Col;
-  	}
-  	errs() << ": ";
-  	return;
+        DILocation Loc(N);
+        errs() << Loc.getFilename() << ":" << Loc.getLineNumber();
+        if (unsigned Col = Loc.getColumnNumber()) {
+            errs() << ":" << Col;
+        }
+        errs() << ": ";
+        return;
     }
     errs() << *I << ":\n";
 }

--- a/libclamav/c++/detect.cpp
+++ b/libclamav/c++/detect.cpp
@@ -43,16 +43,16 @@ using namespace llvm;
 static void warn_assumptions(const char *msg, int a, int b)
 {
     errs() << "LibClamAV Warning: libclamav and llvm make inconsistent "
-	<< "assumptions about " << msg << ": " <<
-	a << " and " << b << "."
-	<< "Please report to https://bugzilla.clamav.net\n";
+           << "assumptions about " << msg << ": " << a << " and " << b << "."
+           << "Please report to https://bugzilla.clamav.net\n";
 }
 
-#define CASE_OS(theos, compat) case Triple::theos:\
-    env->os = llvm_os_##theos;\
-    if (env->os_category != compat)\
-        warn_assumptions("Operating System", env->os_category, Triple::theos);\
-    break
+#define CASE_OS(theos, compat)                                                     \
+    case Triple::theos:                                                            \
+        env->os = llvm_os_##theos;                                                 \
+        if (env->os_category != compat)                                            \
+            warn_assumptions("Operating System", env->os_category, Triple::theos); \
+        break
 
 void cli_detect_env_jit(struct cli_environment *env)
 {
@@ -68,21 +68,21 @@ void cli_detect_env_jit(struct cli_environment *env)
 
 #if LLVM_VERSION < 33
     if (env->big_endian != (int)sys::isBigEndianHost()) {
-	warn_assumptions("host endianness", env->big_endian, sys::isBigEndianHost());
-	env->big_endian = sys::isBigEndianHost();
+        warn_assumptions("host endianness", env->big_endian, sys::isBigEndianHost());
+        env->big_endian = sys::isBigEndianHost();
     }
 #else
     if (env->big_endian != (int)sys::IsBigEndianHost) {
-	warn_assumptions("host endianness", env->big_endian, sys::IsBigEndianHost);
-	env->big_endian = sys::IsBigEndianHost;
+        warn_assumptions("host endianness", env->big_endian, sys::IsBigEndianHost);
+        env->big_endian = sys::IsBigEndianHost;
     }
 #endif
 
 #ifdef __GNUC__
     env->cpp_version = MAKE_VERSION(0, __GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__);
-#elif defined (__INTEL_COMPILER)
+#elif defined(__INTEL_COMPILER)
     env->cpp_version = __INTEL_COMPILER;
-#elif defined (_MSC_VER)
+#elif defined(_MSC_VER)
     env->cpp_version = _MSC_VER;
 #endif
 
@@ -93,96 +93,96 @@ void cli_detect_env_jit(struct cli_environment *env)
     enum arch_list earch;
     bool conflicts = false;
     switch (arch) {
-	case Triple::arm:
-	    earch = arch_arm;
-	    if (env->arch != earch) conflicts = true;
-	    break;
-	case Triple::ppc:
-	    earch = arch_ppc32;
-	    if (env->arch != earch &&
-		env->arch != arch_ppc64) conflicts = true;
-	    break;
-	case Triple::ppc64:
-	    earch = arch_ppc64;
-	    // ppc64 is fixed up by llvm
-	    if (env->arch != arch_ppc32 &&
-		env->arch != arch_ppc64) conflicts = true;
-	    break;
-	case Triple::x86:
-	    earch = arch_i386;
-	    if (env->arch != earch) {
-		/* bb #2153 */
-		if (env->arch != arch_x86_64)
-		    conflicts = true;
-	    }
-	    break;
-	case Triple::x86_64:
-	    earch = arch_x86_64;
-	    if (env->arch != earch) {
-		/* bb #2153, bb #2214 */
-		/* configure can't detect -m32, so it thinks we are x86_64, when
+        case Triple::arm:
+            earch = arch_arm;
+            if (env->arch != earch) conflicts = true;
+            break;
+        case Triple::ppc:
+            earch = arch_ppc32;
+            if (env->arch != earch &&
+                env->arch != arch_ppc64) conflicts = true;
+            break;
+        case Triple::ppc64:
+            earch = arch_ppc64;
+            // ppc64 is fixed up by llvm
+            if (env->arch != arch_ppc32 &&
+                env->arch != arch_ppc64) conflicts = true;
+            break;
+        case Triple::x86:
+            earch = arch_i386;
+            if (env->arch != earch) {
+                /* bb #2153 */
+                if (env->arch != arch_x86_64)
+                    conflicts = true;
+            }
+            break;
+        case Triple::x86_64:
+            earch = arch_x86_64;
+            if (env->arch != earch) {
+                /* bb #2153, bb #2214 */
+                /* configure can't detect -m32, so it thinks we are x86_64, when
 		 * in fact we are i386 only.
 		 * LLVM correctly detects which one it is using preprocessor
 		 * macros, so don't warn here, startup.cbc will just have to
 		 * rely on the LLVM provided info, and not the configure
 		 * provided one! */
-		if (env->arch != arch_i386)
-		    conflicts = true;
-	    }
-	    break;
-	default:
-	    earch = arch_unknown;
-	    break;
+                if (env->arch != arch_i386)
+                    conflicts = true;
+            }
+            break;
+        default:
+            earch = arch_unknown;
+            break;
     }
 #ifndef AC_APPLE_UNIVERSAL_BUILD
     if (conflicts)
-	warn_assumptions("CPU architecture", env->arch, earch);
+        warn_assumptions("CPU architecture", env->arch, earch);
 #endif
     if (earch != arch_unknown)
-	env->arch = earch;
+        env->arch = earch;
 
     // OS
     Triple::OSType os = triple.getOS();
     switch (os) {
-	case Triple::UnknownOS:
-	    env->os = llvm_os_UnknownOS;
-	    break;
+        case Triple::UnknownOS:
+            env->os = llvm_os_UnknownOS;
+            break;
 #if LLVM_VERSION < 36
-	CASE_OS(AuroraUX, os_solaris);
-	CASE_OS(Cygwin, os_win32);
-	CASE_OS(MinGW32, os_win32);
+            CASE_OS(AuroraUX, os_solaris);
+            CASE_OS(Cygwin, os_win32);
+            CASE_OS(MinGW32, os_win32);
 #endif
-	CASE_OS(Darwin, os_darwin);
-	CASE_OS(DragonFly, os_bsd);
-	CASE_OS(FreeBSD, os_bsd);
-	CASE_OS(Linux, os_linux);
-	CASE_OS(Lv2, os_unknown);
+            CASE_OS(Darwin, os_darwin);
+            CASE_OS(DragonFly, os_bsd);
+            CASE_OS(FreeBSD, os_bsd);
+            CASE_OS(Linux, os_linux);
+            CASE_OS(Lv2, os_unknown);
 #if LLVM_VERSION < 29
-	CASE_OS(MinGW64, os_win64);
+            CASE_OS(MinGW64, os_win64);
 #endif
-	CASE_OS(NetBSD,  os_bsd);
-	CASE_OS(OpenBSD, os_bsd);
+            CASE_OS(NetBSD, os_bsd);
+            CASE_OS(OpenBSD, os_bsd);
 #if LLVM_VERSION < 31
-	CASE_OS(Psp, os_unknown);
+            CASE_OS(Psp, os_unknown);
 #endif
-	CASE_OS(Solaris, os_solaris);
-	case Triple::Win32:
-	     env->os = llvm_os_Win32;
-	     if (env->os_category != os_win32 &&
-		 env->os_category != os_win64)
-		 warn_assumptions("Operating System", env->os_category, Triple::Win32);
-	     break;
-	CASE_OS(Haiku, os_unknown);
-	CASE_OS(Minix, os_unknown);
+            CASE_OS(Solaris, os_solaris);
+        case Triple::Win32:
+            env->os = llvm_os_Win32;
+            if (env->os_category != os_win32 &&
+                env->os_category != os_win64)
+                warn_assumptions("Operating System", env->os_category, Triple::Win32);
+            break;
+            CASE_OS(Haiku, os_unknown);
+            CASE_OS(Minix, os_unknown);
     }
 
     // mmap RWX
     std::string ErrMsg;
     sys::MemoryBlock B = sys::Memory::AllocateRWX(4096, NULL, &ErrMsg);
     if (B.base() == 0) {
-	errs() << "LibClamAV Warning: RWX mapping denied: " << ErrMsg << "\n";
+        errs() << "LibClamAV Warning: RWX mapping denied: " << ErrMsg << "\n";
     } else {
-	env->os_features |= 1 << feature_map_rwx;
-	sys::Memory::ReleaseRWX(B);
+        env->os_features |= 1 << feature_map_rwx;
+        sys::Memory::ReleaseRWX(B);
     }
 }

--- a/libclamav/c++/llvm30_compat.h
+++ b/libclamav/c++/llvm30_compat.h
@@ -4,10 +4,10 @@
 #define constStructType const StructType
 #define constPointerType const PointerType
 #define constFunctionType const FunctionType
-#define ARRAYREF(t,a,b) (a),(b)
-#define ARRAYREFPARAM(t,a,b,n) a, b
-#define ARRAYREFP(a,b,n) a, b
-#define ARRAYREFVECTOR(t,a) (a).begin(),(a).end()
+#define ARRAYREF(t, a, b) (a), (b)
+#define ARRAYREFPARAM(t, a, b, n) a, b
+#define ARRAYREFP(a, b, n) a, b
+#define ARRAYREFVECTOR(t, a) (a).begin(), (a).end()
 #define HINT(n)
 #define OPT(n)
 #else
@@ -16,10 +16,10 @@
 #define constStructType StructType
 #define constPointerType PointerType
 #define constFunctionType FunctionType
-#define ARRAYREF(t,a,b) ArrayRef<t>(a,b)
-#define ARRAYREFPARAM(t,a,b,n) ArrayRef<t> n
-#define ARRAYREFP(a,b,n) n
-#define ARRAYREFVECTOR(t,a) ArrayRef<t>(a)
+#define ARRAYREF(t, a, b) ArrayRef<t>(a, b)
+#define ARRAYREFPARAM(t, a, b, n) ArrayRef<t> n
+#define ARRAYREFP(a, b, n) n
+#define ARRAYREFVECTOR(t, a) ArrayRef<t>(a)
 #define HINT(n) n,
-#define OPT(n) ,n
+#define OPT(n) , n
 #endif

--- a/libclamav/petite.c
+++ b/libclamav/petite.c
@@ -262,8 +262,9 @@ int petite_inflate2x_1to9(char *buf, uint32_t minrva, uint32_t bufsz, struct cli
                 return 1;
             }
             bottom += 4;
-            ssrc   = adjbuf + cli_readint32(packed + 4) - (size - 1) * 4;
-            ddst   = adjbuf + cli_readint32(packed + 8) - (size - 1) * 4;
+
+            ssrc = adjbuf + cli_readint32(packed + 4) - (size - 1) * 4;
+            ddst = adjbuf + cli_readint32(packed + 8) - (size - 1) * 4;
 
             if (!CLI_ISCONTAINED(buf, bufsz, ssrc, size * 4) || !CLI_ISCONTAINED(buf, bufsz, ddst, size * 4)) {
                 if (usects)


### PR DESCRIPTION
Previously we'd not clang-formatted the c++ bytecode files because:
A) It's a massive difference in format
B) I wasn't sure, at the time, which code was "ours"

Reformatting now that the LLVM source is all removed and before it gets
updated to support modern LLVM versions.