### PR TITLE
OLE2: don't fail scan if XLM extraction had an error

### DIFF
--- a/libclamav/entconv.c
+++ b/libclamav/entconv.c
@@ -1028,7 +1028,7 @@ cl_error_t cli_codepage_to_utf8(char* in, size_t in_size, uint16_t codepage, cha
                             cli_warnmsg("cli_codepage_to_utf8: iconv error: An invalid multibyte sequence has been encountered in the input.\n");
                             break;
                         case EINVAL:
-                            cli_warnmsg("cli_codepage_to_utf8: iconv error: An incomplete multibyte sequence has been encountered in the input.\n");
+                            cli_dbgmsg("cli_codepage_to_utf8: iconv error: An incomplete multibyte sequence has been encountered in the input.\n");
                             break;
                         default:
                             cli_warnmsg("cli_codepage_to_utf8: iconv error: Unexpected error code %d.\n", errno);

--- a/libclamav/xlm_extract.c
+++ b/libclamav/xlm_extract.c
@@ -4187,7 +4187,7 @@ static cl_error_t parse_formula(FILE *out_file, char data[], unsigned data_size)
                 break;
             }
             default:
-                if (ptg < sizeof(TOKENS)) {
+                if (ptg < sizeof(TOKENS) / sizeof(char*)) {
                     cli_dbgmsg("[cli_extract_xlm_macros_and_images:parse_formula] Encountered unexpected ptg token: %s\n", TOKENS[ptg]);
                 } else {
                     cli_dbgmsg("[cli_extract_xlm_macros_and_images:parse_formula] Encountered unknown ptg token: 0x%02x\n", ptg);
@@ -4662,7 +4662,9 @@ cl_error_t cli_extract_xlm_macros_and_images(const char *dir, cli_ctx *ctx, char
 
     if (in_fd == -1) {
         cli_dbgmsg("[cli_extract_xlm_macros_and_images] Failed to open input file\n");
-        ret = CL_EACCES;
+        /* Don't return an error. If the file is missing, an error probably occured
+         * earlier, such as a UTF8 conversion error in parse_formula() and so the file was never written.
+         * There are no macros to scan, so report SUCCESS / CLEAN. */
         goto done;
     }
 


### PR DESCRIPTION
This PR is to address the only issue I found in the regression test we ran this last weekend.
See CLAM-1521

---

A bug introduced in the OLE2 BIFF XLM & image extraction code is causing
some file scans to fail when part of the macro extraction fails, such as
failing to transcode UTF16LE (Windows unicode) macros to UTF-8.

This commit allows scanning to continue without failing out if the
expected BIFF temp files aren't found.

I also changed the cli_codepage_to_utf8() "incomplete multibyte
sequence" warning to be a debug message, because it is too common, and
too verbose.