### PR TITLE
gh-184 Fix segfault and socket fd leak

### DIFF
--- a/clamonacc/client/client.c
+++ b/clamonacc/client/client.c
@@ -139,6 +139,7 @@ int onas_check_remote(struct onas_context **ctx, cl_error_t *err)
             } else {
                 logg("!ClamClient: Could not connect to clamd, %s\n", curl_easy_strerror(curlcode));
             }
+            curl_easy_cleanup(curl);
             *err = CL_EARG;
             return ret;
         }
@@ -399,7 +400,6 @@ CURLcode onas_curl_init(CURL **curl, const char *ipaddr, int64_t port, int64_t t
         curl_easy_cleanup(*curl);
         return curlcode;
     }
-
     return curlcode;
 }
 
@@ -512,6 +512,7 @@ int onas_get_clamd_version(struct onas_context **ctx)
     curlcode = curl_easy_perform(curl);
     if (CURLE_OK != curlcode) {
         logg("*ClamClient: could not connect to clamd, %s\n", curl_easy_strerror(curlcode));
+        curl_easy_cleanup(curl);
         return 2;
     }
 
@@ -574,6 +575,7 @@ int onas_client_scan(const char *tcpaddr, int64_t portnum, int32_t scantype, uin
             logg("!ClamClient: Connection to clamd failed, %s.\n", curl_easy_strerror(curlcode));
             disconnected = true;
         }
+        curl_easy_cleanup(curl);
         return CL_ECREAT;
     }
     if (disconnected) {

--- a/clamonacc/client/socket.c
+++ b/clamonacc/client/socket.c
@@ -78,7 +78,7 @@ int onas_get_sockd()
 
 #ifdef HAVE_FD_PASSING
 
-    int sockd;
+    int sockd = 0;
     if (onas_sock.written && (sockd = socket(AF_UNIX, SOCK_STREAM, 0)) >= 0) {
         if (connect(sockd, (struct sockaddr *)&onas_sock.sock, sizeof(onas_sock.sock)) == 0)
             return sockd;

--- a/clamonacc/misc/utils.c
+++ b/clamonacc/misc/utils.c
@@ -104,15 +104,15 @@ int onas_fan_checkowner(int pid, const struct optstruct *opts)
                                 break;
                             case EMFILE:
                             case ENFILE:
-                                if (0 == retry) {
+                                if (3 >= retry) {
                                     logg("*ClamMisc: waiting for consumer thread to catch up then retrying ...\n");
-                                    sleep(3);
-                                    retry = 1;
+                                    sleep(6);
+                                    retry += 1;
                                     continue;
                                 } else {
                                     logg("*ClamMisc: fds have been exhausted ... attempting to force the consumer thread to catch up ... (excluding for safety)\n");
                                     pthread_cond_signal(&onas_scan_queue_empty_cond);
-                                    sleep(3);
+                                    sleep(6);
                                     return CHK_FOUND;
                                 }
                             case ERANGE:

--- a/clamonacc/scan/onas_queue.c
+++ b/clamonacc/scan/onas_queue.c
@@ -189,7 +189,7 @@ static int onas_consume_event(threadpool thpool)
 {
     pthread_mutex_lock(&onas_queue_lock);
 
-    if (onas_queue_is_b_empty()) {
+    while (onas_queue_is_b_empty()) {
         pthread_cond_wait(&onas_scan_queue_empty_cond, &onas_queue_lock);
     }
 


### PR DESCRIPTION
This fixes a fatal issue that would occur when unable to queue events due to
clamonacc improperly using all available fds.

It also fixes the core fd socket leak issue at the heart of the segfault by
properly cleaning up after a failed curl connection.