### PR TITLE
libclamav, clamscan: load/unload callbacks & progress meters

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -87,6 +87,23 @@ patch versions do not generally introduce new options:
   BMP and JPEG 2000 files will continue to detect as CL_TYPE_GRAPHICS because
   ClamAV does not yet have BMP or JPEG 2000 format checking capabilities.
 
+- Add progress callbacks to libclamav for:
+  - database load:  `cl_engine_set_clcb_sigload_progress()`
+  - engine compile: `cl_engine_set_clcb_engine_compile_progress()`
+  - engine free:    `cl_engine_set_clcb_engine_free_progress()`
+
+  These new callbacks enable an application to monitor and estiamte load,
+  compile, and unload progress. See `clamav.h` for API details.
+
+- Added progress bars to ClamScan for the signature load and engine compile
+  steps before a scan begins.
+  The start-up progress bars won't be enabled if ClamScan isn't running in a
+  terminal (i.e. stdout is not a TTY), or if any of these options are used:
+    - `--debug`
+    - `--quiet`
+    - `--infected`
+    - `--no-summary`
+
 ### Other improvements
 
 - Added the `%f` format string option to the ClamD VirusEvent feature to insert

--- a/clamscan/manager.c
+++ b/clamscan/manager.c
@@ -660,7 +660,7 @@ static void print_time(time_t seconds)
     }
 }
 
-static void print_no_sigs(size_t sigs, int bPad)
+static void print_num_sigs(size_t sigs, int bPad)
 {
     if (sigs >= (1000 * 1000)) {
         const char *format = bPad ? "%7.02fM" : "%.02fM";
@@ -690,17 +690,17 @@ static void sigload_callback(size_t total_items, size_t now_completed, void *con
 
     struct sigload_progress *sigloadProgress = (struct sigload_progress *)context;
 
-    uint32_t i                = 0;
-    uint32_t totalNumDots     = 25;
-    uint32_t numDots          = 0;
-    double fractiondownloaded = 0.0;
+    uint32_t i             = 0;
+    uint32_t totalNumDots  = 25;
+    uint32_t numDots       = 0;
+    double fraction_loaded = 0.0;
 
     if ((total_items <= 0) || (sigloadProgress->bComplete)) {
         return;
     }
 
-    fractiondownloaded = (double)now_completed / (double)total_items;
-    numDots            = round(fractiondownloaded * totalNumDots);
+    fraction_loaded = (double)now_completed / (double)total_items;
+    numDots         = round(fraction_loaded * totalNumDots);
 
     if (0 == sigloadProgress->startTime) {
         sigloadProgress->startTime = time(0);
@@ -712,12 +712,12 @@ static void sigload_callback(size_t total_items, size_t now_completed, void *con
 #ifndef _WIN32
     fprintf(stdout, "\e[?7l");
 #endif
-    if (fractiondownloaded <= 0.0) {
+    if (fraction_loaded <= 0.0) {
         fprintf(stdout, "Loading:   ");
         print_time(curtime);
         fprintf(stdout, "               ");
     } else {
-        remtime = (curtime / fractiondownloaded) - curtime;
+        remtime = (curtime / fraction_loaded) - curtime;
         fprintf(stdout, "Loading:   ");
         print_time(curtime);
         fprintf(stdout, ", ETA: ");
@@ -741,9 +741,9 @@ static void sigload_callback(size_t total_items, size_t now_completed, void *con
 
     fprintf(stdout, "] ");
 
-    print_no_sigs(now_completed, 1);
+    print_num_sigs(now_completed, 1);
     fprintf(stdout, "/");
-    print_no_sigs(total_items, 0);
+    print_num_sigs(total_items, 0);
     fprintf(stdout, " sigs    ");
 
     if (now_completed < total_items) {
@@ -774,17 +774,17 @@ static void engine_compile_callback(size_t total_items, size_t now_completed, vo
 
     struct engine_compile_progress *engineCompileProgress = (struct engine_compile_progress *)context;
 
-    uint32_t i                  = 0;
-    uint32_t totalNumDots       = 25;
-    uint32_t numDots            = 0;
-    double fractiondowncompiled = 0.0;
+    uint32_t i               = 0;
+    uint32_t totalNumDots    = 25;
+    uint32_t numDots         = 0;
+    double fraction_compiled = 0.0;
 
     if ((total_items <= 0) || (engineCompileProgress->bComplete)) {
         return;
     }
 
-    fractiondowncompiled = (double)now_completed / (double)total_items;
-    numDots              = round(fractiondowncompiled * totalNumDots);
+    fraction_compiled = (double)now_completed / (double)total_items;
+    numDots           = round(fraction_compiled * totalNumDots);
 
     if (0 == engineCompileProgress->startTime) {
         engineCompileProgress->startTime = time(0);
@@ -796,12 +796,12 @@ static void engine_compile_callback(size_t total_items, size_t now_completed, vo
 #ifndef _WIN32
     fprintf(stdout, "\e[?7l");
 #endif
-    if (fractiondowncompiled <= 0.0) {
+    if (fraction_compiled <= 0.0) {
         fprintf(stdout, "Compiling: ");
         print_time(curtime);
         fprintf(stdout, "               ");
     } else {
-        remtime = (curtime / fractiondowncompiled) - curtime;
+        remtime = (curtime / fraction_compiled) - curtime;
         fprintf(stdout, "Compiling: ");
         print_time(curtime);
         fprintf(stdout, ", ETA: ");
@@ -825,9 +825,9 @@ static void engine_compile_callback(size_t total_items, size_t now_completed, vo
 
     fprintf(stdout, "] ");
 
-    print_no_sigs(now_completed, 1);
+    print_num_sigs(now_completed, 1);
     fprintf(stdout, "/");
-    print_no_sigs(total_items, 0);
+    print_num_sigs(total_items, 0);
     fprintf(stdout, " tasks ");
 
     if (now_completed < total_items) {
@@ -858,17 +858,17 @@ static void engine_free_callback(size_t total_items, size_t now_completed, void 
 
     struct engine_free_progress *engineFreeProgress = (struct engine_free_progress *)context;
 
-    uint32_t i                = 0;
-    uint32_t totalNumDots     = 10;
-    uint32_t numDots          = 0;
-    double fractiondownloaded = 0.0;
+    uint32_t i            = 0;
+    uint32_t totalNumDots = 10;
+    uint32_t numDots      = 0;
+    double fraction_freed = 0.0;
 
     if ((total_items <= 0) || (engineFreeProgress->bComplete)) {
         return;
     }
 
-    fractiondownloaded = (double)now_completed / (double)total_items;
-    numDots            = round(fractiondownloaded * totalNumDots);
+    fraction_freed = (double)now_completed / (double)total_items;
+    numDots        = round(fraction_freed * totalNumDots);
 
     if (0 == engineFreeProgress->startTime) {
         engineFreeProgress->startTime = time(0);
@@ -896,9 +896,9 @@ static void engine_free_callback(size_t total_items, size_t now_completed, void 
 
     fprintf(stdout, " ");
 
-    print_no_sigs(now_completed, 1);
+    print_num_sigs(now_completed, 1);
     fprintf(stdout, "/");
-    print_no_sigs(total_items, 0);
+    print_num_sigs(total_items, 0);
     fprintf(stdout, " tasks ");
 
     if (now_completed < total_items) {

--- a/clamscan/manager.c
+++ b/clamscan/manager.c
@@ -683,7 +683,7 @@ static void print_num_sigs(size_t sigs, int bPad)
  * @param now_completed Number of items completed
  * @param context       Opaque application provided data; This maps to sigload_progress
  */
-static void sigload_callback(size_t total_items, size_t now_completed, void *context)
+static cl_error_t sigload_callback(size_t total_items, size_t now_completed, void *context)
 {
     time_t curtime = 0;
     time_t remtime = 0;
@@ -757,7 +757,7 @@ static void sigload_callback(size_t total_items, size_t now_completed, void *con
 #endif
     fflush(stdout);
 
-    return;
+    return CL_SUCCESS;
 }
 
 /**
@@ -767,7 +767,7 @@ static void sigload_callback(size_t total_items, size_t now_completed, void *con
  * @param now_completed Number of items completed
  * @param context       Opaque application provided data; This maps to engine_compile_progress
  */
-static void engine_compile_callback(size_t total_items, size_t now_completed, void *context)
+static cl_error_t engine_compile_callback(size_t total_items, size_t now_completed, void *context)
 {
     time_t curtime = 0;
     time_t remtime = 0;
@@ -841,7 +841,7 @@ static void engine_compile_callback(size_t total_items, size_t now_completed, vo
 #endif
     fflush(stdout);
 
-    return;
+    return CL_SUCCESS;
 }
 
 #ifdef ENABLE_ENGINE_FREE_PROGRESSBAR
@@ -852,7 +852,7 @@ static void engine_compile_callback(size_t total_items, size_t now_completed, vo
  * @param now_completed Number of items completed
  * @param context       Opaque application provided data; This maps to engine_free_progress
  */
-static void engine_free_callback(size_t total_items, size_t now_completed, void *context)
+static cl_error_t engine_free_callback(size_t total_items, size_t now_completed, void *context)
 {
     time_t curtime = 0;
 
@@ -912,7 +912,7 @@ static void engine_free_callback(size_t total_items, size_t now_completed, void 
 #endif
     fflush(stdout);
 
-    return;
+    return CL_SUCCESS;
 }
 #endif
 

--- a/freshclam/freshclam.c
+++ b/freshclam/freshclam.c
@@ -422,7 +422,7 @@ done:
  * @param server            Server string
  * @param defaultProtocol   Default protocol if not already specified. Eg: "https"
  * @param defaultPort       Default port if not already specified. Eg: 443
- * @param serverUrl         [out] A malloced string in the protocol://server:port format.
+ * @param[out] serverUrl    A malloced string in the protocol://server:port format.
  * @return fc_error_t       FC_SUCCESS if success.
  * @return fc_error_t       FC_EARG if invalid args.
  * @return fc_error_t       FC_EMEM if malloc failed.
@@ -555,10 +555,10 @@ static void free_string_list(char **stringList, uint32_t nListItems)
 /**
  * @brief Get the database server list object
  *
- * @param opts          FreshClam options struct.
- * @param serverList    [out] List of servers.
- * @param nServers      [out] Number of servers in list.
- * @param bPrivate      [out] Non-zero if PrivateMirror servers were selected.
+ * @param opts              FreshClam options struct.
+ * @param[out]  serverList  List of servers.
+ * @param[out]  nServers    Number of servers in list.
+ * @param[out]  bPrivate    Non-zero if PrivateMirror servers were selected.
  * @return fc_error_t
  */
 static fc_error_t get_database_server_list(
@@ -656,12 +656,12 @@ done:
 /**
  * @brief Get a list of strings for a given repeatable opt argument.
  *
- * @param opt           optstruct of repeatable argument to collect in a list.
- * @param stringList    [out] String list.
- * @param nListItems    [out] Number of strings in list.
- * @return fc_error_t   FC_SUCCESS if success.
- * @return fc_error_t   FC_EARG if invalid args passed to function.
- * @return fc_error_t   FC_EMEM if failed to allocate memory.
+ * @param opt               optstruct of repeatable argument to collect in a list.
+ * @param[out] stringList   String list.
+ * @param[out] nListItems   Number of strings in list.
+ * @return fc_error_t       FC_SUCCESS if success.
+ * @return fc_error_t       FC_EARG if invalid args passed to function.
+ * @return fc_error_t       FC_EMEM if failed to allocate memory.
  */
 static fc_error_t get_string_list(const struct optstruct *opt, char ***stringList, uint32_t *nListItems)
 {
@@ -981,11 +981,11 @@ done:
  *
  * TODO: Implement system to query list of available standard and optional databases.
  *
- * @param standardDatabases  [out] Standard database string list.
- * @param nStandardDatabases [out] Number of standard databases in list.
- * @param optionalDatabases  [out] Optional database string list.
- * @param nOptionalDatabases [out] Number of optional databases in list.
- * @return fc_error_t        FC_SUCCESS if all databases upddated successfully.
+ * @param[out] standardDatabases    Standard database string list.
+ * @param[out] nStandardDatabases   Number of standard databases in list.
+ * @param[out] optionalDatabases    Optional database string list.
+ * @param[out] nOptionalDatabases   Number of optional databases in list.
+ * @return fc_error_t               FC_SUCCESS if all databases upddated successfully.
  */
 fc_error_t get_official_database_lists(
     char ***standardDatabases,
@@ -1061,8 +1061,8 @@ done:
  * @param nOptIns               Number of opt-in database strings in list.
  * @param optOutList            List of standard databases that are not desired.
  * @param nOptOuts              Number of opt-out database strings in list.
- * @param databaseList          [out] String list of desired databases.
- * @param nDatabases            [out] Number of desired databases in list.
+ * @param[out] databaseList     String list of desired databases.
+ * @param[out] nDatabases       Number of desired databases in list.
  * @return fc_error_t
  */
 fc_error_t select_from_official_databases(
@@ -1196,9 +1196,9 @@ done:
  *
  * @param specificDatabaseList  List of desired databases.
  * @param nSpecificDatabases    Number of databases in list.
- * @param databaseList          [out] String list of desired databases.
- * @param nDatabases            [out] Number of desired databases in list.
- * @param bCustom               [out] "custom" selected.
+ * @param[out] databaseList     String list of desired databases.
+ * @param[out] nDatabases       Number of desired databases in list.
+ * @param[out] bCustom          "custom" selected.
  * @return fc_error_t
  */
 fc_error_t select_specific_databases(

--- a/libclamav/clamav.h
+++ b/libclamav/clamav.h
@@ -604,9 +604,7 @@ enum cl_msg {
 /**
  * @brief Progress callback for sig-load, engine-compile, and engine-free.
  *
- * Disclaimer: total_items may increase with each call as new items to be
- * processed are found. As such, total_items == now_completed does not mean it
- * guaranteed to be complete.
+ * Progress is complete when total_items == now_completed.
  *
  * @param total_items   Total number of items
  * @param now_completed Number of items completed
@@ -1001,10 +999,10 @@ extern cl_error_t cl_scanfile_callback(const char *filename, const char **virnam
 /**
  * @brief Load the signature databases found at the path.
  *
- * @param path      May be a file or directory.
- * @param engine    The engine to load the signatures into
- * @param signo     [out] The number of signatures loaded
- * @param dboptions Database load bitflag field. See the CL_DB_* defines, above.
+ * @param path          May be a file or directory.
+ * @param engine        The engine to load the signatures into
+ * @param[out] signo    The number of signatures loaded
+ * @param dboptions     Database load bitflag field. See the CL_DB_* defines, above.
  * @return cl_error_t
  */
 extern cl_error_t cl_load(const char *path, struct cl_engine *engine, unsigned int *signo, unsigned int dboptions);

--- a/libclamav/clamav.h
+++ b/libclamav/clamav.h
@@ -606,11 +606,16 @@ enum cl_msg {
  *
  * Progress is complete when total_items == now_completed.
  *
+ * Note: The callback should return CL_SUCCESS. We reserve the right to have it
+ *       cancel the operation in the future if you return something else...
+ *       ... but for now, the return value will be ignored.
+ *
  * @param total_items   Total number of items
  * @param now_completed Number of items completed
  * @param context       Opaque application provided data
+ * @return cl_error_t   reserved for future use
  */
-typedef void (*clcb_progress)(size_t total_items, size_t now_completed, void *context);
+typedef cl_error_t (*clcb_progress)(size_t total_items, size_t now_completed, void *context);
 
 /**
  * @brief Set a progress callback function to be called incrementally during a

--- a/libclamav/clamav.h
+++ b/libclamav/clamav.h
@@ -602,6 +602,63 @@ enum cl_msg {
 };
 
 /**
+ * @brief Progress callback for sig-load, engine-compile, and engine-free.
+ *
+ * Disclaimer: total_items may increase with each call as new items to be
+ * processed are found. As such, total_items == now_completed does not mean it
+ * guaranteed to be complete.
+ *
+ * @param total_items   Total number of items
+ * @param now_completed Number of items completed
+ * @param context       Opaque application provided data
+ */
+typedef void (*clcb_progress)(size_t total_items, size_t now_completed, void *context);
+
+/**
+ * @brief Set a progress callback function to be called incrementally during a
+ * database load.
+ *
+ * Caution: changing options for an engine that is in-use is not thread-safe!
+ *
+ * @param engine    The initialized scanning engine
+ * @param callback  The callback function pointer
+ * @param context   Opaque application provided data
+ */
+extern void cl_engine_set_clcb_sigload_progress(struct cl_engine *engine, clcb_progress callback, void *context);
+
+/**
+ * @brief Set a progress callback function to be called incrementally during an
+ * engine compile.
+ *
+ * Disclaimer: the number of items for this is a rough estimate of the items that
+ * tend to take longest to compile and doesn't represent an accurate number of
+ * things compiled.
+ *
+ * Caution: changing options for an engine that is in-use is not thread-safe!
+ *
+ * @param engine    The initialized scanning engine
+ * @param callback  The callback function pointer
+ * @param context   Opaque application provided data
+ */
+extern void cl_engine_set_clcb_engine_compile_progress(struct cl_engine *engine, clcb_progress callback, void *context);
+
+/**
+ * @brief Set a progress callback function to be called incrementally during an
+ * engine free (if the engine is in fact freed).
+ *
+ * Disclaimer: the number of items for this is a rough estimate of the items that
+ * tend to take longest to free and doesn't represent an accurate number of
+ * things freed.
+ *
+ * Caution: changing options for an engine that is in-use is not thread-safe!
+ *
+ * @param engine    The initialized scanning engine
+ * @param callback  The callback function pointer
+ * @param context   Opaque application provided data
+ */
+extern void cl_engine_set_clcb_engine_free_progress(struct cl_engine *engine, clcb_progress callback, void *context);
+
+/**
  * @brief Logging message callback for info, warning, and error messages.
  *
  * The specified callback will be called instead of logging to stderr.
@@ -940,7 +997,23 @@ extern cl_error_t cl_scanfile_callback(const char *filename, const char **virnam
 /* ----------------------------------------------------------------------------
  * Database handling.
  */
+
+/**
+ * @brief Load the signature databases found at the path.
+ *
+ * @param path      May be a file or directory.
+ * @param engine    The engine to load the signatures into
+ * @param signo     [out] The number of signatures loaded
+ * @param dboptions Database load bitflag field. See the CL_DB_* defines, above.
+ * @return cl_error_t
+ */
 extern cl_error_t cl_load(const char *path, struct cl_engine *engine, unsigned int *signo, unsigned int dboptions);
+
+/**
+ * @brief Get the default database directory path.
+ *
+ * @return const char*
+ */
 extern const char *cl_retdbdir(void);
 
 /* ----------------------------------------------------------------------------

--- a/libclamav/egg.h
+++ b/libclamav/egg.h
@@ -54,9 +54,9 @@ typedef struct cl_egg_metadata {
  *
  * @param map               fmap representing archive file.
  * @param sfx_offset        0 for a regular file, or an offset into the fmap for the EGG archive if found embedded in another file.
- * @param hArchive          [out] Handle to opened archive.
- * @param comments          [out] Array of null terminated archive comments, if present in archive. Array will be free'd by cli_egg_close()
- * @param nComments         [out] Number of archive comments in array.
+ * @param[out] hArchive     Handle to opened archive.
+ * @param[out] comments     Array of null terminated archive comments, if present in archive. Array will be free'd by cli_egg_close()
+ * @param[out] nComments    Number of archive comments in array.
  * @return cl_error_t   CL_SUCCESS if success.
  */
 cl_error_t cli_egg_open(
@@ -83,11 +83,11 @@ cl_error_t cli_egg_peek_file_header(
  * Does not return all of the metadata provided by cli_egg_peek_file_header(), so both should be used to get file information.
  * The current file index will be incrememnted on both success and failure.
  *
- * @param hArchive              An open EGG archive handle from cli_egg_open()
- * @param filename              [out] The filename of the extracted file, in UTF-8.
- * @param output_buffer         [out] A malloc'd buffer of the file contents.  Must be free()'d by caller. Set to NULL on failure.
- * @param output_buffer_length  [out] Size of buffer in bytes.
- * @return cl_error_t       CL_SUCCESS if success.
+ * @param hArchive                  An open EGG archive handle from cli_egg_open()
+ * @param[out] filename             The filename of the extracted file, in UTF-8.
+ * @param[out] output_buffer        A malloc'd buffer of the file contents.  Must be free()'d by caller. Set to NULL on failure.
+ * @param[out] output_buffer_length Size of buffer in bytes.
+ * @return cl_error_t               CL_SUCCESS if success.
  */
 cl_error_t cli_egg_extract_file(
     void* hArchive,

--- a/libclamav/entconv.h
+++ b/libclamav/entconv.h
@@ -253,9 +253,9 @@ int encoding_normalize_toascii(const m_area_t* in_m_area, const char* initial_en
  * @param in                string buffer
  * @param in_size           length of string buffer in bytes
  * @param codepage          Windows code page https://docs.microsoft.com/en-us/windows/desktop/Intl/code-page-identifiers)
- * @param [out] out         pointer to receive malloc'ed utf-8 buffer.
- * @param [out] out_size    pointer to receive size of utf-8 buffer, not including null terminating character.
- * @return cl_error_t   CL_SUCCESS if success. CL_BREAK if unable to because iconv is unavailable.  Other error code if outright failure.
+ * @param[out] out          pointer to receive malloc'ed utf-8 buffer.
+ * @param[out] out_size     pointer to receive size of utf-8 buffer, not including null terminating character.
+ * @return cl_error_t       CL_SUCCESS if success. CL_BREAK if unable to because iconv is unavailable.  Other error code if outright failure.
  */
 cl_error_t cli_codepage_to_utf8(char* in, size_t in_size, uint16_t codepage, char** out, size_t* out_size);
 

--- a/libclamav/fmap.h
+++ b/libclamav/fmap.h
@@ -102,12 +102,12 @@ fmap_t *fmap(int fd, off_t offset, size_t len, const char *name);
  * This variant of fmap() provides a boolean output variable to indicate on
  * failure if the failure was because the file is empty (not really a failure).
  *
- * @param fd        File descriptor of file to be mapped.
- * @param offset    Offset into file for start of map.
- * @param len       Length from offset for size of map.
- * @param empty     [out] Boolean will be non-zero if the file couldn't be mapped because it is empty.
- * @param name      (optional) Original name of the file (to set fmap name metadata)
- * @return fmap_t*  The newly created fmap.  Free it with `funmap()`
+ * @param fd            File descriptor of file to be mapped.
+ * @param offset        Offset into file for start of map.
+ * @param len           Length from offset for size of map.
+ * @param[out] empty    Boolean will be non-zero if the file couldn't be mapped because it is empty.
+ * @param name          (optional) Original name of the file (to set fmap name metadata)
+ * @return fmap_t*      The newly created fmap.  Free it with `funmap()`
  */
 fmap_t *fmap_check_empty(int fd, off_t offset, size_t len, int *empty, const char *name);
 

--- a/libclamav/hfsplus.c
+++ b/libclamav/hfsplus.c
@@ -310,7 +310,7 @@ static int hfsplus_readheader(cli_ctx *ctx, hfsPlusVolumeHeader *volHeader, hfsN
  * @param extHeader     Extent overflow file header
  * @param fork          Fork Data
  * @param dirname       Temp directory name
- * @param filename      [out] (optional) temp file name
+ * @param[out] filename (optional) temp file name
  * @param orig_filename (optiopnal) Original filename
  * @return cl_error_t
  */

--- a/libclamav/matcher-ac.c
+++ b/libclamav/matcher-ac.c
@@ -2915,7 +2915,10 @@ cl_error_t cli_ac_addsig(struct cli_matcher *root, const char *virname, const ch
         return ret;
     }
 
-    if (new->offdata[0] != CLI_OFF_ANY && new->offdata[0] != CLI_OFF_ABSOLUTE && new->offdata[0] != CLI_OFF_MACRO) {
+    if ((new->offdata[0] != CLI_OFF_ANY) &&
+        (new->offdata[0] != CLI_OFF_ABSOLUTE) &&
+        (new->offdata[0] != CLI_OFF_MACRO)) {
+
         root->ac_reloff = (struct cli_ac_patt **)MPOOL_REALLOC2(root->mempool, root->ac_reloff, (root->ac_reloff_num + 1) * sizeof(struct cli_ac_patt *));
         if (!root->ac_reloff) {
             cli_errmsg("cli_ac_addsig: Can't allocate memory for root->ac_reloff\n");

--- a/libclamav/matcher.h
+++ b/libclamav/matcher.h
@@ -247,14 +247,14 @@ cl_error_t cli_scan_buff(const unsigned char *buffer, uint32_t length, uint32_t 
  *
  * This function uses the newer cli_scan_fmap() scanning API.
  *
- * @param desc      File descriptor to be used for input
- * @param ctx       The scanning context.
- * @param ftype     If specified, may limit signature matching trie by target type corresponding with the specified CL_TYPE
- * @param ftonly    Boolean indicating if the scan is for file-type detection only.
- * @param ftoffset  [out] A list of file type signature matches with their corresponding offsets.
- * @param acmode    Use AC_SCAN_VIR and AC_SCAN_FT to set scanning modes.
- * @param acres     [out] A list of cli_ac_result AC pattern matching results.
- * @param name      (optional) Original name of the file (to set fmap name metadata)
+ * @param desc          File descriptor to be used for input
+ * @param ctx           The scanning context.
+ * @param ftype         If specified, may limit signature matching trie by target type corresponding with the specified CL_TYPE
+ * @param ftonly        Boolean indicating if the scan is for file-type detection only.
+ * @param[out] ftoffset A list of file type signature matches with their corresponding offsets.
+ * @param acmode        Use AC_SCAN_VIR and AC_SCAN_FT to set scanning modes.
+ * @param[out] acres    A list of cli_ac_result AC pattern matching results.
+ * @param name          (optional) Original name of the file (to set fmap name metadata)
  * @return cl_error_t
  */
 cl_error_t cli_scan_desc(int desc, cli_ctx *ctx, cli_file_t ftype, uint8_t ftonly, struct cli_matched_type **ftoffset, unsigned int acmode, struct cli_ac_result **acres, const char *name);
@@ -264,13 +264,13 @@ cl_error_t cli_scan_desc(int desc, cli_ctx *ctx, cli_file_t ftype, uint8_t ftonl
  *
  * This API will invoke cli_exp_eval() for you.
  *
- * @param ctx       The scanning context.
- * @param ftype     If specified, may limit signature matching trie by target type corresponding with the specified CL_TYPE
- * @param ftonly    Boolean indicating if the scan is for file-type detection only.
- * @param ftoffset  [out] A list of file type signature matches with their corresponding offsets.
- * @param acmode    Use AC_SCAN_VIR and AC_SCAN_FT to set scanning modes.
- * @param acres     [out] A list of cli_ac_result AC pattern matching results.
- * @param refhash   MD5 hash of the current file, used to save time creating hashes and to limit scan recursion for the HandlerType logical signature FTM feature.
+ * @param ctx           The scanning context.
+ * @param ftype         If specified, may limit signature matching trie by target type corresponding with the specified CL_TYPE
+ * @param ftonly        Boolean indicating if the scan is for file-type detection only.
+ * @param[out] ftoffset A list of file type signature matches with their corresponding offsets.
+ * @param acmode        Use AC_SCAN_VIR and AC_SCAN_FT to set scanning modes.
+ * @param[out] acres    A list of cli_ac_result AC pattern matching results.
+ * @param refhash       MD5 hash of the current file, used to save time creating hashes and to limit scan recursion for the HandlerType logical signature FTM feature.
  * @return cl_error_t
  */
 cl_error_t cli_scan_fmap(cli_ctx *ctx, cli_file_t ftype, uint8_t ftonly, struct cli_matched_type **ftoffset, unsigned int acmode, struct cli_ac_result **acres, unsigned char *refhash);

--- a/libclamav/others.c
+++ b/libclamav/others.c
@@ -948,16 +948,22 @@ struct cl_settings *cl_engine_settings_copy(const struct cl_engine *engine)
     settings->bytecode_mode      = engine->bytecode_mode;
     settings->pua_cats           = engine->pua_cats ? strdup(engine->pua_cats) : NULL;
 
-    settings->cb_pre_cache   = engine->cb_pre_cache;
-    settings->cb_pre_scan    = engine->cb_pre_scan;
-    settings->cb_post_scan   = engine->cb_post_scan;
-    settings->cb_virus_found = engine->cb_virus_found;
-    settings->cb_sigload     = engine->cb_sigload;
-    settings->cb_sigload_ctx = engine->cb_sigload_ctx;
-    settings->cb_hash        = engine->cb_hash;
-    settings->cb_meta        = engine->cb_meta;
-    settings->cb_file_props  = engine->cb_file_props;
-    settings->engine_options = engine->engine_options;
+    settings->cb_pre_cache                   = engine->cb_pre_cache;
+    settings->cb_pre_scan                    = engine->cb_pre_scan;
+    settings->cb_post_scan                   = engine->cb_post_scan;
+    settings->cb_virus_found                 = engine->cb_virus_found;
+    settings->cb_sigload                     = engine->cb_sigload;
+    settings->cb_sigload_ctx                 = engine->cb_sigload_ctx;
+    settings->cb_sigload_progress            = engine->cb_sigload_progress;
+    settings->cb_sigload_progress_ctx        = engine->cb_sigload_progress_ctx;
+    settings->cb_engine_compile_progress     = engine->cb_engine_compile_progress;
+    settings->cb_engine_compile_progress_ctx = engine->cb_engine_compile_progress_ctx;
+    settings->cb_engine_free_progress        = engine->cb_engine_free_progress;
+    settings->cb_engine_free_progress_ctx    = engine->cb_engine_free_progress_ctx;
+    settings->cb_hash                        = engine->cb_hash;
+    settings->cb_meta                        = engine->cb_meta;
+    settings->cb_file_props                  = engine->cb_file_props;
+    settings->engine_options                 = engine->engine_options;
 
     settings->cb_stats_add_sample      = engine->cb_stats_add_sample;
     settings->cb_stats_remove_sample   = engine->cb_stats_remove_sample;
@@ -1023,15 +1029,21 @@ cl_error_t cl_engine_settings_apply(struct cl_engine *engine, const struct cl_se
         engine->pua_cats = NULL;
     }
 
-    engine->cb_pre_cache   = settings->cb_pre_cache;
-    engine->cb_pre_scan    = settings->cb_pre_scan;
-    engine->cb_post_scan   = settings->cb_post_scan;
-    engine->cb_virus_found = settings->cb_virus_found;
-    engine->cb_sigload     = settings->cb_sigload;
-    engine->cb_sigload_ctx = settings->cb_sigload_ctx;
-    engine->cb_hash        = settings->cb_hash;
-    engine->cb_meta        = settings->cb_meta;
-    engine->cb_file_props  = settings->cb_file_props;
+    engine->cb_pre_cache                   = settings->cb_pre_cache;
+    engine->cb_pre_scan                    = settings->cb_pre_scan;
+    engine->cb_post_scan                   = settings->cb_post_scan;
+    engine->cb_virus_found                 = settings->cb_virus_found;
+    engine->cb_sigload                     = settings->cb_sigload;
+    engine->cb_sigload_ctx                 = settings->cb_sigload_ctx;
+    engine->cb_sigload_progress            = settings->cb_sigload_progress;
+    engine->cb_sigload_progress_ctx        = settings->cb_sigload_progress_ctx;
+    engine->cb_engine_compile_progress     = settings->cb_engine_compile_progress;
+    engine->cb_engine_compile_progress_ctx = settings->cb_engine_compile_progress_ctx;
+    engine->cb_engine_free_progress        = settings->cb_engine_free_progress;
+    engine->cb_engine_free_progress_ctx    = settings->cb_engine_free_progress_ctx;
+    engine->cb_hash                        = settings->cb_hash;
+    engine->cb_meta                        = settings->cb_meta;
+    engine->cb_file_props                  = settings->cb_file_props;
 
     engine->cb_stats_add_sample      = settings->cb_stats_add_sample;
     engine->cb_stats_remove_sample   = settings->cb_stats_remove_sample;
@@ -1622,6 +1634,24 @@ void cl_engine_set_clcb_sigload(struct cl_engine *engine, clcb_sigload callback,
 {
     engine->cb_sigload     = callback;
     engine->cb_sigload_ctx = callback ? context : NULL;
+}
+
+void cl_engine_set_clcb_sigload_progress(struct cl_engine *engine, clcb_progress callback, void *context)
+{
+    engine->cb_sigload_progress     = callback;
+    engine->cb_sigload_progress_ctx = callback ? context : NULL;
+}
+
+void cl_engine_set_clcb_engine_compile_progress(struct cl_engine *engine, clcb_progress callback, void *context)
+{
+    engine->cb_engine_compile_progress     = callback;
+    engine->cb_engine_compile_progress_ctx = callback ? context : NULL;
+}
+
+void cl_engine_set_clcb_engine_free_progress(struct cl_engine *engine, clcb_progress callback, void *context)
+{
+    engine->cb_engine_free_progress     = callback;
+    engine->cb_engine_free_progress_ctx = callback ? context : NULL;
 }
 
 void cl_engine_set_clcb_hash(struct cl_engine *engine, clcb_hash callback)

--- a/libclamav/others.h
+++ b/libclamav/others.h
@@ -992,7 +992,7 @@ cl_error_t cli_get_filepath_from_filedesc(int desc, char **filepath);
  * to get the real path.
  *
  * @param desc          A file path to evaluate.
- * @param char*         [out] A malloced string containing the real path.
+ * @param[out] char*    A malloced string containing the real path.
  * @return cl_error_t   CL_SUCCESS if found, else an error code.
  */
 cl_error_t cli_realpath(const char *file_name, char **real_filename);

--- a/libclamav/others.h
+++ b/libclamav/others.h
@@ -353,6 +353,9 @@ struct cl_engine {
     /* Database information from .info files */
     struct cli_dbinfo *dbinfo;
 
+    /* Signature counting, for progress callbacks */
+    size_t num_total_signatures;
+
     /* Used for memory pools */
     mpool_t *mempool;
 
@@ -369,6 +372,12 @@ struct cl_engine {
     clcb_hash cb_hash;
     clcb_meta cb_meta;
     clcb_file_props cb_file_props;
+    clcb_progress cb_sigload_progress;
+    void *cb_sigload_progress_ctx;
+    clcb_progress cb_engine_compile_progress;
+    void *cb_engine_compile_progress_ctx;
+    clcb_progress cb_engine_free_progress;
+    void *cb_engine_free_progress_ctx;
 
     /* Used for bytecode */
     struct cli_all_bc bcs;
@@ -449,6 +458,12 @@ struct cl_settings {
     clcb_hash cb_hash;
     clcb_meta cb_meta;
     clcb_file_props cb_file_props;
+    clcb_progress cb_sigload_progress;
+    void *cb_sigload_progress_ctx;
+    clcb_progress cb_engine_compile_progress;
+    void *cb_engine_compile_progress_ctx;
+    clcb_progress cb_engine_free_progress;
+    void *cb_engine_free_progress_ctx;
 
     /* Engine max settings */
     uint64_t maxembeddedpe;      /* max size to scan MSEXE for PE */

--- a/libclamav/readdb.c
+++ b/libclamav/readdb.c
@@ -1346,7 +1346,7 @@ static int cli_loadndb(FILE *fs, struct cl_engine *engine, unsigned int *signo, 
 
         if (engine->cb_sigload_progress && ((*signo + sigs) % 10000 == 0)) {
             /* Let the progress callback function know how we're doing */
-            engine->cb_sigload_progress(engine->num_total_signatures, *signo + sigs, engine->cb_sigload_progress_ctx);
+            (void)engine->cb_sigload_progress(engine->num_total_signatures, *signo + sigs, engine->cb_sigload_progress_ctx);
         }
     }
     if (engine->ignored)
@@ -1934,7 +1934,7 @@ static int cli_loadldb(FILE *fs, struct cl_engine *engine, unsigned int *signo, 
 
         if (engine->cb_sigload_progress && ((*signo + sigs) % 10000 == 0)) {
             /* Let the progress callback function know how we're doing */
-            engine->cb_sigload_progress(engine->num_total_signatures, *signo + sigs, engine->cb_sigload_progress_ctx);
+            (void)engine->cb_sigload_progress(engine->num_total_signatures, *signo + sigs, engine->cb_sigload_progress_ctx);
         }
     }
 
@@ -2587,7 +2587,7 @@ static int cli_loadhash(FILE *fs, struct cl_engine *engine, unsigned int *signo,
 
         if (engine->cb_sigload_progress && ((*signo + sigs) % 10000 == 0)) {
             /* Let the progress callback function know how we're doing */
-            engine->cb_sigload_progress(engine->num_total_signatures, *signo + sigs, engine->cb_sigload_progress_ctx);
+            (void)engine->cb_sigload_progress(engine->num_total_signatures, *signo + sigs, engine->cb_sigload_progress_ctx);
         }
     }
     if (engine->ignored)
@@ -4504,7 +4504,7 @@ cl_error_t cli_load(const char *filename, struct cl_engine *engine, unsigned int
 
     if (engine->cb_sigload_progress) {
         /* Let the progress callback function know how we're doing */
-        engine->cb_sigload_progress(engine->num_total_signatures, *signo, engine->cb_sigload_progress_ctx);
+        (void)engine->cb_sigload_progress(engine->num_total_signatures, *signo, engine->cb_sigload_progress_ctx);
     }
 
     return ret;
@@ -4957,7 +4957,7 @@ cl_error_t cl_load(const char *path, struct cl_engine *engine, unsigned int *sig
 
     if (engine->cb_sigload_progress) {
         /* Let the progress callback function know we're done! */
-        engine->cb_sigload_progress(*signo, *signo, engine->cb_sigload_progress_ctx);
+        (void)engine->cb_sigload_progress(*signo, *signo, engine->cb_sigload_progress_ctx);
     }
 
 #ifdef YARA_PROTO
@@ -5307,7 +5307,7 @@ cl_error_t cl_engine_free(struct cl_engine *engine)
      */
 #define TASK_COMPLETE()                           \
     if (engine->cb_engine_free_progress) {        \
-        engine->cb_engine_free_progress(          \
+        (void)engine->cb_engine_free_progress(    \
             tasks_to_do,                          \
             ++tasks_complete,                     \
             engine->cb_engine_free_progress_ctx); \
@@ -5582,7 +5582,7 @@ cl_error_t cl_engine_compile(struct cl_engine *engine)
 #undef TASK_COMPLETE
 #define TASK_COMPLETE()                              \
     if (engine->cb_engine_compile_progress) {        \
-        engine->cb_engine_compile_progress(          \
+        (void)engine->cb_engine_compile_progress(    \
             tasks_to_do,                             \
             ++tasks_complete,                        \
             engine->cb_engine_compile_progress_ctx); \

--- a/libclamav/readdb.c
+++ b/libclamav/readdb.c
@@ -4553,7 +4553,7 @@ static size_t count_line_based_signatures(const char *filepath)
 {
     FILE *fp              = NULL;
     int current_character = 0;
-    int sig_count         = 0;
+    size_t sig_count      = 0;
     bool in_sig           = false;
 
     fp = fopen(filepath, "r");
@@ -4568,7 +4568,7 @@ static size_t count_line_based_signatures(const char *filepath)
 
         if (!in_sig) {
             /* Not inside of a signature, yet */
-            if (!isspace(current_character) && // Ignore new lines and other forms of white space before a signature
+            if (!isspace(current_character) && // Ignore newlines and other forms of white space before a signature
                 ('#' != current_character))    // Ignore lines that begin with a # comment character
             {
                 /* Found first character of a new signatures */
@@ -4745,7 +4745,7 @@ static cl_error_t cli_loaddbdir(const char *dirname, struct cl_engine *engine, u
                     goto done;
                 }
 
-                /* Successfully opened the daily CLD file and ready the header info. */
+                /* Successfully opened the daily CLD file and read the header info. */
                 engine->num_total_signatures += daily_cld->sigs;
             }
 

--- a/libclamav/readdb.c
+++ b/libclamav/readdb.c
@@ -25,6 +25,7 @@
 #endif
 
 #include <stdio.h>
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
@@ -1342,6 +1343,11 @@ static int cli_loadndb(FILE *fs, struct cl_engine *engine, unsigned int *signo, 
             break;
         }
         sigs++;
+
+        if (engine->cb_sigload_progress && ((*signo + sigs) % 10000 == 0)) {
+            /* Let the progress callback function know how we're doing */
+            engine->cb_sigload_progress(engine->num_total_signatures, *signo + sigs, engine->cb_sigload_progress_ctx);
+        }
     }
     if (engine->ignored)
         free(buffer_cpy);
@@ -1925,6 +1931,11 @@ static int cli_loadldb(FILE *fs, struct cl_engine *engine, unsigned int *signo, 
                           engine, options, dbname, line, &sigs, 0, buffer_cpy, NULL);
         if (ret)
             break;
+
+        if (engine->cb_sigload_progress && ((*signo + sigs) % 10000 == 0)) {
+            /* Let the progress callback function know how we're doing */
+            engine->cb_sigload_progress(engine->num_total_signatures, *signo + sigs, engine->cb_sigload_progress_ctx);
+        }
     }
 
     if (engine->ignored)
@@ -2573,6 +2584,11 @@ static int cli_loadhash(FILE *fs, struct cl_engine *engine, unsigned int *signo,
         }
 
         sigs++;
+
+        if (engine->cb_sigload_progress && ((*signo + sigs) % 10000 == 0)) {
+            /* Let the progress callback function know how we're doing */
+            engine->cb_sigload_progress(engine->num_total_signatures, *signo + sigs, engine->cb_sigload_progress_ctx);
+        }
     }
     if (engine->ignored)
         free(buffer_cpy);
@@ -4486,6 +4502,11 @@ cl_error_t cli_load(const char *filename, struct cl_engine *engine, unsigned int
     if (fs)
         fclose(fs);
 
+    if (engine->cb_sigload_progress) {
+        /* Let the progress callback function know how we're doing */
+        engine->cb_sigload_progress(engine->num_total_signatures, *signo, engine->cb_sigload_progress_ctx);
+    }
+
     return ret;
 }
 
@@ -4520,6 +4541,126 @@ cli_insertdbtoll(struct db_ll_entry **head, struct db_ll_entry *entry)
     return;
 }
 
+/**
+ * @brief Count the number of signatures in a line-based signature file
+ *
+ * Ignores lines starting with # comment character
+ *
+ * @param filepath
+ * @return size_t
+ */
+static size_t count_line_based_signatures(const char *filepath)
+{
+    FILE *fp              = NULL;
+    int current_character = 0;
+    int sig_count         = 0;
+    bool in_sig           = false;
+
+    fp = fopen(filepath, "r");
+    if (fp == NULL) {
+        return 0;
+    }
+
+    sig_count++;
+    while (0 == feof(fp)) {
+        /* Get the next character */
+        current_character = fgetc(fp);
+
+        if (!in_sig) {
+            /* Not inside of a signature, yet */
+            if (!isspace(current_character) && // Ignore new lines and other forms of white space before a signature
+                ('#' != current_character))    // Ignore lines that begin with a # comment character
+            {
+                /* Found first character of a new signatures */
+                sig_count++;
+                in_sig = true;
+            }
+        } else {
+            /* Inside of a signature */
+            if (current_character == '\n') {
+                in_sig = false;
+            }
+        }
+    }
+
+    fclose(fp);
+    return sig_count;
+}
+
+/**
+ * @brief Count the number of signatures in a database file.
+ *
+ * Non-database files will be ignored, and count as 0 signatures.
+ * Database validation is not done, just signature counting.
+ *
+ * CVD/CLD/CUD database archives are not counted the hard way, we just trust
+ * signature count in the header. Yara rules and bytecode sigs count as 1 each.
+ *
+ * @param filepath  Filepath of the database file to count.
+ * @return size_t   The number of signatures.
+ */
+static size_t count_signatures(const char *filepath, struct cl_engine *engine, unsigned int options)
+{
+    size_t num_signatures            = 0;
+    struct cl_cvd *db_archive_header = NULL;
+
+    if (cli_strbcasestr(filepath, ".cld") ||
+        cli_strbcasestr(filepath, ".cvd") ||
+        cli_strbcasestr(filepath, ".cud")) {
+        /* use the CVD head to get the sig count. */
+        if (0 == access(filepath, R_OK)) {
+            db_archive_header = cl_cvdhead(filepath);
+            if (!db_archive_header) {
+                cli_errmsg("cli_loaddbdir: error parsing header of %s\n", filepath);
+                goto done;
+            }
+
+            num_signatures += db_archive_header->sigs;
+        }
+
+    } else if ((CL_BYTECODE_TRUST_ALL == engine->bytecode_security) &&
+               cli_strbcasestr(filepath, ".cbc")) {
+        /* Counts as 1 signature if loading plain .cbc files. */
+        num_signatures += 1;
+
+    } else if ((options & CL_DB_YARA_ONLY) &&
+               (cli_strbcasestr(filepath, ".yar") || cli_strbcasestr(filepath, ".yara"))) {
+        /* Counts as 1 signature. */
+        num_signatures += 1;
+
+    } else if (cli_strbcasestr(filepath, ".db") ||
+               cli_strbcasestr(filepath, ".crb") ||
+               cli_strbcasestr(filepath, ".hdb") || cli_strbcasestr(filepath, ".hsb") ||
+               cli_strbcasestr(filepath, ".hdu") || cli_strbcasestr(filepath, ".hsu") ||
+               cli_strbcasestr(filepath, ".fp") || cli_strbcasestr(filepath, ".sfp") ||
+               cli_strbcasestr(filepath, ".mdb") || cli_strbcasestr(filepath, ".msb") ||
+               cli_strbcasestr(filepath, ".imp") ||
+               cli_strbcasestr(filepath, ".mdu") || cli_strbcasestr(filepath, ".msu") ||
+               cli_strbcasestr(filepath, ".ndb") || cli_strbcasestr(filepath, ".ndu") || cli_strbcasestr(filepath, ".sdb") ||
+               cli_strbcasestr(filepath, ".ldb") || cli_strbcasestr(filepath, ".ldu") ||
+               cli_strbcasestr(filepath, ".zmd") || cli_strbcasestr(filepath, ".rmd") ||
+               cli_strbcasestr(filepath, ".cfg") ||
+               cli_strbcasestr(filepath, ".wdb") ||
+               cli_strbcasestr(filepath, ".pdb") || cli_strbcasestr(filepath, ".gdb") ||
+               cli_strbcasestr(filepath, ".ftm") ||
+               cli_strbcasestr(filepath, ".ign") || cli_strbcasestr(filepath, ".ign2") ||
+               cli_strbcasestr(filepath, ".idb") ||
+               cli_strbcasestr(filepath, ".cdb") ||
+               cli_strbcasestr(filepath, ".cat") ||
+               cli_strbcasestr(filepath, ".ioc") ||
+               cli_strbcasestr(filepath, ".pwdb")) {
+        /* Should be a line-based signaure file, count it the old fashioned way */
+        num_signatures += count_line_based_signatures(filepath);
+    }
+
+done:
+    if (NULL != db_archive_header) {
+        cl_cvdfree(db_archive_header);
+    }
+
+    return num_signatures;
+}
+
 static cl_error_t cli_loaddbdir(const char *dirname, struct cl_engine *engine, unsigned int *signo, unsigned int options)
 {
     cl_error_t ret = CL_EOPEN;
@@ -4538,7 +4679,7 @@ static cl_error_t cli_loaddbdir(const char *dirname, struct cl_engine *engine, u
     cli_dbgmsg("Loading databases from %s\n", dirname);
 
     if ((dd = opendir(dirname)) == NULL) {
-        cli_errmsg("cli_loaddbdir(): Can't open directory %s\n", dirname);
+        cli_errmsg("cli_loaddbdir: Can't open directory %s\n", dirname);
         ret = CL_EOPEN;
         goto done;
     }
@@ -4546,7 +4687,7 @@ static cl_error_t cli_loaddbdir(const char *dirname, struct cl_engine *engine, u
     dirname_len = strlen(dirname);
     if (dirname_len >= strlen(PATHSEP)) {
         if (strcmp(dirname + dirname_len - strlen(PATHSEP), PATHSEP) == 0) {
-            cli_dbgmsg("cli_loaddbdir(): dirname ends with separator\n");
+            cli_dbgmsg("cli_loaddbdir: dirname ends with separator\n");
             ends_with_sep = 1;
         }
     }
@@ -4567,7 +4708,7 @@ static cl_error_t cli_loaddbdir(const char *dirname, struct cl_engine *engine, u
 
         dbfile = (char *)cli_malloc(strlen(dent->d_name) + dirname_len + 2);
         if (!dbfile) {
-            cli_errmsg("cli_loaddbdir(): dbfile == NULL\n");
+            cli_errmsg("cli_loaddbdir: dbfile == NULL\n");
             ret = CL_EMEM;
             goto done;
         }
@@ -4588,6 +4729,8 @@ static cl_error_t cli_loaddbdir(const char *dirname, struct cl_engine *engine, u
             /* load .ign and .ign2 files first */
             load_priority = DB_LOAD_PRIORITY_IGN;
 
+            engine->num_total_signatures += count_line_based_signatures(dbfile);
+
         } else if (!strcmp(dent->d_name, "daily.cld")) {
             /* The daily db must be loaded before main, this way, the
                daily ign & ign2 signatures prevent ign'ored signatures
@@ -4597,10 +4740,13 @@ static cl_error_t cli_loaddbdir(const char *dirname, struct cl_engine *engine, u
             if (0 == access(dbfile, R_OK)) {
                 daily_cld = cl_cvdhead(dbfile);
                 if (!daily_cld) {
-                    cli_errmsg("cli_loaddbdir(): error parsing header of %s\n", dbfile);
+                    cli_errmsg("cli_loaddbdir: error parsing header of %s\n", dbfile);
                     ret = CL_EMALFDB;
                     goto done;
                 }
+
+                /* Successfully opened the daily CLD file and ready the header info. */
+                engine->num_total_signatures += daily_cld->sigs;
             }
 
         } else if (!strcmp(dent->d_name, "daily.cvd")) {
@@ -4609,17 +4755,23 @@ static cl_error_t cli_loaddbdir(const char *dirname, struct cl_engine *engine, u
             if (0 == access(dbfile, R_OK)) {
                 daily_cvd = cl_cvdhead(dbfile);
                 if (!daily_cvd) {
-                    cli_errmsg("cli_loaddbdir(): error parsing header of %s\n", dbfile);
+                    cli_errmsg("cli_loaddbdir: error parsing header of %s\n", dbfile);
                     ret = CL_EMALFDB;
                     goto done;
                 }
+                /* Successfully opened the daily CVD file and ready the header info. */
+                engine->num_total_signatures += daily_cvd->sigs;
             }
 
         } else if (!strcmp(dent->d_name, "local.gdb")) {
             load_priority = DB_LOAD_PRIORITY_LOCAL_GDB;
 
+            engine->num_total_signatures += count_line_based_signatures(dbfile);
+
         } else if (!strcmp(dent->d_name, "daily.cfg")) {
             load_priority = DB_LOAD_PRIORITY_DAILY_CFG;
+
+            engine->num_total_signatures += count_line_based_signatures(dbfile);
 
         } else if ((options & CL_DB_OFFICIAL_ONLY) &&
                    !strstr(dirname, "clamav-") &&            // Official databases that are temp-files (in the process of updating).
@@ -4639,13 +4791,17 @@ static cl_error_t cli_loaddbdir(const char *dirname, struct cl_engine *engine, u
              * Therefore, we need to ensure the .crb rules are loaded prior */
             load_priority = DB_LOAD_PRIORITY_CRB;
 
+            engine->num_total_signatures += count_line_based_signatures(dbfile);
+
         } else {
             load_priority = DB_LOAD_PRIORITY_NORMAL;
+
+            engine->num_total_signatures += count_signatures(dbfile, engine, options);
         }
 
         entry = malloc(sizeof(*entry));
         if (NULL == entry) {
-            cli_errmsg("cli_loaddbdir(): entry == NULL\n");
+            cli_errmsg("cli_loaddbdir: failed to allocate memory for database load list entry\n");
             ret = CL_EMEM;
             goto done;
         }
@@ -4682,7 +4838,7 @@ static cl_error_t cli_loaddbdir(const char *dirname, struct cl_engine *engine, u
 
         ret = cli_load(iter->path, engine, signo, options, NULL);
         if (ret) {
-            cli_errmsg("cli_loaddbdir(): error loading database %s\n", iter->path);
+            cli_errmsg("cli_loaddbdir: error loading database %s\n", iter->path);
             goto done;
         }
     }
@@ -4711,7 +4867,7 @@ done:
     }
 
     if (ret == CL_EOPEN)
-        cli_errmsg("cli_loaddbdir(): No supported database files found in %s\n", dirname);
+        cli_errmsg("cli_loaddbdir: No supported database files found in %s\n", dirname);
 
     return ret;
 }
@@ -4783,16 +4939,25 @@ cl_error_t cl_load(const char *path, struct cl_engine *engine, unsigned int *sig
 
     switch (sb.st_mode & S_IFMT) {
         case S_IFREG:
+            /* Count # of sigs in the database now */
+            engine->num_total_signatures += count_signatures(path, engine, dboptions);
+
             ret = cli_load(path, engine, signo, dboptions, NULL);
             break;
 
         case S_IFDIR:
+            /* Count # of signatures inside cli_loaddbdir(), before loading */
             ret = cli_loaddbdir(path, engine, signo, dboptions | CL_DB_DIRECTORY);
             break;
 
         default:
             cli_errmsg("cl_load(%s): Not supported database file type\n", path);
             return CL_EOPEN;
+    }
+
+    if (engine->cb_sigload_progress) {
+        /* Let the progress callback function know we're done! */
+        engine->cb_sigload_progress(*signo, *signo, engine->cb_sigload_progress_ctx);
     }
 
 #ifdef YARA_PROTO
@@ -5034,6 +5199,9 @@ cl_error_t cl_engine_free(struct cl_engine *engine)
     unsigned int i, j;
     struct cli_matcher *root;
 
+    size_t tasks_to_do    = 0;
+    size_t tasks_complete = 0;
+
     if (!engine) {
         cli_errmsg("cl_free: engine == NULL\n");
         return CL_ENULLARG;
@@ -5065,54 +5233,148 @@ cl_error_t cl_engine_free(struct cl_engine *engine)
 
     pthread_mutex_unlock(&cli_ref_mutex);
 #endif
+
     if (engine->stats_data)
         free(engine->stats_data);
+
+    /*
+     * Pre-calculate number of "major" tasks to complete for the progress callback
+     */
+    if (engine->root) {
+        for (i = 0; i < CLI_MTARGETS; i++) {
+            if ((root = engine->root[i])) {
+                if (!root->ac_only) {
+                    tasks_to_do += 1; // bm root
+                }
+                tasks_to_do += 1; // ac root
+                if (root->ac_lsigtable) {
+                    tasks_to_do += root->ac_lsigs / 1000; // every 1000 logical sigs
+                    tasks_to_do += 1;                     // ac lsig table
+                }
+#if HAVE_PCRE
+                tasks_to_do += 1; // pcre table
+#endif
+                tasks_to_do += 1; // root mempool
+            }
+        }
+        tasks_to_do += 1; // engine root mempool
+    }
+    tasks_to_do += 7; // hdb, mdb, imp, fp, crtmgr, cdb, dbinfo
+
+    if (engine->dconf) {
+        if (engine->dconf->bytecode & BYTECODE_ENGINE_MASK) {
+            if (engine->bcs.all_bcs) {
+                tasks_to_do += engine->bcs.count;
+            }
+            tasks_to_do += 1; // bytecode done
+            tasks_to_do += 1; // bytecode hooks
+        }
+
+        if (engine->dconf->phishing & PHISHING_CONF_ENGINE) {
+            tasks_to_do += 1; // phishing cleanup
+        }
+
+        tasks_to_do += 1; // dconf mempool
+    }
+    tasks_to_do += 7; // pwdbs, pua cats, iconcheck, tempdir, cache, engine, ignored
+
+    if (engine->test_root) {
+        root = engine->test_root;
+        if (!root->ac_only) {
+            tasks_to_do += 1; // bm root
+        }
+        tasks_to_do += 1; // ac root
+        if (root->ac_lsigtable) {
+            tasks_to_do += root->ac_lsigs / 1000; // every 1000 logical sigs
+            tasks_to_do += 1;                     // ac lsig table
+        }
+#if HAVE_PCRE
+        tasks_to_do += 1; // pcre table
+#endif
+        tasks_to_do += 1; // engine root mempool
+    }
+
+#ifdef USE_MPOOL
+    tasks_to_do += 1; // mempool
+#endif
+
+#ifdef HAVE_YARA
+    tasks_to_do += 1; // yara
+#endif
+
+    /*
+     * Ok, now actually free everything.
+     */
+#define TASK_COMPLETE()                           \
+    if (engine->cb_engine_free_progress) {        \
+        engine->cb_engine_free_progress(          \
+            tasks_to_do,                          \
+            ++tasks_complete,                     \
+            engine->cb_engine_free_progress_ctx); \
+    }
 
     if (engine->root) {
         for (i = 0; i < CLI_MTARGETS; i++) {
             if ((root = engine->root[i])) {
-                if (!root->ac_only)
+                if (!root->ac_only) {
                     cli_bm_free(root);
+                    TASK_COMPLETE();
+                }
+
                 cli_ac_free(root);
+                TASK_COMPLETE();
+
                 if (root->ac_lsigtable) {
                     for (j = 0; j < root->ac_lsigs; j++) {
                         if (root->ac_lsigtable[j]->type == CLI_LSIG_NORMAL)
                             MPOOL_FREE(engine->mempool, root->ac_lsigtable[j]->u.logic);
                         FREE_TDB(root->ac_lsigtable[j]->tdb);
                         MPOOL_FREE(engine->mempool, root->ac_lsigtable[j]);
+
+                        TASK_COMPLETE();
                     }
+
                     MPOOL_FREE(engine->mempool, root->ac_lsigtable);
+                    TASK_COMPLETE();
                 }
 #if HAVE_PCRE
                 cli_pcre_freetable(root);
+                TASK_COMPLETE();
 #endif /* HAVE_PCRE */
                 MPOOL_FREE(engine->mempool, root);
+                TASK_COMPLETE();
             }
         }
         MPOOL_FREE(engine->mempool, engine->root);
+        TASK_COMPLETE();
     }
 
     if ((root = engine->hm_hdb)) {
         hm_free(root);
         MPOOL_FREE(engine->mempool, root);
     }
+    TASK_COMPLETE();
 
     if ((root = engine->hm_mdb)) {
         hm_free(root);
         MPOOL_FREE(engine->mempool, root);
     }
+    TASK_COMPLETE();
 
     if ((root = engine->hm_imp)) {
         hm_free(root);
         MPOOL_FREE(engine->mempool, root);
     }
+    TASK_COMPLETE();
 
     if ((root = engine->hm_fp)) {
         hm_free(root);
         MPOOL_FREE(engine->mempool, root);
     }
+    TASK_COMPLETE();
 
     crtmgr_free(&engine->cmgr);
+    TASK_COMPLETE();
 
     while (engine->cdb) {
         struct cli_cdb *pt = engine->cdb;
@@ -5123,6 +5385,7 @@ cl_error_t cl_engine_free(struct cl_engine *engine)
         MPOOL_FREE(engine->mempool, pt->virname);
         MPOOL_FREE(engine->mempool, pt);
     }
+    TASK_COMPLETE();
 
     while (engine->dbinfo) {
         struct cli_dbinfo *pt = engine->dbinfo;
@@ -5133,23 +5396,35 @@ cl_error_t cl_engine_free(struct cl_engine *engine)
             cl_cvdfree(pt->cvd);
         MPOOL_FREE(engine->mempool, pt);
     }
+    TASK_COMPLETE();
 
     if (engine->dconf) {
         if (engine->dconf->bytecode & BYTECODE_ENGINE_MASK) {
-            if (engine->bcs.all_bcs)
-                for (i = 0; i < engine->bcs.count; i++)
+            if (engine->bcs.all_bcs) {
+                for (i = 0; i < engine->bcs.count; i++) {
                     cli_bytecode_destroy(&engine->bcs.all_bcs[i]);
+                    TASK_COMPLETE();
+                }
+            }
+
             cli_bytecode_done(&engine->bcs);
+            TASK_COMPLETE();
+
             free(engine->bcs.all_bcs);
+
             for (i = 0; i < _BC_LAST_HOOK - _BC_START_HOOKS; i++) {
                 free(engine->hooks[i]);
             }
+            TASK_COMPLETE();
         }
 
-        if (engine->dconf->phishing & PHISHING_CONF_ENGINE)
+        if (engine->dconf->phishing & PHISHING_CONF_ENGINE) {
             phishing_done(engine);
+            TASK_COMPLETE();
+        }
 
         MPOOL_FREE(engine->mempool, engine->dconf);
+        TASK_COMPLETE();
     }
 
     if (engine->pwdbs) {
@@ -5158,9 +5433,12 @@ cl_error_t cl_engine_free(struct cl_engine *engine)
                 cli_pwdb_list_free(engine, engine->pwdbs[i]);
         MPOOL_FREE(engine->mempool, engine->pwdbs);
     }
+    TASK_COMPLETE();
 
-    if (engine->pua_cats)
+    if (engine->pua_cats) {
         MPOOL_FREE(engine->mempool, engine->pua_cats);
+    }
+    TASK_COMPLETE();
 
     if (engine->iconcheck) {
         struct icon_matcher *iconcheck = engine->iconcheck;
@@ -5185,47 +5463,68 @@ cl_error_t cl_engine_free(struct cl_engine *engine)
         }
         MPOOL_FREE(engine->mempool, iconcheck);
     }
+    TASK_COMPLETE();
 
-    if (engine->tmpdir)
+    if (engine->tmpdir) {
         MPOOL_FREE(engine->mempool, engine->tmpdir);
+    }
+    TASK_COMPLETE();
 
-    if (engine->cache)
+    if (engine->cache) {
         cli_cache_destroy(engine);
+    }
+    TASK_COMPLETE();
 
     cli_ftfree(engine);
+    TASK_COMPLETE();
+
     if (engine->ignored) {
         cli_bm_free(engine->ignored);
         MPOOL_FREE(engine->mempool, engine->ignored);
     }
+    TASK_COMPLETE();
+
     if (engine->test_root) {
         root = engine->test_root;
-        if (!root->ac_only)
+        if (!root->ac_only) {
             cli_bm_free(root);
+            TASK_COMPLETE();
+        }
         cli_ac_free(root);
+        TASK_COMPLETE();
+
         if (root->ac_lsigtable) {
             for (i = 0; i < root->ac_lsigs; i++) {
                 if (root->ac_lsigtable[i]->type == CLI_LSIG_NORMAL)
                     MPOOL_FREE(engine->mempool, root->ac_lsigtable[i]->u.logic);
                 FREE_TDB(root->ac_lsigtable[i]->tdb);
                 MPOOL_FREE(engine->mempool, root->ac_lsigtable[i]);
+
+                TASK_COMPLETE();
             }
             MPOOL_FREE(engine->mempool, root->ac_lsigtable);
+            TASK_COMPLETE();
         }
 #if HAVE_PCRE
         cli_pcre_freetable(root);
+        TASK_COMPLETE();
 #endif /* HAVE_PCRE */
         MPOOL_FREE(engine->mempool, root);
+        TASK_COMPLETE();
     }
 
 #ifdef USE_MPOOL
     if (engine->mempool) mpool_destroy(engine->mempool);
+    TASK_COMPLETE();
 #endif
 
 #ifdef HAVE_YARA
     cli_yara_free(engine);
+    TASK_COMPLETE();
 #endif
 
     free(engine);
+
     return CL_SUCCESS;
 }
 
@@ -5235,8 +5534,60 @@ cl_error_t cl_engine_compile(struct cl_engine *engine)
     cl_error_t ret;
     struct cli_matcher *root;
 
-    if (!engine)
+    size_t tasks_to_do    = 0;
+    size_t tasks_complete = 0;
+
+    if (!engine) {
         return CL_ENULLARG;
+    }
+
+    /*
+     * Pre-calculate number of "major" tasks to complete for the progress callback
+     */
+#ifdef HAVE_YARA
+    tasks_to_do += 1; // yara free
+#endif
+    tasks_to_do += 1; // load ftm
+
+    tasks_to_do += 1; // load pwdb
+
+    for (i = 0; i < CLI_MTARGETS; i++) {
+        if ((root = engine->root[i])) {
+            tasks_to_do += 1; // build ac trie
+#if HAVE_PCRE
+            tasks_to_do += 1; // compile pcre regex
+#endif
+        }
+    }
+    tasks_to_do += 1; // flush hdb
+    tasks_to_do += 1; // flush mdb
+    tasks_to_do += 1; // flush imp
+    tasks_to_do += 1; // flush fp
+    tasks_to_do += 1; // build allow list regex list
+    tasks_to_do += 1; // build domain list regex list
+    if (engine->ignored) {
+        tasks_to_do += 1; // free list of ignored sigs (no longer needed)
+    }
+    if (engine->test_root) {
+        tasks_to_do += 1; // free test root (no longer needed)
+    }
+    tasks_to_do += 1; // prepare bytecode sigs
+                      // Note: Adding a task to compile each bytecode is doable
+                      //       but would be painful to implement. For now, just
+                      //       having it all as one task should be good enough.
+
+    /*
+     * Ok, now actually compile everything.
+     */
+#undef TASK_COMPLETE
+#define TASK_COMPLETE()                              \
+    if (engine->cb_engine_compile_progress) {        \
+        engine->cb_engine_compile_progress(          \
+            tasks_to_do,                             \
+            ++tasks_complete,                        \
+            engine->cb_engine_compile_progress_ctx); \
+    }
+
 #ifdef HAVE_YARA
     /* Free YARA hash tables - only needed for parse and load */
     if (engine->yara_global != NULL) {
@@ -5246,24 +5597,29 @@ cl_error_t cl_engine_compile(struct cl_engine *engine)
             yr_hash_table_destroy(engine->yara_global->objects_table, NULL);
         engine->yara_global->rules_table = engine->yara_global->objects_table = NULL;
     }
+    TASK_COMPLETE();
 #endif
 
     if (!engine->ftypes)
         if ((ret = cli_loadftm(NULL, engine, 0, 1, NULL)))
             return ret;
+    TASK_COMPLETE();
 
     /* handle default passwords */
     if (!engine->pwdbs[0] && !engine->pwdbs[1] && !engine->pwdbs[2])
         if ((ret = cli_loadpwdb(NULL, engine, 0, 1, NULL)))
             return ret;
+    TASK_COMPLETE();
 
     for (i = 0; i < CLI_MTARGETS; i++) {
         if ((root = engine->root[i])) {
             if ((ret = cli_ac_buildtrie(root)))
                 return ret;
+            TASK_COMPLETE();
 #if HAVE_PCRE
             if ((ret = cli_pcre_build(root, engine->pcre_match_limit, engine->pcre_recmatch_limit, engine->dconf)))
                 return ret;
+            TASK_COMPLETE();
 
             cli_dbgmsg("Matcher[%u]: %s: AC sigs: %u (reloff: %u, absoff: %u) BM sigs: %u (reloff: %u, absoff: %u) PCREs: %u (reloff: %u, absoff: %u) maxpatlen %u %s\n", i, cli_mtargets[i].name, root->ac_patterns, root->ac_reloff_num, root->ac_absoff_num, root->bm_patterns, root->bm_reloff_num, root->bm_absoff_num, root->pcre_metas, root->pcre_reloff_num, root->pcre_absoff_num, root->maxpatlen, root->ac_only ? "(ac_only mode)" : "");
 #else
@@ -5271,29 +5627,40 @@ cl_error_t cl_engine_compile(struct cl_engine *engine)
 #endif
         }
     }
+
     if (engine->hm_hdb)
         hm_flush(engine->hm_hdb);
+    TASK_COMPLETE();
 
     if (engine->hm_mdb)
         hm_flush(engine->hm_mdb);
+    TASK_COMPLETE();
 
     if (engine->hm_imp)
         hm_flush(engine->hm_imp);
+    TASK_COMPLETE();
 
     if (engine->hm_fp)
         hm_flush(engine->hm_fp);
+    TASK_COMPLETE();
 
     if ((ret = cli_build_regex_list(engine->allow_list_matcher))) {
         return ret;
     }
+    TASK_COMPLETE();
+
     if ((ret = cli_build_regex_list(engine->domain_list_matcher))) {
         return ret;
     }
+    TASK_COMPLETE();
+
     if (engine->ignored) {
         cli_bm_free(engine->ignored);
         MPOOL_FREE(engine->mempool, engine->ignored);
         engine->ignored = NULL;
+        TASK_COMPLETE();
     }
+
     if (engine->test_root) {
         root = engine->test_root;
         if (!root->ac_only)
@@ -5313,7 +5680,9 @@ cl_error_t cl_engine_compile(struct cl_engine *engine)
 #endif /* HAVE_PCRE */
         MPOOL_FREE(engine->mempool, root);
         engine->test_root = NULL;
+        TASK_COMPLETE();
     }
+
     cli_dconf_print(engine->dconf);
     MPOOL_FLUSH(engine->mempool);
 
@@ -5322,6 +5691,7 @@ cl_error_t cl_engine_compile(struct cl_engine *engine)
         cli_errmsg("Unable to compile/load bytecode: %s\n", cl_strerror(ret));
         return ret;
     }
+    TASK_COMPLETE();
 
     engine->dboptions |= CL_DB_COMPILED;
     return CL_SUCCESS;

--- a/libclamav/scanners.c
+++ b/libclamav/scanners.c
@@ -1506,7 +1506,8 @@ static cl_error_t vba_scandata(const unsigned char *data, size_t len, cli_ctx *c
     cli_ac_freedata(&tmdata);
     cli_ac_freedata(&gmdata);
 
-    return (ret != CL_CLEAN) ? ret : viruses_found ? CL_VIRUS : CL_CLEAN;
+    return (ret != CL_CLEAN) ? ret : viruses_found ? CL_VIRUS
+                                                   : CL_CLEAN;
 }
 
 #define min(x, y) ((x) < (y) ? (x) : (y))
@@ -3089,13 +3090,13 @@ static inline void perf_done(cli_ctx *ctx)
 /**
  * @brief Perform raw scan of current fmap.
  *
- * @param ctx       Current scan context.
- * @param type      File type
- * @param typercg   Enable type recognition (file typing scan results).
- *                  If 0, will be a regular ac-mode scan.
- * @param dettype   [out] If typercg enabled and scan detects HTML or MAIL types,
- *                  will output HTML or MAIL types after performing HTML/MAIL scans
- * @param refhash   Hash of current fmap
+ * @param ctx           Current scan context.
+ * @param type          File type
+ * @param typercg       Enable type recognition (file typing scan results).
+ *                      If 0, will be a regular ac-mode scan.
+ * @param[out] dettype  If typercg enabled and scan detects HTML or MAIL types,
+ *                      will output HTML or MAIL types after performing HTML/MAIL scans
+ * @param refhash       Hash of current fmap
  * @return cl_error_t
  */
 static cl_error_t scanraw(cli_ctx *ctx, cli_file_t type, uint8_t typercg, cli_file_t *dettype, unsigned char *refhash)

--- a/libfreshclam/libfreshclam.h
+++ b/libfreshclam/libfreshclam.h
@@ -151,8 +151,8 @@ fc_error_t fc_test_database(
  * Caller must free dnsUpdateInfo.
  *
  * @param dnsUpdateInfoServer   (optional) The DNS server to query for Update Info. If NULL, will disable DNS update info query feature.
- * @param dnsUpdateInfo         [out] The Update Info DNS reply string.
- * @param newVersion            [out] New version of ClamAV available.
+ * @param[out] dnsUpdateInfo    The Update Info DNS reply string.
+ * @param[out] newVersion       New version of ClamAV available.
  * @return fc_error_t           FC_SUCCESS if success.
  * @return fc_error_t           FC_EARG if invalid args.
  * @return fc_error_t           FC_EFAILEDGET if error or disabled and should fall back to HTTP mode for update info.
@@ -169,7 +169,7 @@ fc_error_t fc_dns_query_update_info(
  *
  * @param url           Database URL (http, https, file).
  * @param context       Application context to pass to fccb_download_complete callback.
- * @param bUpdated      [out] Non-zero if database was updated to new version or is entirely new.
+ * @param[out] bUpdated Non-zero if database was updated to new version or is entirely new.
  * @return fc_error_t   FC_SUCCESS if database downloaded and callback executed successfully.
  */
 fc_error_t fc_download_url_database(
@@ -183,7 +183,7 @@ fc_error_t fc_download_url_database(
  * @param urlDatabaseList List of database URLs
  * @param nUrlDatabases   Number of URLs in list.
  * @param context         Application context to pass to fccb_download_complete callback.
- * @param nUpdated        [out] Number of databases that were updated.
+ * @param[out] nUpdated   Number of databases that were updated.
  * @return fc_error_t     FC_SUCCESS if database downloaded and callback executed successfully.
  */
 fc_error_t fc_download_url_databases(
@@ -201,7 +201,7 @@ fc_error_t fc_download_url_databases(
  * @param dnsUpdateInfoServer   DNS server for update info check. May be NULL to disable use of DNS.
  * @param bScriptedUpdates      Enable incremental/updates (should not be enabled for PrivateMirrors).
  * @param context               Application context to pass to fccb_download_complete callback.
- * @param bUpdated              [out] Non-zero if database was updated to new version or is entirely new.
+ * @param[out] bUpdated         Non-zero if database was updated to new version or is entirely new.
  * @return fc_error_t           FC_SUCCESS if database downloaded and callback executed successfully.
  */
 fc_error_t fc_update_database(
@@ -224,7 +224,7 @@ fc_error_t fc_update_database(
  * @param dnsUpdateInfoServer   DNS server for update info check. May be NULL to disable use of DNS.
  * @param bScriptedUpdates      Enable incremental/updates (should not be enabled for PrivateMirrors).
  * @param context               Application context to pass to fccb_download_complete callback.
- * @param nUpdated              [out] Number of databases that were updated.
+ * @param[out] nUpdated         Number of databases that were updated.
  * @return fc_error_t           FC_SUCCESS if database downloaded and callback executed successfully.
  */
 fc_error_t fc_update_databases(

--- a/libfreshclam/libfreshclam_internal.c
+++ b/libfreshclam/libfreshclam_internal.c
@@ -792,7 +792,7 @@ static size_t WriteFileCallback(void *contents, size_t size, size_t nmemb, void 
  * @param ifModifiedSince   modified time of local database. May be 0 to always get the CVD header.
  * @param server            server to use to retrieve for database header.
  * @param logerr            non-zero to upgrade warnings to errors.
- * @param cvd               [out] CVD header of newest available CVD, if FC_SUCCESS
+ * @param[out] cvd          CVD header of newest available CVD, if FC_SUCCESS
  * @return fc_error_t       FC_SUCCESS if CVD header obtained.
  * @return fc_error_t       FC_UPTODATE if received 304 in response to ifModifiedSince date.
  * @return fc_error_t       Another error code if failure occured.
@@ -1474,7 +1474,7 @@ done:
  * Will create the temp dir if it does not already exist.
  *
  * @param database      The database we're updating.
- * @param tmpdir        [out] The name of the temp dir to use.
+ * @param[out] tmpdir   The name of the temp dir to use.
  * @return fc_error_t
  */
 static fc_error_t mkdir_and_chdir_for_cdiff_tmp(const char *database, const char *tmpdir)
@@ -1645,7 +1645,7 @@ done:
  * @brief Get CVD header info for local CVD/CLD database.
  *
  * @param database          Database name
- * @param localname         [out] (optional) filename of local database.
+ * @param[out] localname    (optional) filename of local database.
  * @return struct cl_cvd*   CVD info struct of local database, if found. NULL if not found.
  */
 static struct cl_cvd *currentdb(const char *database, char **localname)


### PR DESCRIPTION
Add progress callbacks to libclamav for:
- database load
- engine compile
- engine free

Add a progress bar to clamscan for load & compile.
These are disabled if you run with --debug.

Added code so you can test the engine-free callback by building with
ENABLE_ENGINE_FREE_PROGRESSBAR defined.

The compile & free progress callbacks pre-calculate the number of
tasks to complete to estimate the progress. Some tasks may take longer
than others so the progress speed my appear to vary a little.