### PR TITLE
Yara: Fix crash with partially loaded yara files

### DIFF
--- a/libclamav/yara_exec.h
+++ b/libclamav/yara_exec.h
@@ -24,7 +24,7 @@ limitations under the License.
 #include <yara/rules.h>
 #endif
 
-#define UNDEFINED           0xFFFABADAFABADAFFLL
+#define UNDEFINED           (int64_t)0xFFFABADAFABADAFF
 #define IS_UNDEFINED(x)     ((x) == UNDEFINED)
 
 #define OP_HALT           255


### PR DESCRIPTION
Yara rule files may contain multiple signatures. If one of the
signatures fails to load because of a parse error in the yara rule
condition, the rest of the rules still load. This is fine, but it seems
that something isn't properly cleaned up, so there end up being runtime
crashes when running the correctly loaded rules as a result.

Specifically, the crash occurs because of an assert() that expects the
operation stack to be empty and it is not. A simple fix is to print an
error or debug message instead of crashing. It's not the right fix, but
it at least prevents crash.

Resolves: https://bugzilla.clamav.net/show_bug.cgi?id=12077

Also fixed a bunch of warnings in the yara module caused by comparing
different integer types.