### PR TITLE
0.104 install docs cleanup and flevel bump

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,179 +1,372 @@
-# Installation Instructions
+# Installing ClamAV
 
-As of ClamAV 0.104, CMake is required to build ClamAV.
-The Windows Visual Studio and Autotools build systems have been removed.
+See our online documentation for installation instructions:
+- [Installing ClamAV Main Page](https://docs.clamav.net/manual/Installing.html)
+- [Third Party Package Installation](https://docs.clamav.net/manual/Installing/Packages.html)
 
-_Known Issues / To-do:_
+**For step-by-step compiling instructions** for each major operating system
+and distribution, see:
+- [Unix/Linux/Mac Instructions](https://docs.clamav.net/manual/Installing/Installing-from-source-Unix.html)
+- [Windows Instructions](https://docs.clamav.net/manual/Installing/Installing-from-source-Windows.html)
+
+You can find additional tips for development builds in our
+[online documentation](https://docs.clamav.net/manual/Development/development-builds.html).
+
+> _Tip_: If you have a source tarball from an official release, you can find
+> a copy of the online documentation in the `docs/html` directory.
+
+The rest of this document serves as a reference, detailing each of the build
+configuration options.
+
+**Table Of Contents**
+
+- [Installing ClamAV](#installing-clamav)
+  - [Known Issues / To-do's:](#known-issues--to-dos)
+  - [Build Requirements](#build-requirements)
+    - [Build Tools](#build-tools)
+    - [External Library Dependencies](#external-library-dependencies)
+      - [libclamav dependencies](#libclamav-dependencies)
+      - [libfreshclam dependencies](#libfreshclam-dependencies)
+      - [Program dependencies](#program-dependencies)
+  - [Getting Started](#getting-started)
+  - [CMake Basics](#cmake-basics)
+    - [CMake Generators](#cmake-generators)
+    - [CMake Build Types](#cmake-build-types)
+    - [Customizing the Install Directories](#customizing-the-install-directories)
+    - [Running the Public Test Suite](#running-the-public-test-suite)
+  - [Custom CMake Config Options](#custom-cmake-config-options)
+  - [External Library Depedency Configuration Options](#external-library-depedency-configuration-options)
+    - [`libcheck`](#libcheck)
+    - [`bzip2`](#bzip2)
+    - [`zlib`](#zlib)
+    - [`libxml2`](#libxml2)
+    - [`libpcre2`](#libpcre2)
+    - [`openssl` (`libcrypto`, `libssl`)](#openssl-libcrypto-libssl)
+    - [`libjson-c`](#libjson-c)
+    - [`libmspack`](#libmspack)
+    - [`iconv` (POSIX-only)](#iconv-posix-only)
+    - [`pthreads-win32` (Windows-only)](#pthreads-win32-windows-only)
+    - [`llvm` (optional, _see "Bytecode Runtime" section_)](#llvm-optional-see-bytecode-runtime-section)
+    - [`libcurl`](#libcurl)
+    - [`ncurses` or `pdcurses`, for `clamdtop`](#ncurses-or-pdcurses-for-clamdtop)
+    - [Bytecode Runtime](#bytecode-runtime)
+  - [Compiling For Multiple Architectures (Cross-Compiling)](#compiling-for-multiple-architectures-cross-compiling)
+  - [Un-install](#un-install)
+
+## Known Issues / To-do's:
 
 - The newest LLVM version supported is 3.6.2. We ran out of time during 0.104
   development to add support for newer versions of LLVM.
   The bytecode interpreter is therefore the default option for the bytecode
   signature runtime in this release.
+
 - Complete the `MAINTAINER_MODE` option to generate jsparse files with GPerf.
-- The test suite will fail to run if you have `pytest` from Python 2 installed
-  and you don't have `pytest` from Python 3 installed. If this happens, run:
+
+- The test suite will fail to run if you have `pytest` from Python2 installed
+  and you don't have `pytest` from Python3 installed. If this happens, run:
   `python3 -m pip install pytest` and then delete your build directory before
   recompiling clamav and trying again.
 
-**Table Of Contents**
+- The documentation generated using Doxygen isn't very good.
 
-- [Installation Instructions](#installation-instructions)
-  - [CMake Basics](#cmake-basics)
-    - [Build requirements](#build-requirements)
-    - [Optional build requirements (Maintainer-Mode)](#optional-build-requirements-maintainer-mode)
-    - [Basic Release build & system install](#basic-release-build--system-install)
-    - [Basic Debug build](#basic-debug-build)
-    - [Build and install to a specific install location (prefix)](#build-and-install-to-a-specific-install-location-prefix)
-    - [Build using Ninja](#build-using-ninja)
-    - [Build and run tests](#build-and-run-tests)
-  - [Custom CMake options](#custom-cmake-options)
-  - [Custom Library Paths](#custom-library-paths)
-    - [Example Build Commands](#example-build-commands)
-      - [Linux release build, install to system](#linux-release-build-install-to-system)
-      - [macOS debug build, custom OpenSSL path, build examples, local install](#macos-debug-build-custom-openssl-path-build-examples-local-install)
-      - [Windows builds](#windows-builds)
-        - [Windows build (with Mussels)](#windows-build-with-mussels)
-        - [Windows build (with vcpkg)](#windows-build-with-vcpkg)
-        - [Build the Installer](#build-the-installer)
-    - [External Depedencies](#external-depedencies)
-      - [libclamav dependencies](#libclamav-dependencies)
-      - [libfreshclam dependencies](#libfreshclam-dependencies)
-      - [Application dependencies](#application-dependencies)
-      - [Dependency build options](#dependency-build-options)
-        - [`libcheck`](#libcheck)
-        - [`bzip2`](#bzip2)
-        - [`zlib`](#zlib)
-        - [`libxml2`](#libxml2)
-        - [`libpcre2`](#libpcre2)
-        - [`openssl` (`libcrypto`, `libssl`)](#openssl-libcrypto-libssl)
-        - [`libjson-c`](#libjson-c)
-        - [`libmspack`](#libmspack)
-        - [`iconv` (POSIX-only)](#iconv-posix-only)
-        - [`pthreads-win32` (Windows-only)](#pthreads-win32-windows-only)
-        - [`llvm` (optional, _see "Bytecode Runtime" section_)](#llvm-optional-see-bytecode-runtime-section)
-        - [`libcurl`](#libcurl)
-        - [`ncurses` or `pdcurses`, for `clamdtop`](#ncurses-or-pdcurses-for-clamdtop)
-        - [Bytecode Runtime](#bytecode-runtime)
-  - [Compilers and Options](#compilers-and-options)
-  - [Compiling For Multiple Architectures](#compiling-for-multiple-architectures)
+## Build Requirements
 
-## CMake Basics
+### Build Tools
 
-### Build requirements
+As of ClamAV 0.104, CMake is required to build ClamAV.
 
-- CMake 3.16 for Windows, and 3.14+ for other operating systems.
-- A C compiler toolchain such as gcc, clang, or Microsoft Visual Studio.
+The Windows Visual Studio and Autotools build systems have been removed.
+
+You will need:
+- CMake (3.14+ for Unix/Linux; 3.16+ for Windows)
+- A C compiler toolchain such as `gcc`, `clang`, or Microsoft Visual Studio.
+
+Recommended tools:
+- pkg-config
 - Python 3 (to run the test suite)
 
-### Optional build requirements (Maintainer-Mode)
+For Maintainer-mode only (not recommended):
+- Flex
+- Bison
+- Gperf
 
-- GPerf, Flex and Bison. On Windows, `choco install winflexbison`.
+### External Library Dependencies
 
-**_Important_**: The following instructions assume that you have created a `build`
-subdirectory and that subsequent commands are performed from said directory,
-like so:
+For installation instructions, see our online documentation:
+
+- [Dependencies - Unix/Linux/Mac ](https://docs.clamav.net/manual/Installing/Installing-from-source-Unix.html#install-prerequisites)
+
+- [Dependencies - Windows](https://docs.clamav.net/manual/Installing/Installing-from-source-Windows.html#building-the-library-dependencies)
+
+> _Important_: Linux users will need the "-dev" or "-devel" package variants
+> which include C headers. For macOS, Homebrew doesn't separate the headers.
+
+#### libclamav dependencies
+
+App developers that only need libclamav can use the `-D ENABLE_LIBCLAMAV_ONLY`
+option to bypass the libfreshclam and program dependencies.
+
+libclamav requires these library dependencies:
+
+- `libbz2` / `bzip2`
+- `libz` / `zlib`
+- `libxml2`
+- `libpcre2`
+- `openssl`
+- `json-c`
+- `libjson-c` / `json-c`
+- `libmspack` (built-in by default, enable with `ENABLE_EXTERNAL_MSPACK=ON`)
+- `libiconv` (built-in to `libc` 99% of the time, not requires on Windows)
+- `pthreads` (provided by Linux/Unix; requires `pthreads-win32` on Windows)
+- `llvm` (optional, see: [Bytecode Runtime](#bytecode-runtime), below)
+- `libcheck` (default, disable with `ENABLE_TESTS=OFF`)
+
+#### libfreshclam dependencies
+
+If you are building an app and need libclamav _and_ libfreshclam but don't need
+to build the ClamAV programs, configure the build with `-D ENABLE_APP=OFF`.
+
+libfreshclam adds these additional library dependencies:
+
+- `libcurl`
+
+#### Program dependencies
+
+For regular folk who want the ClamAV apps, you'll also need:
+
+- `libmilter` (Unix/Linux-only, disable with `ENABLE_MILTER=OFF`)
+- `ncurses` or `pdcurses`, for ClamDTop.
+
+Optionally, if on a Linux distro with SystemD:
+
+- `systemd`, so ClamD, FreshClam, ClamOnAcc SystemD service.
+- `libsystemd`, so ClamD will support the `clamd.ctl` socket.
+
+## Getting Started
+
+***Important***: The following instructions assume that you have created a
+`build` subdirectory and that subsequent commands are performed from said
+directory, like so:
 
 ```sh
 mkdir build && cd build
 ```
 
-### Basic Release build & system install
+## CMake Basics
 
-```sh
-cmake .. -D CMAKE_BUILD_TYPE="Release"
-cmake --build . --config Release
-sudo cmake --build . --config Release --target install
-```
+CMake isn't actually a built system. It's a meta-build system. In other words,
+CMake is a build system *generator*.
 
-### Basic Debug build
+On Unix systems, CMake generates Makefiles by default, just like Autotools.
+On Windows, it generates Visual Studio projects by default.
 
-In CMake, "Debug" builds mean that symbols are compiled in.
+The process for using CMake is very similar to Autotools:
+1. *Configure*: Generate the build system.
+2. *Build*: Compile the project.
+3. *Install*: Install to the "prefix" directory.
 
-```sh
-cmake .. -D CMAKE_BUILD_TYPE="Debug"
-cmake --build . --config Debug
-```
+### CMake Generators
 
-You will likely also wish to disable compiler/linker optimizations, which you
-can do like so, using our custom `OPTIMIZE` option:
+You can choose to use a different generator using the `-G` option.
+For example, on macOS you can generate Xcode projects.
 
-```sh
-cmake .. -D CMAKE_BUILD_TYPE="Debug" -D OPTIMIZE=OFF
-cmake --build . --config Debug
-```
-
-_Tip_: CMake provides four build configurations which you can set using the
-`CMAKE_BUILD_TYPE` variable or the `--config` (`-C`) command line option.
-These are:
-- `Debug`
-- `Release`
-- `MinSizeRel`
-- `RelWithDebInfo`
-
-For multi-config generators, such as "Visual Studio" and "Ninja Multi-Config",
-you should not specify the config when you initially configure the project but
-you _will_ need to specify the config when you build the project and when
-running `ctest` or `cpack`.
-
-For single-config generators, such as "Make" or "Ninja", you will need to
-specify the config when you configure the project, and should _not_ specify the
-config when you build the project or run `ctest`.
-
-### Build and install to a specific install location (prefix)
-
-```sh
-cmake -D CMAKE_INSTALL_PREFIX:PATH=install ..
-cmake --build . --target install --config Release
-```
-
-### Build using Ninja
-
-This build uses Ninja (ninja-build) instead of Make. It's _really_ fast.
+Ninja is a popular build system, available on both Unix and Windows.
+If you want to use Ninja, you could configure the project with:
 
 ```sh
 cmake .. -G Ninja
-cmake --build . --config Release
 ```
 
-### Build and run tests
+For more information about generators, refer to the
+[CMake documentation](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-The option to build and run tests is enabled by default, which requires that
-you provide libcheck (i.e. `check`, `check-devel`, `check-dev`, etc).
+### CMake Build Types
+
+CMake provides four build types. These are:
+- `Release`: Optimized for speed, with no debugging info, code or asserts.
+- `Debug`: No optimization, asserts enabled, debugging info included.
+- `RelWithDebInfo`: Like `Release`, but *with* debug info, but no asserts.
+- `MinSizeRel`: Like `Release` but optimizing for size rather than speed.
+
+There are two basic types of generators. How you select the build type for
+your build will depend on which type of generator you're using:
+
+1. **Single-config generators** (Unix Makefiles, Ninja)
+
+  These generate a build system that can only build a single build type.
+
+  With a single-config generator, you need to specify the build type up
+  front. You can do this using the `-C` option. For example:
+  ```sh
+  # Configure
+  cmake .. -G Ninja -D CMAKE_BUILD_TYPE=RelWithDebInfo
+  # Build
+  cmake --build .
+  ```
+
+2. **Multi-config generators** (Xcode, Visual Studio, Ninja Multi-Config)
+
+  These generate a build system capable of building more than one build type.
+
+  With a multi-config generator, the generated build system can build all
+  of CMake's different build types. It's up to you to decide which type, or
+  "config" you want to build at build time instead of at configuration time.
+  You can do that with the `--config` option. For example:
+  ```sh
+  # Configure
+  cmake .. -G "Ninja Multi-Config"
+  # Build
+  cmake --build . --config RelWithDebInfo
+  ```
+
+> _Tip_: `RelWithDebInfo` is probably the best option for open source projects.
+> It will have the speed optimizations you need. And, if a crash occurs, the
+> crash backtrace you obtain with with a debugger will significantly help in
+> identifying the bug.
+
+For multi-config generators, you _will_ also need to specify the config when
+you use `ctest` to run the test suite, or if using `cpack` to build a package.
+
+> _Tip_: When using the default generator on Unix operating systems, you can
+> also simply call `make` after the first `cmake` command, like so:
+> ```sh
+> # Configure
+> cmake ..
+> # Build
+> make -j12
+> # Install
+> sudo make install
+> ```
+>
+> Similarly, if using Ninja, you could call `ninja` directly instead.
+> ```sh
+> # Configure
+> cmake .. -G Ninja
+> # Build
+> ninja
+> # Install
+> sudo ninja install
+> ```
+>
+> And for Windows & Mac developers, if generating Visual Studio or Xcode
+> projects, you're free to open those project solutions in Visual Studio or
+> Xcode after the configure step, to use for compiling AND debugging, which
+> may be very useful.
+
+### Customizing the Install Directories
+
+A default from-source install on a Unix system will go in `/usr/local`, with:
+- applications in `bin`,
+- daemons in `sbin`,
+- libraries in `lib`,
+- headers in `include`,
+- configs in `etc`,
+- and databases in `share/clamav`.
+
+Use the following variables to customize the install paths:
+
+- `CMAKE_INSTALL_PREFIX`: Customize the install prefix.
+- `APP_CONFIG_DIRECTORY`: Customize the config directory, may be relative.
+- `DATABASE_DIRECTORY`: Customize the database directory, may be relative.
+- `SYSTEMD_UNIT_DIR`: Install SystemD service files to a specific directory.
+
+This example configuration should be familiar if you've used the ClamAV
+packages provided by Debian, Ubuntu, Alpine, and some other distributions:
+```sh
+# Configure
+cmake .. \
+    -D CMAKE_BUILD_TYPE=RelWithDebInfo \
+    -D CMAKE_INSTALL_PREFIX=/usr \
+    -D CMAKE_INSTALL_LIBDIR=/usr/lib \
+    -D APP_CONFIG_DIRECTORY=/etc/clamav \
+    -D DATABASE_DIRECTORY=/var/lib/clamav \
+    -D ENABLE_JSON_SHARED=OFF # require libjson-c to be static
+# Build
+cmake --build .
+# Install
+sudo cmake --build . --target install
+```
+
+ClamAV has a couple other important paths you can configure. At this time,
+these are only configureable through the `clamd.conf` application config file:
+
+- `LocalSocket`: You may configure ClamD to listen on a TCP socket or on a
+  "local" socket (a Unix socket). A local socket is probably best, for safety.
+  But that means you'll need to select a path for the local socket. The sample
+  configu sugegsts using the `/tmp` directory, but you may wish to select
+  a directory like `/var/run/clamav`.
+
+- `TemporaryDirectory`: ClamAV creates a lot of temp files when scanning.
+  By default, ClamD and ClamScan will use the system's default temp directory,
+  which is typically `/tmp` or `/var/tmp`. But it may be best to give ClamAV
+  it's own directory. Maybe `/var/lib/clamav-tmp`.
+
+### Running the Public Test Suite
+
+The option to build so that you can run run the tests is enabled by default.
+It requires that you provide `python3` and `libcheck`.
 
 If you're building with `ENABLE_LIBCLAMAV_ONLY=ON` or `ENABLE_APP=OFF`, then
-libcheck will still be required and you can still run the tests, but it will
+`libcheck` will still be required and you can still run the tests, but it will
 skip all app tests and only run the libclamav unit tests.
 
-If you wish to disable test support, then configure with `-D ENABLE_TESTS=OFF`.
-
+To run the tests, first build ClamAV, then run `ctest`.
+Use the following options as needed:
 
 - `-V`: Verbose
 
-- `-C <config>`: Specify build configuration (i.e. Debug / Release), required
-                 for Windows builds
+  This option will show the test output. You may wish to use Pip (`pip3`) to
+  install `pytest` as well. If detected at configure-time, `pytest` will be
+  used to run the tests and will make it so you only see output from failed
+  tests.
 
+- `-C <config>`: Specify which build type to test (e.g. `RelWithDebInfo`).
+
+  This option is *only* required if using a multi-config generator, such as
+  "Visual Studio", "Xcode", or "Ninja Multi-Config".
+
+On a typical Linux system, you'll probably just run this:
 ```sh
-cmake ..
-cmake --build . --config Release
-ctest -C Release -V
+# Configure
+cmake .. -D CMAKE_BUILD_TYPE=RelWithDebInfo #... other options snipped
+# Build
+cmake --build .
+# Test
+ctest
 ```
 
-## Custom CMake options
-
-The following CMake options can be selected by using `-D`. For example:
-
+On Windows, you may run something like this:
 ```sh
-cmake .. -D ENABLE_EXAMPLES
-cmake --build . --config Debug
+# Configure
+cmake .. #... other options snipped
+# Build
+cmake --build . --config RelWithDebInfo
+# Test
+ctest -C RelWithDebInfo -V
 ```
 
-- `APP_CONFIG_DIRECTORY`: App Config directory.
+If you encounter a test failure, please re-run `ctest` with `-V` enabled and
+submit the output in a bug report
+[on GitHub Issues](https://github.com/Cisco-Talos/clamav/issues).
+The test output is also saved to log files in the `unit_tests` directory.
+You can zip those up and attach those instead.
 
-  _Default: Windows: `{prefix}`, POSIX: `{prefix}/etc`_
+> _Tip_: You can configure with `-D ENABLE_TESTS=OFF` to disable test support.
+> This will also remove the dependency on Python and libcheck.
+
+## Custom CMake Config Options
+
+The following is a complete list of CMake options unique to configuring ClamAV:
+
+- `APP_CONFIG_DIRECTORY`: Program config directory.
+  Relative to the `CMAKE_INSTALL_PREFIX` unless an absolute path is given.
+
+  _Default: Windows: `.`, POSIX: `etc`_
 
 - `DATABASE_DIRECTORY`: Database directory.
+  Relative to the `CMAKE_INSTALL_PREFIX` unless an absolute path is given.
 
-  _Default: Windows: `{prefix}/database`, POSIX: `{prefix}/share/clamav`_
+  _Default: Windows: `database`, POSIX: `share/clamav`_
 
 - `CLAMAV_USER`: ClamAV User (POSIX-only).
 
@@ -206,11 +399,12 @@ cmake --build . --config Debug
   _Default: `OFF`_
 
 - `ENABLE_ALL_THE_WARNINGS`: By default we use `-Wall -Wextra -Wformat-security`
-  for clamav libs and apps. This option enables a whole lot more.
+  for ClamAV libraries and programs. This option enables a whole lot more.
 
   _Default: `OFF`_
 
 - `ENABLE_DEBUG`: Turn on extra debug output.
+  Disclaimer: Does nothing in the current version.
 
   _Default: `OFF`_
 
@@ -236,19 +430,24 @@ cmake --build . --config Debug
   shared library then downstream applications which use a different JSON
   library may crash!
 
+  This option is default "ON" only because the libjson-c static library is not
+  available on many systems by default.
+
   _Default: `ON`_
 
-- `ENABLE_APP`: Build applications (clamscan, clamd, clamdscan, sigtool,
+- `ENABLE_APP`: Build the ClamAV programs (clamscan, clamd, clamdscan, sigtool,
   clambc, clamdtop, clamsubmit, clamconf).
 
   _Default: `ON`_
 
-- `ENABLE_CLAMONACC`: (Linux-only) Build the clamonacc on-access scanning daemon.
-  Requires: `ENABLE_APP`
+- `ENABLE_CLAMONACC`: (Linux-only) Build the ClamOnAcc on-access scanning
+  daemon. Requires: `ENABLE_APP`
+
+  ClamOnAcc will not compile on MUSL-based Linux distros such as Alpine.
 
   _Default: `ON`_
 
-- `ENABLE_MILTER`: (Posix-only) Build the clamav-milter mail filter daemon.
+- `ENABLE_MILTER`: (Posix-only) Build the clamav-milter Sendmail filter daemon.
   Requires: `ENABLE_APP`
 
   _Default: `OFF` for Mac & Windows, `ON` for Linux/Unix_
@@ -259,29 +458,32 @@ cmake --build . --config Debug
 
 - `ENABLE_MAN_PAGES`: Generate man pages.
 
-  _Default: `OFF`_
+  _Default: `ON` for Linux/Unix, `OFF` for Windows_
 
-- `ENABLE_DOXYGEN`: Generate doxygen HTML documentation for clamav.h,
-  libfreshclam.h. Requires doxygen.
-
-  _Default: `OFF`_
-
-- `ENABLE_EXAMPLES`: Build examples.
+- `ENABLE_DOXYGEN`: Generate Doxygen HTML documentation for `clamav.h`,
+  and `libfreshclam.h`. Requires Doxygen. *To-do*: Needs work.
 
   _Default: `OFF`_
 
-- `ENABLE_TESTS`: Build examples.
+- `ENABLE_EXAMPLES`: Build the example programs.
+
+  _Default: `OFF`_
+
+- `ENABLE_TESTS`: Enable support for running the test suite with `ctest`.
 
   _Default: `ON`_
 
-- `ENABLE_LIBCLAMAV_ONLY`: Build libclamav only. Excludes libfreshclam too!
+- `ENABLE_LIBCLAMAV_ONLY`: Build libclamav only.
+
+  > _Tip_: This Excludes libfreshclam too! Use `ENABLE_APP=OFF` instead if
+  > you want libclamav and libfreshclam.
 
   _Default: `OFF`_
 
 - `ENABLE_STATIC_LIB`: Build libclamav and/or libfreshclam static libraries.
 
-  Tip: If you wish to build `clamscan` and the other apps statically, you must
-  also set ENABLE_SHARED_LIB=OFF.
+  > _Tip_: If you wish to build `clamscan` and the other programs statically,
+  > you must also set `ENABLE_SHARED_LIB=OFF`.
 
   _Default: `OFF`_
 
@@ -289,342 +491,34 @@ cmake --build . --config Debug
 
   _Default: `ON`_
 
-- `ENABLE_SYSTEMD`: Install systemd service files if systemd is found.
+- `ENABLE_SYSTEMD`: Install SystemD service files if SystemD is found.
 
   _Default: `ON`_
 
 - `MAINTAINER_MODE`: Generate Yara lexer and grammar C source with Flex & Bison.
-  TODO: Also generate JS parse source with Gperf.
+  *To-do*: Also generate JS parse source with Gperf.
 
   _Default: `OFF`_
 
-- `SYSTEMD_UNIT_DIR`: Install systemd service files to a specific directory.
-  This will fail the build if systemd not found.
+- `SYSTEMD_UNIT_DIR`: Install SystemD service files to a specific directory.
+  This will fail the build if SystemD not found.
 
   _Default: not set_
 
-## Custom Library Paths
+## External Library Depedency Configuration Options
 
-### Example Build Commands
+The CMake tooling is good about finding installed dependencies on POSIX systems
+provided that you have pkg-config installed, and the dependencies are installed
+in the standard locations (i.e. `/usr` and `/usr/local`).
 
-#### Linux release build, install to system
+But if you:
+- have custom install paths for the dependencies,
+- want to target static libraries, or
+- are building on Windows...
 
-This example sets the build generator to Ninja instead of using Make, for speed.
-You may need to first use `apt`/`dnf`/`pkg` to install `ninja-build`
+... you may need to use the following build configuration options.
 
-```sh
-cmake .. -G Ninja \
-  -D CMAKE_BUILD_TYPE=Release \
-  -D ENABLE_JSON_SHARED=OFF
-ninja
-sudo ninja install
-```
-
-#### macOS debug build, custom OpenSSL path, build examples, local install
-
-For macOS builds, we recommend using Homebrew to install the build tools, such
-as `cmake`, `flex`, `bison`, as well as ClamAV's library dependencies.
-
-Note that explicit paths for OpenSSL are requires so as to avoid using an older
-OpenSSL install provided by the operating system.
-
-This example also:
-- Sets the build generator to Ninja instead of using Make.
-  - You may need to first use `brew` to install `ninja`.
-- Sets build config to "Debug" and explicitly disables compiler optimizations.
-- Builds static libraries (and also shared libraries, which are on by default).
-- Builds the example programs, just to test them out.
-- Sets the install path (prefix) to `./install`.
-
-```sh
-cmake .. -G Ninja                                                             \
-  -D CMAKE_BUILD_TYPE=Debug                                                    \
-  -D OPTIMIZE=OFF                                                              \
-  -D ENABLE_JSON_SHARED=OFF                                                    \
-  -D OPENSSL_ROOT_DIR=/usr/local/opt/openssl@1.1/                              \
-  -D OPENSSL_CRYPTO_LIBRARY=/usr/local/opt/openssl@1.1/lib/libcrypto.1.1.dylib \
-  -D OPENSSL_SSL_LIBRARY=/usr/local/opt/openssl@1.1/lib/libssl.1.1.dylib       \
-  -D ENABLE_STATIC_LIB=ON                                                      \
-  -D ENABLE_EXAMPLES=ON                                                        \
-  -D CMAKE_INSTALL_PREFIX=install
-ninja
-ninja install
-```
-
-#### Windows builds
-
-At a minimum you will need Visual Studio 2015 or newer, and CMake.
-If you want to build the installer, you'll also need WiX Toolset.
-
-If you're using Chocolatey, you can install CMake and WiX simply like this:
-
-```ps1
-choco install cmake wixtoolset
-```
-
-Then open a new terminal so that CMake and WiX will be in your `$PATH`.
-**The following commands for building on Windows are written for Powershell**.
-
-There are two options for building and supplying the library dependencies.
-These are Mussels and vcpkg.
-
-Mussels is an open source project developed in-house by the ClamAV team.
-It offers great flexibility for defining your own collections (cookbooks) of
-build instructions (recipes) instead of solely relying on a centralized
-repository of ports. And unlike vcpkg, Mussels does not implement CMake build
-tooling for projects that don't support CMake, but instead leverages whatever
-build system is provided by the project. This means that Mussels builds may
-require installing additional tools, like NMake and ActivePerl rather than
-simply requiring CMake. The advantage is that you'll be building those projects
-the same way that those developers intended, and that Mussels recipes are
-generally very light weight. Mussels has some sharp edges because it's a newer
-and much smaller project than vcpkg.
-
-Vcpkg is an open source project developed by Microsoft and is heavily oriented
-towards CMake projects. Vcpkg offers a very large collection of "ports" for
-almost any project you may need to build.
-It is very easy to get started with vcpkg.
-
-Mussels is the preferred tool to supply the library dependencies at least until
-such time as the vcpkg Debug-build libclamav unit test heap-corruption crash
-is resolved [(see below)](#windows-build-with-vcpkg).
-
-##### Windows build (with Mussels)
-
-Much like `vcpkg`, [Mussels](https://github.com/Cisco-Talos/Mussels) can be
-used to automatically build the ClamAV library dependencies. Unlike `vcpkg`,
-Mussels does not provide a mechanism for CMake to automatically detect the
-library paths.
-
-**Preprequisites:**
-
-To build the library dependencies with Mussels, use Python's `pip` package
-manager to install Mussels:
-
-```ps1
-python3 -m pip install mussels
-```
-
-Update the Mussels cookbooks to get the latest build recipes and set the
-`clamav` cookbook to be trusted:
-
-```ps1
-msl update
-msl cookbook trust clamav
-```
-
-Use `msl list` if you wish to see the recipes provided by the `clamav` cookbook.
-
-**Building the libraries and ClamAV:**
-
-Build the `clamav_deps` recipe to compile ClamAV's library dependencies.
-By default, Mussels will install them to `~\.mussels\install\<target>`
-
-```ps1
-msl build clamav_deps
-```
-
-Next, set `$env:CLAMAV_DEPENDENCIES` to the location where Mussels built your
-library dependencies:
-
-```ps1
-$env:CLAMAV_DEPENDENCIES="$env:userprofile\.mussels\install\x64"
-```
-
-To configure the project, run:
-
-```ps1
-cmake ..  -G "Visual Studio 15 2017" -A x64 `
-  -D JSONC_INCLUDE_DIR="$env:CLAMAV_DEPENDENCIES\include\json-c"         `
-  -D JSONC_LIBRARY="$env:CLAMAV_DEPENDENCIES\lib\json-c.lib"             `
-  -D ENABLE_JSON_SHARED=OFF                                              `
-  -D BZIP2_INCLUDE_DIR="$env:CLAMAV_DEPENDENCIES\include"                `
-  -D BZIP2_LIBRARY_RELEASE="$env:CLAMAV_DEPENDENCIES\lib\libbz2.lib"     `
-  -D CURL_INCLUDE_DIR="$env:CLAMAV_DEPENDENCIES\include"                 `
-  -D CURL_LIBRARY="$env:CLAMAV_DEPENDENCIES\lib\libcurl_imp.lib"         `
-  -D OPENSSL_ROOT_DIR="$env:CLAMAV_DEPENDENCIES"                         `
-  -D OPENSSL_INCLUDE_DIR="$env:CLAMAV_DEPENDENCIES\include"              `
-  -D OPENSSL_CRYPTO_LIBRARY="$env:CLAMAV_DEPENDENCIES\lib\libcrypto.lib" `
-  -D OPENSSL_SSL_LIBRARY="$env:CLAMAV_DEPENDENCIES\lib\libssl.lib"       `
-  -D ZLIB_LIBRARY="$env:CLAMAV_DEPENDENCIES\lib\libssl.lib"              `
-  -D LIBXML2_INCLUDE_DIR="$env:CLAMAV_DEPENDENCIES\include"              `
-  -D LIBXML2_LIBRARY="$env:CLAMAV_DEPENDENCIES\lib\libxml2.lib"          `
-  -D PCRE2_INCLUDE_DIR="$env:CLAMAV_DEPENDENCIES\include"                `
-  -D PCRE2_LIBRARY="$env:CLAMAV_DEPENDENCIES\lib\pcre2-8.lib"            `
-  -D CURSES_INCLUDE_DIR="$env:CLAMAV_DEPENDENCIES\include"               `
-  -D CURSES_LIBRARY="$env:CLAMAV_DEPENDENCIES\lib\pdcurses.lib"          `
-  -D PThreadW32_INCLUDE_DIR="$env:CLAMAV_DEPENDENCIES\include"           `
-  -D PThreadW32_LIBRARY="$env:CLAMAV_DEPENDENCIES\lib\pthreadVC2.lib"    `
-  -D ZLIB_INCLUDE_DIR="$env:CLAMAV_DEPENDENCIES\include"                 `
-  -D ZLIB_LIBRARY="$env:CLAMAV_DEPENDENCIES\lib\zlibstatic.lib"          `
-  -D LIBCHECK_INCLUDE_DIR="$env:CLAMAV_DEPENDENCIES\include"             `
-  -D LIBCHECK_LIBRARY="$env:CLAMAV_DEPENDENCIES\lib\checkDynamic.lib"    `
-  -D CMAKE_INSTALL_PREFIX="install"
-```
-
-Now, go ahead and build the project:
-
-```ps1
-cmake --build . --config Release
-```
-
-_Tip_: If you're having include-path issues when building, try building with
-detailed verbosity so you can verify that the paths are correct:
-
-```ps1
-cmake --build . --config Release -- /verbosity:detailed
-```
-
-You can run the test suite with CTest:
-
-```ps1
-ctest -C Release
-```
-
-And you can install to the `install` (set above) like this:
-
-```ps1
-cmake --build . --config Release --target install
-```
-
-##### Windows build (with vcpkg)
-
-`vcpkg` can be used to build the ClamAV library dependencies automatically.
-
-`vcpkg` integrates really well with CMake, enabling CMake to find your compiled
-libraries automatically, so you don't have to specify the include & library
-paths manually as you do when using Mussels.
-
-_DISCLAIMER_: There is a known issue with the unit tests when building with
-vcpkg in Debug mode. When you run the libclamav unit tests (check_clamav), the
-program will crash and a popup will claim there was heap corruption. If you use
-Task Manager to kill the `check_clamav.exe` process, the rest of the tests pass
-just fine. This issue does not occur when using Mussels to supply the library
-dependencies. Commenting out the following lines in `readdb.c` resolves the
-heap corruption crash when running `check_clamav`, but of course introduces a
-memory leak:
-```c
-    if (engine->stats_data)
-        free(engine->stats_data);
-```
-If anyone has time to figure out the real cause of the vcpkg Debug-build crash
-in check_clamav, it would be greatly appreciated.
-
-**Preprequisites:**
-
-You'll need to install [vcpkg](https://github.com/microsoft/vcpkg).
-See the `vcpkg` README for installation instructions.
-
-Once installed, set the variable `$VCPKG_PATH` to the location where you
-installed `vcpkg`:
-
-```ps1
-$VCPKG_PATH="..." # Path to your vcpkg installation
-```
-
-By default, CMake and `vcpkg` build for 32-bit. If you want to build for 64-bit,
-set the `VCPKG_DEFAULT_TRIPLET` environment variable:
-
-```ps1
-$env:VCPKG_DEFAULT_TRIPLET="x64-windows"
-```
-
-**Building the libraries and ClamAV:**
-
-Next, use `vcpkg` to build the required library dependencies:
-
-```ps1
-& "$VCPKG_PATH\vcpkg" install 'curl[openssl]' 'json-c' 'libxml2' 'pcre2' 'pthreads' 'zlib' 'pdcurses' 'bzip2' 'check'
-```
-
-Now configure the ClamAV build using the `CMAKE_TOOLCHAIN_FILE` variable which
-will enable CMake to automatically find the libraries we built with `vcpkg`.
-
-```ps1
-cmake .. -A x64 `
-  -D CMAKE_TOOLCHAIN_FILE="$VCPKG_PATH\scripts\buildsystems\vcpkg.cmake" `
-  -D CMAKE_INSTALL_PREFIX="install"
-```
-
-_Tip_: You have to drop the `-A x64` arguments if you're building for 32-bits,
-and correct the package paths accordingly.
-
-Now, go ahead and build the project:
-
-```ps1
-cmake --build . --config Release
-```
-
-You can run the test suite with CTest:
-
-```ps1
-ctest -C Release
-```
-
-And you can install to the `install` directory (set above) like this:
-
-```ps1
-cmake --build . --config Release --target install
-```
-
-##### Build the Installer
-
-To build the installer, you must have WIX Toolset installed. If you're using
-Chocolatey, you can install it simply with `choco install wixtoolset` and then
-open a new terminal so that WIX will be in your PATH.
-
-```ps1
-cpack -C Release
-```
-
-### External Depedencies
-
-The CMake tooling is good about finding installed dependencies on POSIX systems.
-
-_Important_: Linux users will want the "-dev" or "-devel" package variants
-which include C headers. For macOS, Homebrew doesn't separate the headers.
-
-#### libclamav dependencies
-
-App developers that only need libclamav can use the `-D ENABLE_LIBCLAMAV_ONLY`
-option to bypass ClamAV app dependencies.
-
-libclamav requires these library dependencies:
-
-- `bzip2`
-- `zlib`
-- `libxml2`
-- `libpcre2`
-- `openssl`
-- `json-c`
-- `iconv` (POSIX-only, may be provided by system)
-- `pthreads` (Provided by the system on POSIX; Use `pthreads-win32` on Windows)
-- `llvm` (optional, _see [Bytecode Runtime](#bytecode-runtime))
-
-#### libfreshclam dependencies
-
-If you want libclamav _and_ libfreshclam for your app, then use the
-`-D ENABLE_APP=OFF` option instead.
-
-libfreshclam adds these additional library dependencies:
-
-- `libcurl`
-
-#### Application dependencies
-
-For regular folk who want the ClamAV apps, you'll also need:
-
-- `ncurses` (or `pdcurses`), for `clamdtop`.
-- `systemd`, so `clamd`, `freshclam`, `clamonacc` may run as a `systemd`
-  service (Linux).
-- `libsystemd`, so `clamd` will support the `clamd.ctl` socket (Linux).
-
-#### Dependency build options
-
-If you have custom install paths for the dependencies on your system or are
-on Windows, you may need to use the following options...
-
-##### `libcheck`
+### `libcheck`
 
 ```sh
   -D LIBCHECK_ROOT_DIR="_path to libcheck install root_"
@@ -632,35 +526,35 @@ on Windows, you may need to use the following options...
   -D LIBCHECK_LIBRARY="_filepath of libcheck library_"
 ```
 
-##### `bzip2`
+### `bzip2`
 
 ```sh
   -D BZIP2_INCLUDE_DIR="_filepath of bzip2 header directory_"
   -D BZIP2_LIBRARIES="_filepath of bzip2 library_"
 ```
 
-##### `zlib`
+### `zlib`
 
 ```sh
   -D ZLIB_INCLUDE_DIR="_filepath of zlib header directory_"
   -D ZLIB_LIBRARY="_filepath of zlib library_"
 ```
 
-##### `libxml2`
+### `libxml2`
 
 ```sh
   -D LIBXML2_INCLUDE_DIR="_filepath of libxml2 header directory_"
   -D LIBXML2_LIBRARY="_filepath of libxml2 library_"
 ```
 
-##### `libpcre2`
+### `libpcre2`
 
 ```sh
   -D PCRE2_INCLUDE_DIR="_filepath of libpcre2 header directory_"
   -D PCRE2_LIBRARY="_filepath of libcpre2 library_"
 ```
 
-##### `openssl` (`libcrypto`, `libssl`)
+### `openssl` (`libcrypto`, `libssl`)
 
 ```sh
   -D OPENSSL_ROOT_DIR="_path to openssl install root_"
@@ -669,7 +563,7 @@ on Windows, you may need to use the following options...
   -D OPENSSL_SSL_LIBRARY="_filepath of libssl library_"
 ```
 
-##### `libjson-c`
+### `libjson-c`
 
 _Tip_: You're strongly encouraged to link with the a static json-c library.
 
@@ -678,7 +572,7 @@ _Tip_: You're strongly encouraged to link with the a static json-c library.
   -D JSONC_LIBRARY="_filepath of json-c library_"
 ```
 
-##### `libmspack`
+### `libmspack`
 
 These options only apply if you use the `-D ENABLE_EXTERNAL_MSPACK=ON` option.
 
@@ -687,7 +581,7 @@ These options only apply if you use the `-D ENABLE_EXTERNAL_MSPACK=ON` option.
   -D MSPack_LIBRARY="_filepath of libmspack library_"
 ```
 
-##### `iconv` (POSIX-only)
+### `iconv` (POSIX-only)
 
 On POSIX platforms, iconv might be part of the C library in which case you
 would not want to specify an external iconv library.
@@ -697,7 +591,7 @@ would not want to specify an external iconv library.
   -D Iconv_LIBRARY="_filepath of iconv library_"
 ```
 
-##### `pthreads-win32` (Windows-only)
+### `pthreads-win32` (Windows-only)
 
 On POSIX platforms, pthread support is detected automatically.  On Windows, you
 need to specify the following:
@@ -707,51 +601,51 @@ need to specify the following:
   -D PThreadW32_LIBRARY="_filepath of pthread-win32 library_"
 ```
 
-##### `llvm` (optional, _see "Bytecode Runtime" section_)
+### `llvm` (optional, _see "Bytecode Runtime" section_)
 
 ```sh
   -D BYTECODE_RUNTIME="llvm"
   -D LLVM_ROOT_DIR="_path to llvm install root_" -D LLVM_FIND_VERSION="3.6.0"
 ```
 
-##### `libcurl`
+### `libcurl`
 
 ```sh
   -D CURL_INCLUDE_DIR="_path to curl header directory_"
   -D CURL_LIBRARY="_filepath of curl library_"
 ```
 
-##### `ncurses` or `pdcurses`, for `clamdtop`
+### `ncurses` or `pdcurses`, for `clamdtop`
 
 ```sh
   -D CURSES_INCLUDE_DIR="_path to curses header directory_"
   -D CURSES_LIBRARY="_filepath of curses library_"
 ```
 
-##### Bytecode Runtime
+### Bytecode Runtime
 
 Bytecode signatures are a type of executable plugin that provide extra
 detection capabilities.
 
 ClamAV has two bytecode runtimes:
 
-- *Interpreter*: The bytecode interpreter evaluates and executes bytecode
-  instructions one by one.
+1. **Interpreter**: The bytecode interpreter evaluates and executes bytecode
+   instructions one by one.
 
-  With the interpreter, signature database (re)loads are faster, but execution
-  time for scans that make use of the bytecode sigantures is slower.
+   With the interpreter, signature database (re)loads are faster, but execution
+   time for scans that make use of the bytecode sigantures is slower.
 
-- *LLVM*: LLVM can be used to Just-in-Time (JIT) compile bytecode signatures
-  at database load time.
+2. **LLVM**: LLVM can be used to Just-in-Time (JIT) compile bytecode signatures
+   at database load time.
 
-  With LLVM, signature database loading is slower, but bytecode signature
-  execution should be faster. Not all scans will run bytecode signatures, so
-  performance testing will depend heavily depending on what files are tested.
+   With LLVM, signature database loading is slower, but bytecode signature
+   execution should be faster. Not all scans will run bytecode signatures, so
+   performance testing will depend heavily depending on what files are tested.
 
-  We ran out of time in 0.104 development to update to support newer versions
-  of LLVM. LLVM 3.6.2 is the newest version supported in ClamAV 0.104.
+   We ran out of time in 0.104 development to update to support newer versions
+   of LLVM. LLVM 3.6.2 is the newest version supported in ClamAV 0.104.
 
-At the moment, the interpreter is the default runtime, while we work out
+At the moment, the *interpreter* is the default runtime, while we work out
 compatibility issues with newer versions of libLLVM. This default equates to:
 
 ```sh
@@ -774,10 +668,32 @@ To disable bytecode signature support entirely, you may build with this option:
 cmake .. -D BYTECODE_RUNTIME="none"
 ```
 
-## Compilers and Options
+## Compiling For Multiple Architectures (Cross-Compiling)
 
-_TODO_: Describe how to customize compiler toolchain with CMake.
+For cross-compling information, see the cmake-toolchains documentation in the
+[CMake Manual](https://cmake.org/cmake/help/latest/manual/cmake-toolchains.7.html)
 
-## Compiling For Multiple Architectures
+## Un-install
 
-_TODO_: Describe how to cross-compile with CMake.
+CMake doesn't provide a simple command to uninstall. However, CMake does build
+an `install_manifest.txt` file when you do the install. You can use the
+manifest to remove the installed files.
+
+You will find the manifest in the directory where you compiled ClamAV. If you
+followed the recommendations (above), then you will find it at
+`<clamav source directory>/build/install_manifest.txt`.
+
+Feel free to inspect the file so you're comfortable knowing what you're about
+to delete.
+
+Open a terminal and `cd` to that `<clamav source directory>/build` directory.
+Then run:
+```bash
+xargs rm < install_manifest.txt
+```
+
+This will leave behind the directories, and will leave behind any files added
+after install including the signature databases and any config files. You will
+have to delete these extra files yourself.
+
+> _Tip_: You may need to use `sudo`, depending on where you installed to.

--- a/README.md
+++ b/README.md
@@ -36,12 +36,18 @@ our images on [Docker Hub](https://hub.docker.com/r/clamav/clamav).
 
 #### Build from Source
 
-For comprehensive compile and install instructions, please see
-[INSTALL.md](INSTALL.md).
-
 For step-by-step instructions, visit our online documentation:
-- [Unix/Linux/Mac Instructions](Installing-from-source/Installing-from-source-Unix.md)
-- [Windows Instructions](Installing-from-source/Installing-from-source-Windows.md)
+- [Unix/Linux/Mac Instructions](https://docs.clamav.net/manual/Installing/Installing-from-source-Unix.html)
+- [Windows Instructions](https://docs.clamav.net/manual/Installing/Installing-from-source-Windows.html)
+
+If you have a source tarball from an official release, you can also find
+a copy of the online documentation in the [docs/html](docs/html) directory.
+
+A more comprehensive reference with all of the available build options can be
+found in the [INSTALL.md](INSTALL.md) file.
+
+You can find additional tips for development builds in our
+[online documentation](https://docs.clamav.net/manual/Development/development-builds.html).
 
 #### Install from a binary package distribution
 

--- a/libclamav/bytecode_api.h
+++ b/libclamav/bytecode_api.h
@@ -148,8 +148,9 @@ enum FunctionalityLevels {
     FUNC_LEVEL_0103      = 121, /**< LibClamAV release 0.103.0 */
     FUNC_LEVEL_0103_1    = 122, /**< LibClamAV release 0.103.1 */
     FUNC_LEVEL_0103_2    = 123, /**< LibClamAV release 0.103.2 */
+    FUNC_LEVEL_0103_3    = 124, /**< LibClamAV release 0.103.2 */
 
-    FUNC_LEVEL_0104 = 131, /**< LibClamAV release 0.104.0 */
+    FUNC_LEVEL_0104 = 140, /**< LibClamAV release 0.104.0 */
 };
 
 /**

--- a/libclamav/others.h
+++ b/libclamav/others.h
@@ -72,7 +72,7 @@
  * in re-enabling affected modules.
  */
 
-#define CL_FLEVEL 130
+#define CL_FLEVEL 140
 #define CL_FLEVEL_DCONF CL_FLEVEL
 #define CL_FLEVEL_SIGTOOL CL_FLEVEL
 


### PR DESCRIPTION
Clean up the INSTALL.md and make it clear that folks should see the online documentation (or offline copy in the release tarball) when looking for instructions to install the dependencies and compile clamav for their operating system.

Increase the FLEVEL from 130 to 140.  Reminder, the FLEVEL for 0.103 was 120, so this gives ample room for additional 0.103 patch versions now that 0.103 will be our first Long Term Support (LTS) release.