### PR TITLE
CLAM 1525: Fixed freshclam network path renaming bug

### DIFF
--- a/libfreshclam/libfreshclam_internal.c
+++ b/libfreshclam/libfreshclam_internal.c
@@ -1794,7 +1794,7 @@ static fc_error_t buildcld(
         }
     }
 
-    if (NULL == (dir = opendir("."))) {
+    if (NULL == (dir = opendir(tmpdir))) {
         logg("!buildcld: Can't open directory %s\n", tmpdir);
         status = FC_EDIRECTORY;
         goto done;

--- a/win32/compat/w32_stat.c
+++ b/win32/compat/w32_stat.c
@@ -214,3 +214,14 @@ int w32_access(const char *pathname, int mode)
     free(wpath);
     return ret;
 }
+
+#undef rename
+int w32_rename(const char *oldname, const char *newname)
+{
+    DWORD dwAttrs = GetFileAttributes(newname);
+    SetFileAttributes(newname, dwAttrs & ~(FILE_ATTRIBUTE_READONLY | FILE_ATTRIBUTE_HIDDEN));
+    if (!DeleteFileA(newname) && (GetLastError() != ERROR_FILE_NOT_FOUND)) {
+        return -1;
+    }
+    return rename(oldname, newname);
+}

--- a/win32/compat/w32_stat.c
+++ b/win32/compat/w32_stat.c
@@ -202,16 +202,32 @@ int w32_stat(const char *path, struct stat *buf)
 
 int w32_access(const char *pathname, int mode)
 {
-    wchar_t *wpath = uncpath(pathname);
     int ret;
+    HANDLE hFile          = INVALID_HANDLE_VALUE;
+    DWORD dwDesiredAccess = GENERIC_READ;
 
-    if (!wpath) {
-        errno = ENOMEM;
-        return -1;
+    if (W_OK & mode) {
+        dwDesiredAccess = dwDesiredAccess | GENERIC_WRITE;
     }
 
-    ret = _waccess(wpath, mode);
-    free(wpath);
+    hFile = CreateFileA(pathname, // file to open
+                        dwDesiredAccess,
+                        FILE_SHARE_READ,            // share for reading
+                        NULL,                       // default security
+                        OPEN_EXISTING,              // existing file only
+                        FILE_FLAG_BACKUP_SEMANTICS, // may be a directory
+                        NULL);
+    if (hFile == INVALID_HANDLE_VALUE) {
+        if (GetLastError() == ERROR_ACCESS_DENIED) {
+            _set_errno(EACCES);
+        } else {
+            _set_errno(ENOENT);
+        }
+        ret = -1;
+    } else {
+        CloseHandle(hFile);
+        ret = 0;
+    }
     return ret;
 }
 

--- a/win32/compat/w32_stat.h
+++ b/win32/compat/w32_stat.h
@@ -43,6 +43,7 @@ int w32_stat(const char *path, struct stat *buf);
 int w32_access(const char *pathname, int mode);
 
 #define access(pathname, mode) w32_access(pathname, mode)
+#define rename w32_rename
 
 wchar_t *uncpath(const char *path);
 int safe_open(const char *path, int flags, ...);


### PR DESCRIPTION
Fixed freshclam bug that, when using network paths, wouldn't allow temp files to be renamed. Cause: rename() doesn't work on Windows if the destination file already exists. 
Redefined rename() to w32_rename() on Windows.