### PR TITLE
Fix systemd detection to detect also older versions of systemd

### DIFF
--- a/cmake/FindSYSTEMD.cmake
+++ b/cmake/FindSYSTEMD.cmake
@@ -63,7 +63,7 @@ if (NOT PC_SYSTEMD_FOUND)
 endif()
 
 find_path(SYSTEMD_INCLUDE_DIR
-    NAMES systemd/sd-bus.h
+    NAMES systemd/sd-daemon.h
     PATHS ${PC_SYSTEMD_INCLUDE_DIRS}
     PATH_SUFFIXES systemd
 )


### PR DESCRIPTION
This fixes issue when building on rhel7/centos7 and other distros with older systemd versions.

Fixes issue #258 