### PR TITLE
cmake/FindIconv.cmake: fix return type in test code

### DIFF
--- a/cmake/FindIconv.cmake
+++ b/cmake/FindIconv.cmake
@@ -91,6 +91,7 @@ if(NOT DEFINED Iconv_IS_BUILT_IN)
         ic = iconv_open(\"to\", \"from\");
         iconv(ic, &a, &i, &b, &j);
         iconv_close(ic);
+        return 0;
       }
       "
     )


### PR DESCRIPTION
In openSUSE Tumbleweed, this test always fails because it compiles with `-Werror=return-type` by default. Fixing this by adding a return value in the test script to keep the compiler happy.