### PR TITLE
Manpages: Add environment variables to the docs

### DIFF
--- a/docs/man/clamd.8.in
+++ b/docs/man/clamd.8.in
@@ -94,6 +94,7 @@ Scan stream \- on this command clamd will return "PORT number" you should connec
 .TP
 \fBSESSION, END\fR
 Start/end a clamd session which will allow you to run multiple commands per TCP session. (use IDSESSION instead)
+
 .SH "OPTIONS"
 .LP
 .TP
@@ -111,6 +112,13 @@ Enable debug mode.
 .TP
 \fB\-c FILE, \-\-config\-file=FILE\fR
 Read configuration from FILE.
+
+.SH "ENVIRONMENT VARIABLES"
+.LP
+clamd uses the following environment variables:
+.TP
+LD_LIBRARY_PATH - May be used on startup to find the libclamunrar_iface shared library module to enable RAR archive support.
+
 .SH "SIGNALS"
 .LP
 Clamd recognizes the following signals:

--- a/docs/man/clamdscan.1.in
+++ b/docs/man/clamdscan.1.in
@@ -72,6 +72,7 @@ Only available if connected to clamd via local(unix) socket.
 .TP
 \fB\-\-stream\fR
 Forces file streaming to clamd. This is generally not needed as clamdscan detects automatically if streaming is required. This option only exists for debugging and testing purposes, in all other cases \-\-fdpass is preferred.
+
 .SH "EXAMPLES"
 .LP
 .TP

--- a/docs/man/clamscan.1.in
+++ b/docs/man/clamscan.1.in
@@ -261,6 +261,13 @@ Maximum size file to perform PCRE subsig matching (default: 25 MB, max: <4 GB).
 .TP
 \fB\-\-disable\-cache\fR
 Disable caching and cache checks for hash sums of scanned files.
+
+.SH "ENVIRONMENT VARIABLES"
+.LP
+clamscan uses the following environment variables:
+.TP
+LD_LIBRARY_PATH - May be used on startup to find the libclamunrar_iface shared library module to enable RAR archive support.
+
 .SH "EXAMPLES"
 .LP
 .TP

--- a/docs/man/clamsubmit.1.in
+++ b/docs/man/clamsubmit.1.in
@@ -1,26 +1,26 @@
 .TH "File submission tool" "1" "March 20, 2014" "ClamAV @VERSION@" "Clam AntiVirus"
 .SH "NAME"
-.LP 
+.LP
 clamsubmit \- File submission utility for ClamAV
 .SH "SYNOPSIS"
-.LP 
+.LP
 clamsubmit [options]
 .SH "DESCRIPTION"
-.LP 
+.LP
 clamsubmit submits files to Sourcefire for further analysis.
 .SH "OPTIONS"
-.LP 
+.LP
 
-.TP 
+.TP
 \fB\-h, \-?\fR
 Display help to stderr and exit.
-.TP 
+.TP
 \fB\-e EMAIL\fR
 Required option for setting the email address for the submission.
-.TP 
+.TP
 \fB\-n FILE\fR
 Submit a file that reports as a false negative (ClamAV reports CLEAN). FILE can be \- to specify stdin. Mutually exclusive with \-p.
-.TP 
+.TP
 \fB\-N NAME\fR
 Required option for setting the name of the sender for the submission.
 .TP
@@ -29,6 +29,15 @@ Submit a file that reports as a false positive (ClamAV flags the file as virus).
 .TP
 \fB-V VIRUS\fR
 The name of the virus detected as false positive. This option is required for false positive submissions.
+
+.SH "ENVIRONMENT VARIABLES"
+.LP
+clamsubmit uses the following environment variables:
+.TP
+CURL_CA_BUNDLE - May be set to the path of a file (bundle) containing one or more CA certificates. This will override the default openssl certificate path.
+
+Note that the CURL_CA_BUNDLE environment variable is also used by the curl command line tool for the same purpose.
+
 .SH "AUTHOR"
-.LP 
+.LP
 Shawn Webb <swebb@sourcefire.com>

--- a/docs/man/freshclam.1.in
+++ b/docs/man/freshclam.1.in
@@ -80,6 +80,15 @@ Execute COMMAND when freshclam reports outdated version. In the command string %
 .TP
 \fB\-\-update\-db=DBNAME\fR
 With this option you can limit updates to a subset of database files. The DBNAME should be "main", "daily", "bytecode", "safebrowsing" or one of the 3rd party database names. This option can be used multiple times and only works with the official and 3rd party databases distributed through the ClamAV mirrors, your custom databases (specified with DatabaseCustomURL in freshclam.conf) will not be ignored.
+
+.SH "ENVIRONMENT VARIABLES"
+.LP
+freshclam uses the following environment variables:
+.TP
+CURL_CA_BUNDLE - May be set to the path of a file (bundle) containing one or more CA certificates. This will override the default openssl certificate path.
+
+Note that the CURL_CA_BUNDLE environment variable is also used by the curl command line tool for the same purpose.
+
 .SH "EXAMPLES"
 .LP
 .TP
@@ -94,6 +103,7 @@ With this option you can limit updates to a subset of database files. The DBNAME
 (2) Run as a daemon and check 2 times per day for new database:
 
 \fBfreshclam \-d \-c 2\fR
+
 .SH "RETURN CODES"
 Some return codes of freshclam can be overwritten with a built-in command EXIT_n which can be passed to \-\-on\-*\-execute, eg. \-\-on\-update\-execute=EXIT_1 will force freshclam to always return 1 after successful database update.
 .TP

--- a/docs/man/sigtool.1.in
+++ b/docs/man/sigtool.1.in
@@ -1,130 +1,140 @@
 .TH "sigtool" "1" "February 12, 2007" "ClamAV @VERSION@" "Clam AntiVirus"
 .SH "NAME"
-.LP 
+.LP
 sigtool \- signature and database management tool
 .SH "SYNOPSIS"
-.LP 
+.LP
 sigtool [options]
 .SH "DESCRIPTION"
-.LP 
+.LP
 sigtool can be used to generate MD5 checksums, convert data into hexadecimal format, list virus signatures and build/unpack/test/verify CVD databases and update scripts.
 .SH "OPTIONS"
-.LP 
+.LP
 
-.TP 
+.TP
 \fB\-h, \-\-help\fR
 Output help information and exit.
-.TP 
+.TP
 \fB\-V, \-\-version\fR
 Print version number and exit.
-.TP 
+.TP
 \fB\-\-quiet\fR
 Be quiet \- output only error messages.
-.TP 
+.TP
 \fB\-\-stdout\fR
 Write all messages to stdout.
-.TP 
+.TP
 \fB\-\-hex\-dump\fR
 Read data from stdin and write hex string to stdout.
-.TP 
+.TP
 \fB\-\-md5 [FILES]\fR
 Generate MD5 checksum from stdin or MD5 sigs for FILES.
-.TP 
+.TP
 \fB\-\-sha1 [FILES]\fR
 Generate SHA1 checksum from stdin or SHA1 sigs for FILES.
-.TP 
+.TP
 \fB\-\-sha256 [FILES]\fR
 Generate SHA256 checksum from stdin or SHA256 sigs for FILES.
-.TP 
+.TP
 \fB\-\-mdb [FILES]\fR
 Generate .mdb signatures for FILES.
-.TP 
+.TP
 \fB\-\-html\-normalise=FILE\fR
 Create normalised HTML files comment.html, nocomment.html, and script.html in current working directory.
-.TP 
+.TP
 \fB\-\-utf16\-decode=FILE\fR
 Decode UTF16 encoded data.
-.TP 
+.TP
 \fB\-\-vba=FILE\fR
 Extract VBA/Word6 macros from given MS Office document.
-.TP 
+.TP
 \fB\-\-vba\-hex=FILE\fR
 Extract Word6 macros from given MS Office document and display the corresponding hex values.
-.TP 
+.TP
 \fB\-i, \-\-info\fR
 Print a CVD information and verify MD5 and a digital signature.
-.TP 
+.TP
 \fB\-\-build=FILE, \-b FILE\fR
 Build a CVD file. \-s, \-\-server is required for signed virus databases(.cvd), or, \-\-unsigned for unsigned(.cud).
-.TP 
+.TP
 \fB\-\-max\-bad\-sigs=NUMBER\fR
 Maximum number of mismatched signatures when building a CVD. Default: 3000
-.TP 
+.TP
 \fB\-\-flevel\fR
 Specify a custom flevel. Default: 77
-.TP 
+.TP
 \fB\-\-cvd\-version\fR
 Specify the version number to use for the build. Default is to use the value+1
 from the current CVD in \-\-datadir. If no datafile is found the default
 behaviour is to prompt for a version number, this switch will prevent the
 prompt.
 NOTE: If a CVD is found in the \-\-datadir its version+1 is used and this value is ignored.
-.TP 
+.TP
 \fB\-\-no\-cdiff\fR
 Don't create a .cdiff file when building a new database file.
-.TP 
+.TP
 \fB\-\-unsigned\fR
 Create a database file without digital signatures (.cud).
-.TP 
+.TP
 \fB\-\-server\fR
 ClamAV Signing Service address (for virus database maintainers only).
-.TP 
+.TP
 \fB\-\-datadir=DIR\fR
 Use DIR as the default database directory for all operations.
-.TP 
+.TP
 \fB\-\-unpack=FILE, \-u FILE\fR
 Unpack FILE (CVD) to a current directory.
-.TP 
+.TP
 \fB\-\-unpack\-current\fR
 Unpack a local CVD file (main or daily) to current directory.
-.TP 
+.TP
 \fB\-\-diff=OLD NEW, \-d OLD NEW\fR
 Create a diff file for OLD and NEW CVDs/INCDIRs.
-.TP 
+.TP
 \fB\-\-compare=OLD NEW, \-c OLD NEW\fR
 This command will compare two text files and print differences in a cdiff format.
-.TP 
+.TP
 \fB\-\-run\-cdiff=FILE, \-r FILE\fR
 Execute update script FILE in current directory.
-.TP 
+.TP
 \fB\-\-verify\-cdiff=FILE, \-r FILE\fR
 Verify DIFF against CVD/INCDIR.
-.TP 
+.TP
 \fB\-l[FILE], \-\-list\-sigs[=FILE]\fR
 List all signature names from the local database directory (default) or from FILE.
-.TP 
+.TP
 \fB\-fREGEX, \-\-find\-sigs=REGEX\fR
 Find and display signatures from the local database directory which match the given REGEX. The whole signature body (name, hex string, etc.) is checked.
-.TP 
+.TP
 \fB\-\-decode\-sigs=REGEX\fR
 Decode signatures read from the standard input (eg. piped from \-\-find\-sigs)
-.TP 
+.TP
 \fB\-\-test\-sigs=DATABASE TARGET_FILE\fR
 Test all signatures from DATABASE against TARGET_FILE. This option will only give valid results if the target file is the final one (after unpacking, normalization, etc.) for which the signatures were created.
 .TP
 \fB\-\-print\-certs=FILE\fR
 Print Authenticode details from a PE file.
+
+.SH "ENVIRONMENT VARIABLES"
+.LP
+Sigtool uses the following environment variables:
+.TP
+SIGNDUSER - The username to authenticate with the signing server when building a signed CVD database.
+.TP
+SIGNDPASS - The password to authenticate with the signing server when building a signed CVD database.
+
 .SH "EXAMPLES"
-.LP 
-.TP 
+.LP
+.TP
 Generate hex string from testfile and save it to testfile.hex:
 
 \fBcat testfile | sigtool \-\-hex\-dump > testfile.hex\fR
+
 .SH "CREDITS"
 Please check the full documentation for credits.
 .SH "AUTHOR"
-.LP 
+.LP
 Tomasz Kojm <tkojm@clamav.net>
 .SH "SEE ALSO"
-.LP 
+.LP
 freshclam(1), freshclam.conf(5)


### PR DESCRIPTION
The CURL_CA_BUNDLE environment variable used by freshclam & clamsubmit to
specify a custom path to a CA bundle is undocumented.

Feature was added here: https://bugzilla.clamav.net/show_bug.cgi?id=12504

Resolves: https://github.com/Cisco-Talos/clamav/issues/175

Also document:
- clamd/clamscan: using LD_LIBRARY_PATH to find libclamunrar_iface.so/dylib
- sigtool: using SIGNDUSER, SIGNDPASS for auth creds when building CVD

This info also needs to be added to the online documentation.