### PR TITLE
Tests: tune valgrind suppression rule

### DIFF
--- a/unit_tests/valgrind.supp
+++ b/unit_tests/valgrind.supp
@@ -299,8 +299,6 @@
    fun:allocate_stack
    ...
    fun:thrmgr_dispatch_internal
-   fun:thrmgr_group_dispatch
-   fun:dispatch_command
    ...
 }
 {


### PR DESCRIPTION
Handle the case where thrmgr_dispatch_internal was called from somewhere
other than thrmgr_group_dispatch, triggering the valgrind supression
rule.