### PR TITLE
Fix clamd_valgrind tests when built with clang-8

### DIFF
--- a/libclamav/cpio.c
+++ b/libclamav/cpio.c
@@ -191,12 +191,14 @@ leave:
 int cli_scancpio_odc(cli_ctx *ctx)
 {
     struct cpio_hdr_odc hdr_odc;
-    char name[513], buff[12];
+    char name[513] = {0}, buff[12] = {0};
     unsigned int file = 0, trailer = 0;
-    uint32_t filesize, namesize, hdr_namesize;
+    uint32_t filesize = 0, namesize = 0, hdr_namesize = 0;
     int ret         = CL_CLEAN;
     size_t pos      = 0;
     int virus_found = 0;
+
+    memset(&hdr_odc, 0, sizeof(hdr_odc));
 
     while (fmap_readn(*ctx->fmap, &hdr_odc, pos, sizeof(hdr_odc)) == sizeof(hdr_odc)) {
         pos += sizeof(hdr_odc);

--- a/libclamav/matcher.c
+++ b/libclamav/matcher.c
@@ -329,9 +329,9 @@ cl_error_t cli_scan_buff(const unsigned char *buffer, uint32_t length, uint32_t 
  */
 cl_error_t cli_caloff(const char *offstr, const struct cli_target_info *info, unsigned int target, uint32_t *offdata, uint32_t *offset_min, uint32_t *offset_max)
 {
-    char offcpy[65];
-    unsigned int n, val;
-    char *pt;
+    char offcpy[65] = {0};
+    unsigned int n = 0, val = 0;
+    char *pt = NULL;
 
     if (!info) { /* decode offset string */
         if (!offstr) {


### PR DESCRIPTION
Since strcpy only writes a null-byte to the first terminating byte,
valgrind is throwing errors about uninitialized reads for strncpy's
that could potentially read beyond the null-byte.  Initializing
the whole array to 0 resolves this.