### PR TITLE
clamav.net URL update for new docs, github issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ include(Version)
 set(PACKAGE_NAME      "${PROJECT_NAME}")
 set(PACKAGE_VERSION   "${PROJECT_VERSION}")
 set(PACKAGE_STRING    "${PROJECT_NAME} ${PROJECT_VERSION}${VERSION_SUFFIX}")
-set(PACKAGE_BUGREPORT "https://bugzilla.clamav.net/")
+set(PACKAGE_BUGREPORT "https://github.com/Cisco-Talos/clamav/issues")
 set(PACKAGE_URL       "https://www.clamav.net/")
 HexVersion(PACKAGE_VERSION_NUM ${PROJECT_VERSION_MAJOR} ${PROJECT_VERSION_MINOR} ${PROJECT_VERSION_PATCH})
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -68,8 +68,8 @@ ClamAV 0.104.0 includes the following improvements and changes.
   new Docker files, image database deployment tooling, and user documentation.
 
 - `clamd` and `freshclam` are now available as Windows services. To install
-  and run them, use the `--install-service` option and `net start [name]` command. 
-  
+  and run them, use the `--install-service` option and `net start [name]` command.
+
   Special thanks to Gianluigi Tiesi for his original work on this feature.
 
 ### Notable changes
@@ -683,7 +683,7 @@ changes.
   - With `clamonacc`, it is now possible to copy, move, or remove a file if the
     scan triggered an alert, just like with `clamdscan`.
   For details on how to use the new `clamonacc` On-Access scanner, please
-  refer to the user manual on [ClamAV.net](http://www.clamav.net/documents/),
+  refer to the user manual on [ClamAV.net](https://docs.clamav.net/),
   and keep an eye out for a new blog post on the topic
 - The `freshclam` database update utility has undergone a significant update.
   This includes:
@@ -700,7 +700,7 @@ changes.
   This was necessary because the UnEgg library's license includes restrictions
   limiting the commercial use of the UnEgg library.
 - The documentation has moved!
-  - Users should navigate to [ClamAV.net](http://www.clamav.net/documents/)
+  - Users should navigate to [ClamAV.net](https://docs.clamav.net/)
     to view the documentation online.
   - The documentation will continue to be provided in HTML format with each
     release for offline viewing in the `docs/html` directory.
@@ -2031,7 +2031,7 @@ The following are the key features of this release:
   phishing and malware sites. The ClamAV Project distributes a constantly
   updated Safe Browsing database, which can be automatically fetched by
   freshclam. For more information, please see freshclam.conf(5) and
-  https://www.clamav.net/documents/safebrowsing.
+  https://docs.clamav.net/faq/faq-safebrowsing.html.
 
 - New clamav-milter: The program has been redesigned and rewritten from
   scratch. The most notable difference is that the internal mode has been
@@ -3265,7 +3265,6 @@ the highest possible level.
 New mirroring mechanisms. Luca Gibelli (ClamAV) and mirror administrators
 (22 sites) are converting mirrors to new "push mirroring"
 method. It uses advanced techniques to ensure all the mirrors are up to date.
-More info: https://www.clamav.net/documents/introduction
 
 We would like to thank our donors:
 

--- a/README.md
+++ b/README.md
@@ -18,18 +18,14 @@
 ## Documentation & FAQ
 
 Official documentation can be found online at
-[ClamAV.net](https://www.clamav.net/documents).
+[ClamAV.net](https://docs.clamav.net/).
 Our source code release tarballs also includes a copy of the documentation for
 [offline](docs/html/UserManual.html) reading.
 
 ## ClamAV Signatures
 
-Anyone can learn to read and write ClamAV signatures. Take a look
-at the
-[signature writing documentation](https://www.clamav.net/documents/creating-signatures-for-clamav)
-and
-[phishing signature writing documentation](https://www.clamav.net/documents/phishsigs)
-to get started!
+Anyone can learn to read and write ClamAV signatures. To get started, see our
+[signature writing documentation](https://docs.clamav.net/manual/Signatures.html).
 
 ## Installation Instructions
 

--- a/common/optparser.c
+++ b/common/optparser.c
@@ -359,7 +359,7 @@ const struct clam_option __clam_options[] = {
 
     {"DetectPUA", "detect-pua", 0, CLOPT_TYPE_BOOL, MATCH_BOOL, 0, NULL, 0, OPT_CLAMD | OPT_CLAMSCAN, "Detect Potentially Unwanted Applications.", "yes"},
 
-    {"ExcludePUA", "exclude-pua", 0, CLOPT_TYPE_STRING, NULL, -1, NULL, FLAG_MULTIPLE, OPT_CLAMD | OPT_CLAMSCAN, "Exclude a specific PUA category. This directive can be used multiple times.\nSee https://www.clamav.net/documents/potentially-unwanted-applications-pua for the complete list of PUA\ncategories.", "NetTool\nPWTool"},
+    {"ExcludePUA", "exclude-pua", 0, CLOPT_TYPE_STRING, NULL, -1, NULL, FLAG_MULTIPLE, OPT_CLAMD | OPT_CLAMSCAN, "Exclude a specific PUA category. This directive can be used multiple times.\nSee https://docs.clamav.net/faq/faq-pua.html for the complete list of PUA\ncategories.", "NetTool\nPWTool"},
 
     {"IncludePUA", "include-pua", 0, CLOPT_TYPE_STRING, NULL, -1, NULL, FLAG_MULTIPLE, OPT_CLAMD | OPT_CLAMSCAN, "Only include a specific PUA category. This directive can be used multiple\ntimes.", "Spy\nScanner\nRAT"},
 

--- a/libclamav/blob.c
+++ b/libclamav/blob.c
@@ -479,11 +479,11 @@ void fileblobDestroy(fileblob *fb)
     } else if (fb->b.data) {
         free(fb->b.data);
         if (fb->b.name) {
-            cli_errmsg("fileblobDestroy: %s not saved: report to https://bugzilla.clamav.net\n",
+            cli_errmsg("fileblobDestroy: %s not saved: report to https://github.com/Cisco-Talos/clamav/issues\n",
                        (fb->fullname) ? fb->fullname : fb->b.name);
             free(fb->b.name);
         } else
-            cli_errmsg("fileblobDestroy: file not saved (%lu bytes): report to https://bugzilla.clamav.net\n",
+            cli_errmsg("fileblobDestroy: file not saved (%lu bytes): report to https://github.com/Cisco-Talos/clamav/issues\n",
                        (unsigned long)fb->b.len);
     }
     if (fb->fullname)

--- a/libclamav/builtin_bytecodes.h
+++ b/libclamav/builtin_bytecodes.h
@@ -147,7 +147,7 @@ int entrypoint()
         else
           /* RWX mapping got denied but apparently not due to SELinux/PaX */
           disable_jit_if("^RWX mapping denied for unknown reason."
-            "Please report to https://bugzilla.clamav.net\n", 0, 1);
+            "Please report to https://github.com/Cisco-Talos/clamav/issues\n", 0, 1);
       }
     } else {
       if ((env.os_category == os_linux || env.os == llvm_os_Linux) &&

--- a/libclamav/bytecode.c
+++ b/libclamav/bytecode.c
@@ -2662,7 +2662,7 @@ int cli_bytecode_prepare2(struct cl_engine *engine, struct cli_all_bc *bcs, unsi
     }
     rc = run_builtin_or_loaded(bcs, BC_STARTUP, builtin_bc_startup, ctx, "BC_STARTUP");
     if (rc != CL_SUCCESS) {
-        cli_warnmsg("Bytecode: BC_STARTUP failed to run, disabling ALL bytecodes! Please report to https://bugzilla.clamav.net\n");
+        cli_warnmsg("Bytecode: BC_STARTUP failed to run, disabling ALL bytecodes! Please report to https://github.com/Cisco-Talos/clamav/issues\n");
         ctx->bytecode_disable_status = 2;
     } else {
         cli_dbgmsg("Bytecode: disable status is %d\n", ctx->bytecode_disable_status);
@@ -2670,7 +2670,7 @@ int cli_bytecode_prepare2(struct cl_engine *engine, struct cli_all_bc *bcs, unsi
         /* check magic number, don't use 0 here because it is too easy for a
 	 * buggy bytecode to return 0 */
         if ((unsigned int)rc != (unsigned int)0xda7aba5e) {
-            cli_warnmsg("Bytecode: selftest failed with code %08x. Please report to https://bugzilla.clamav.net\n",
+            cli_warnmsg("Bytecode: selftest failed with code %08x. Please report to https://github.com/Cisco-Talos/clamav/issues\n",
                         rc);
             if (engine->bytecode_mode == CL_BYTECODE_MODE_TEST)
                 return CL_EBYTECODE_TESTFAIL;

--- a/libclamav/c++/detect.cpp
+++ b/libclamav/c++/detect.cpp
@@ -44,7 +44,7 @@ static void warn_assumptions(const char *msg, int a, int b)
 {
     errs() << "LibClamAV Warning: libclamav and llvm make inconsistent "
            << "assumptions about " << msg << ": " << a << " and " << b << "."
-           << "Please report to https://bugzilla.clamav.net\n";
+           << "Please report to https://github.com/Cisco-Talos/clamav/issues\n";
 }
 
 #define CASE_OS(theos, compat)                                                     \

--- a/libclamav/cvd.c
+++ b/libclamav/cvd.c
@@ -670,7 +670,7 @@ int cli_cvdload(FILE *fs, struct cl_engine *engine, unsigned int *signo, unsigne
     if (cvd.fl > cl_retflevel()) {
         cli_warnmsg("*******************************************************************\n");
         cli_warnmsg("***  This version of the ClamAV engine is outdated.             ***\n");
-        cli_warnmsg("***   Read https://www.clamav.net/documents/installing-clamav   ***\n");
+        cli_warnmsg("***   Read https://docs.clamav.net/manual/Installing.html       ***\n");
         cli_warnmsg("*******************************************************************\n");
     }
 

--- a/libclamav/mpool.c
+++ b/libclamav/mpool.c
@@ -626,7 +626,7 @@ void *mpool_malloc(struct MP *mp, size_t size)
 
     /*  check_all(mp); */
     if (!size || sbits == FRAGSBITS) {
-        cli_errmsg("mpool_malloc(): Attempt to allocate %lu bytes. Please report to https://bugzilla.clamav.net\n", (unsigned long)size);
+        cli_errmsg("mpool_malloc(): Attempt to allocate %lu bytes. Please report to https://github.com/Cisco-Talos/clamav/issues\n", (unsigned long)size);
         return NULL;
     }
 
@@ -651,7 +651,7 @@ void *mpool_malloc(struct MP *mp, size_t size)
     }
 
     if (!(needed = from_bits(sbits))) {
-        cli_errmsg("mpool_malloc(): Attempt to allocate %lu bytes. Please report to https://bugzilla.clamav.net\n", (unsigned long)size);
+        cli_errmsg("mpool_malloc(): Attempt to allocate %lu bytes. Please report to https://github.com/Cisco-Talos/clamav/issues\n", (unsigned long)size);
         return NULL;
     }
 
@@ -735,7 +735,7 @@ void *mpool_realloc(struct MP *mp, void *ptr, size_t size)
     if (!ptr) return mpool_malloc(mp, size);
 
     if (!size || !(csize = from_bits(f->u.a.sbits))) {
-        cli_errmsg("mpool_realloc(): Attempt to allocate %lu bytes. Please report to https://bugzilla.clamav.net\n", (unsigned long)size);
+        cli_errmsg("mpool_realloc(): Attempt to allocate %lu bytes. Please report to https://github.com/Cisco-Talos/clamav/issues\n", (unsigned long)size);
         return NULL;
     }
     csize -= FRAG_OVERHEAD + f->u.a.padding;
@@ -789,7 +789,7 @@ char *cli_mpool_strdup(mpool_t *mp, const char *s)
     size_t strsz;
 
     if (s == NULL) {
-        cli_errmsg("cli_mpool_strdup(): s == NULL. Please report to https://bugzilla.clamav.net\n");
+        cli_errmsg("cli_mpool_strdup(): s == NULL. Please report to https://github.com/Cisco-Talos/clamav/issues\n");
         return NULL;
     }
 
@@ -808,7 +808,7 @@ char *cli_mpool_strndup(mpool_t *mp, const char *s, size_t n)
     size_t strsz;
 
     if (s == NULL) {
-        cli_errmsg("cli_mpool_strndup(): s == NULL. Please report to https://bugzilla.clamav.net\n");
+        cli_errmsg("cli_mpool_strndup(): s == NULL. Please report to https://github.com/Cisco-Talos/clamav/issues\n");
         return NULL;
     }
 

--- a/libclamav/others_common.c
+++ b/libclamav/others_common.c
@@ -190,7 +190,7 @@ void *cli_malloc(size_t size)
     void *alloc;
 
     if (!size || size > CLI_MAX_ALLOCATION) {
-        cli_errmsg("cli_malloc(): Attempt to allocate %lu bytes. Please report to https://bugzilla.clamav.net\n", (unsigned long int)size);
+        cli_errmsg("cli_malloc(): Attempt to allocate %lu bytes. Please report to https://github.com/Cisco-Talos/clamav/issues\n", (unsigned long int)size);
         return NULL;
     }
 
@@ -209,7 +209,7 @@ void *cli_calloc(size_t nmemb, size_t size)
     void *alloc;
 
     if (!nmemb || !size || size > CLI_MAX_ALLOCATION || nmemb > CLI_MAX_ALLOCATION || (nmemb * size > CLI_MAX_ALLOCATION)) {
-        cli_errmsg("cli_calloc(): Attempt to allocate %lu bytes. Please report to https://bugzilla.clamav.net\n", (unsigned long int)nmemb * size);
+        cli_errmsg("cli_calloc(): Attempt to allocate %lu bytes. Please report to https://github.com/Cisco-Talos/clamav/issues\n", (unsigned long int)nmemb * size);
         return NULL;
     }
 
@@ -228,7 +228,7 @@ void *cli_realloc(void *ptr, size_t size)
     void *alloc;
 
     if (!size || size > CLI_MAX_ALLOCATION) {
-        cli_errmsg("cli_realloc(): Attempt to allocate %lu bytes. Please report to https://bugzilla.clamav.net\n", (unsigned long int)size);
+        cli_errmsg("cli_realloc(): Attempt to allocate %lu bytes. Please report to https://github.com/Cisco-Talos/clamav/issues\n", (unsigned long int)size);
         return NULL;
     }
 
@@ -247,7 +247,7 @@ void *cli_realloc2(void *ptr, size_t size)
     void *alloc;
 
     if (!size || size > CLI_MAX_ALLOCATION) {
-        cli_errmsg("cli_realloc2(): Attempt to allocate %lu bytes. Please report to https://bugzilla.clamav.net\n", (unsigned long int)size);
+        cli_errmsg("cli_realloc2(): Attempt to allocate %lu bytes. Please report to https://github.com/Cisco-Talos/clamav/issues\n", (unsigned long int)size);
         return NULL;
     }
 
@@ -268,7 +268,7 @@ char *cli_strdup(const char *s)
     char *alloc;
 
     if (s == NULL) {
-        cli_errmsg("cli_strdup(): s == NULL. Please report to https://bugzilla.clamav.net\n");
+        cli_errmsg("cli_strdup(): s == NULL. Please report to https://github.com/Cisco-Talos/clamav/issues\n");
         return NULL;
     }
 

--- a/libfreshclam/libfreshclam.c
+++ b/libfreshclam/libfreshclam.c
@@ -561,7 +561,7 @@ fc_error_t fc_dns_query_update_info(
 
                 logg("^Your ClamAV installation is OUTDATED!\n");
                 logg("^Local version: %s Recommended version: %s\n", version_string, reply_token);
-                logg("DON'T PANIC! Read https://www.clamav.net/documents/upgrading-clamav\n");
+                logg("DON'T PANIC! Read https://docs.clamav.net/manual/Installing.html\n");
                 *newVersion = cli_strdup(reply_token);
             }
         }
@@ -674,7 +674,7 @@ fc_error_t fc_update_database(
                     logg("   a. Running an up-to-date version of FreshClam\n");
                     logg("   b. Running FreshClam no more than once an hour\n");
                     logg("   c. If you have checked (a) and (b), please open a ticket at\n");
-                    logg("      https://bugzilla.clamav.net under the 'Mirrors' component\n");
+                    logg("      https://github.com/Cisco-Talos/clamav/issues\n");
                     logg("      and we will investigate why your network is blocked.\n");
                     status = ret;
                     goto done;
@@ -880,7 +880,7 @@ fc_error_t fc_download_url_database(
                 logg("   a. Running an up-to-date version of FreshClam\n");
                 logg("   b. Running FreshClam no more than once an hour\n");
                 logg("   c. If you have checked (a) and (b), please open a ticket at\n");
-                logg("      https://bugzilla.clamav.net under the 'Mirrors' component\n");
+                logg("      https://github.com/Cisco-Talos/clamav/issues\n");
                 logg("      and we will investigate why your network is blocked.\n");
                 status = ret;
                 goto done;

--- a/unit_tests/testcase.py
+++ b/unit_tests/testcase.py
@@ -294,7 +294,7 @@ class TestCase(unittest.TestCase):
         except AssertionError:
             self.log.warning("*" * 69)
             self.log.warning('Valgrind test failed!'.center(69, ' '))
-            self.log.warning('Please submit this log to https://bugzilla.clamav.net:'.center(69, ' '))
+            self.log.warning('Please submit this log to https://github.com/Cisco-Talos/clamav/issues:'.center(69, ' '))
             self.log.warning(str(log_file).center(69, ' '))
             self.log.warning("*" * 69)
             errors = True


### PR DESCRIPTION
Replace new bugzilla ticket links with links to github issues.
Replace clamav.net/documentation links with docs.clamav.net equivalents.