### PR TITLE
Add valgrind suppression rule for non-serious clamd leak

### DIFF
--- a/unit_tests/valgrind.supp
+++ b/unit_tests/valgrind.supp
@@ -236,7 +236,7 @@
 }
 
 {
-   <insert_a_suppression_name_here>
+   bsd-lowering3
    Memcheck:Cond
    fun:_ZNK4llvm17X86TargetLowering9LowerCallERNS_14TargetLowering16CallLoweringInfoERNS_15SmallVectorImplINS_7SDValueEEE
    fun:_ZNK4llvm14TargetLowering11LowerCallToERNS0_16CallLoweringInfoE
@@ -288,4 +288,31 @@
    fun:__gconv_transform_internal_utf8
    fun:wcsrtombs
    ...
+}
+{
+   thrmgr_dispatch_internal-pthread_create
+   Memcheck:Leak
+   match-leak-kinds: possible,definite
+   fun:calloc
+   fun:allocate_dtv
+   fun:_dl_allocate_tls
+   fun:allocate_stack
+   ...
+   fun:thrmgr_dispatch_internal
+   fun:thrmgr_group_dispatch
+   fun:dispatch_command
+   ...
+}
+{
+   reload_db-pthread_create
+   Memcheck:Leak
+   match-leak-kinds: possible,definite
+   fun:calloc
+   fun:allocate_dtv
+   fun:_dl_allocate_tls
+   fun:allocate_stack
+   ...
+   fun:reload_db
+   fun:recvloop
+   fun:main
 }


### PR DESCRIPTION
There is a minor leak in clamd that causes intermittent clamd test
failures. This cause by a thread leaking occasionally, due to not
exiting before the program terminates. I don't believe this to be a
serious issue. Tracking down the exact cause and crafting a fix isn't
worth the effort.

This commit adds a valgrind suppression rule so the tests are stable.

I believe this PR will resolve the issue.  I tested it a few times running the clamd_valgrind test many times over, like this: `ctest -V -R clamd_ && ctest -V -R clamd_ && ctest -V -R clamd_ && ctest -V -R clamd_ && ctest -V -R clamd_ && ctest -V -R clamd_ && ctest -V -R clamd_ && ctest -V -R clamd_ && ctest -V -R clamd_ && ctest -V -R clamd_ && ctest -V -R clamd_ && ctest -V -R clamd_ && ctest -V -R clamd_ && ctest -V -R clamd_ && ctest -V -R clamd_ && ctest -V -R clamd_ && ctest -V -R clamd_ && ctest -V -R clamd_ && ctest -V -R clamd_ && ctest -V -R clamd_ && ctest -V -R clamd_ && ctest -V -R clamd_ && ctest -V -R clamd_ && ctest -V -R clamd_ && ctest -V -R clamd_ && ctest -V -R clamd_ && ctest -V -R clamd_ && ctest -V -R clamd_ && ctest -V -R clamd_ && ctest -V -R clamd_ && ctest -V -R clamd_ && ctest -V -R clamd_ && ctest -V -R clamd_ && ctest -V -R clamd_ && echo "============ ALL TESTS PASSED ==============="`