### PR TITLE
CLAM-1531: Fix clamdscan directory scan on Windows

### DIFF
--- a/libclamav/others.h
+++ b/libclamav/others.h
@@ -993,6 +993,19 @@ cl_error_t cli_ftw(char *base, int flags, int maxdepth, cli_ftw_cb callback, str
 
 const char *cli_strerror(int errnum, char *buf, size_t len);
 
+#ifdef _WIN32
+/**
+ * @brief   Attempt to get a filename from an open file handle.
+ * 
+ * Windows only.
+ *
+ * @param hFile          File handle
+ * @param[out] filepath  Will be set to file path if found, or NULL.
+ * @return cl_error_t    CL_SUCCESS if found, else an error code.
+ */
+cl_error_t cli_get_filepath_from_handle(HANDLE hFile, char **filepath);
+#endif
+
 /**
  * @brief   Attempt to get a filename from an open file descriptor.
  *

--- a/libclamav/others_common.c
+++ b/libclamav/others_common.c
@@ -1461,7 +1461,7 @@ cl_error_t cli_realpath(const char *file_name, char **real_filename)
     char *real_file_path = NULL;
     cl_error_t status    = CL_EARG;
 #ifdef _WIN32
-    int desc = -1;
+    HANDLE hFile = INVALID_HANDLE_VALUE;
 #endif
 
     cli_dbgmsg("Checking realpath of %s\n", file_name);
@@ -1482,8 +1482,6 @@ cl_error_t cli_realpath(const char *file_name, char **real_filename)
     status = CL_SUCCESS;
 
 #else
-
-    HANDLE hFile;
     hFile = CreateFileA(file_name,                  // file to open
                         GENERIC_READ,               // open for reading
                         FILE_SHARE_READ,            // share for reading
@@ -1506,8 +1504,8 @@ cl_error_t cli_realpath(const char *file_name, char **real_filename)
 done:
 
 #ifdef _WIN32
-    if (-1 != desc) {
-        close(desc);
+    if (hFile != INVALID_HANDLE_VALUE) {
+        CloseHandle(hFile);
     }
 #endif
 


### PR DESCRIPTION
Cause: _wopen on Windows doesn't work on directories and gives a Permission Denied error.
Old approach used _wopen to get a file descriptor and gets the
realpath from that. New approach redefines realpath() to _fullpath
on Windows, removing the use of _wopen in clamdscan on directories.

_fullpath: https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/fullpath-wfullpath?view=msvc-160