### PR TITLE
nfc, clamonacc printing missing -c in help statement

### DIFF
--- a/clamonacc/clamonacc.c
+++ b/clamonacc/clamonacc.c
@@ -439,7 +439,7 @@ void help(void)
     mprintf("    --remove                           Remove infected files. Be careful!\n");
     mprintf("    --move=DIRECTORY                   Move infected files into DIRECTORY\n");
     mprintf("    --copy=DIRECTORY                   Copy infected files into DIRECTORY\n");
-    mprintf("    --config-file=FILE                 Read configuration from FILE.\n");
+    mprintf("    --config-file=FILE     -c FILE     Read configuration from FILE\n");
     mprintf("    --allmatch             -z          Continue scanning within file after finding a match.\n");
     mprintf("    --fdpass                           Pass filedescriptor to clamd (useful if clamd is running as a different user)\n");
     mprintf("    --stream                           Force streaming files to clamd (for debugging and unit testing)\n");


### PR DESCRIPTION
evidence for parameter working
```
[hp@t480s build]$ clamonacc/clamonacc -c /etc/clamd.d/clamd.conf --help

           ClamAV: On Access Scanning Application and Client 0.104.0-devel-20210706
           By The ClamAV Team: https://www.clamav.net/about.html#credits
           (C) 2021 Cisco Systems, Inc.

    clamonacc [options] [file/directory/-]

    --help                 -h          Show this help
    --version              -V          Print version number and exit
    --verbose              -v          Be verbose
    --log=FILE             -l FILE     Save scanning output to FILE
    --foreground           -F          Output to foreground and do not daemonize
    --watch-list=FILE      -W FILE     Watch directories from FILE
    --exclude-list=FILE    -e FILE     Exclude directories from FILE
    --ping                 -p A[:I]    Ping clamd up to [A] times at optional interval [I] until it responds.
    --wait                 -w          Wait up to 30 seconds for clamd to start. Optionally use alongside --ping to set attempts [A] and interval [I] to check clamd.
    --remove                           Remove infected files. Be careful!
    --move=DIRECTORY                   Move infected files into DIRECTORY
    --copy=DIRECTORY                   Copy infected files into DIRECTORY
    --config-file=FILE     -c FILE     Read configuration from FILE
    --allmatch             -z          Continue scanning within file after finding a match.
    --fdpass                           Pass filedescriptor to clamd (useful if clamd is running as a different user)
    --stream                           Force streaming files to clamd (for debugging and unit testing)
```