### PR TITLE
Tests: fix flakey ClamD test on Windows

### DIFF
--- a/unit_tests/check_clamd.c
+++ b/unit_tests/check_clamd.c
@@ -144,13 +144,9 @@ static void conn_teardown(void)
 #define CLEANREPLY CLEANFILE ": OK"
 #define UNKNOWN_REPLY "UNKNOWN COMMAND"
 
-#define NONEXISTENT PATHSEP "nonexistent\vfilename"
+#define NONEXISTENT PATHSEP "nonexistentfilename"
 
-#ifdef _WIN32
-#define NONEXISTENT_REPLY NONEXISTENT ": File path check failure: Invalid argument. ERROR"
-#else
 #define NONEXISTENT_REPLY NONEXISTENT ": File path check failure: No such file or directory. ERROR"
-#endif
 
 #ifndef _WIN32
 #define ACCDENIED OBJDIR PATHSEP "accdenied"


### PR DESCRIPTION
The non-existent file test has a hack to "expect" a wierd error message
caused by the '\v' character rather than the file not actually existing.
Recently something(?) changed and the test started reporting yet a
different message or no message.

Removing the '\v' special character fixes the test so it actually tests
a non-existent file and returns the same message as on other operating
systems.