### PR TITLE
CLAM-1535: Long file path support on Windows

### DIFF
--- a/clamd/CMakeLists.txt
+++ b/clamd/CMakeLists.txt
@@ -31,7 +31,10 @@ target_sources( clamd
         thrmgr.c
         thrmgr.h )
 if(WIN32)
-    target_sources( clamd PRIVATE ${CMAKE_SOURCE_DIR}/win32/res/clamd.rc )
+    target_sources( clamd 
+    PRIVATE 
+        ${CMAKE_SOURCE_DIR}/win32/res/clamd.rc
+        ${CMAKE_SOURCE_DIR}/win32/res/clam.manifest )
 endif()
 target_include_directories( clamd
     PRIVATE ${CMAKE_BINARY_DIR} # For clamav-config.h

--- a/clamdscan/CMakeLists.txt
+++ b/clamdscan/CMakeLists.txt
@@ -20,7 +20,10 @@ target_sources( clamdscan
         proto.c
         proto.h )
 if(WIN32)
-    target_sources( clamdscan PRIVATE ${CMAKE_SOURCE_DIR}/win32/res/clamdscan.rc )
+    target_sources( clamdscan 
+    PRIVATE 
+        ${CMAKE_SOURCE_DIR}/win32/res/clamdscan.rc
+        ${CMAKE_SOURCE_DIR}/win32/res/clam.manifest )
 endif()
 target_include_directories( clamdscan
     PRIVATE ${CMAKE_BINARY_DIR} # For clamav-config.h

--- a/clamscan/CMakeLists.txt
+++ b/clamscan/CMakeLists.txt
@@ -19,7 +19,10 @@ target_sources( clamscan
         manager.h
         global.h )
 if(WIN32)
-    target_sources( clamscan PRIVATE ${CMAKE_SOURCE_DIR}/win32/res/clamscan.rc )
+    target_sources( clamscan 
+    PRIVATE 
+        ${CMAKE_SOURCE_DIR}/win32/res/clamscan.rc 
+        ${CMAKE_SOURCE_DIR}/win32/res/clam.manifest )
 endif()
 target_include_directories( clamscan
     PRIVATE ${CMAKE_BINARY_DIR} # For clamav-config.h

--- a/freshclam/CMakeLists.txt
+++ b/freshclam/CMakeLists.txt
@@ -20,7 +20,10 @@ target_sources( freshclam-bin
         notify.c
         notify.h )
 if(WIN32)
-    target_sources( freshclam-bin PRIVATE ${CMAKE_SOURCE_DIR}/win32/res/freshclam.rc )
+    target_sources( freshclam-bin 
+        PRIVATE 
+            ${CMAKE_SOURCE_DIR}/win32/res/freshclam.rc
+            ${CMAKE_SOURCE_DIR}/win32/res/clam.manifest )
 endif()
 set_target_properties( freshclam-bin PROPERTIES COMPILE_FLAGS "${WARNCFLAGS}" )
 target_link_libraries(freshclam-bin

--- a/win32/res/clam.manifest
+++ b/win32/res/clam.manifest
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0"> 
+    <application xmlns="urn:schemas-microsoft-com:asm.v3">
+        <windowsSettings xmlns:ws2="http://schemas.microsoft.com/SMI/2016/WindowsSettings">
+            <ws2:longPathAware>true</ws2:longPathAware>
+        </windowsSettings>
+    </application>
+</assembly>


### PR DESCRIPTION
via clam.manifest in win32/res. Opts into new Windows behavior that
does not have file path limitations.
Only works on Windows 10. In addition, you must set the registry key
"LongPathsEnabled" to  1.
(as described here: https://docs.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=powershell)