### PR TITLE
CMake: restore clamunrar SO version, match clamav (0.104)

### DIFF
--- a/libclamunrar/CMakeLists.txt
+++ b/libclamunrar/CMakeLists.txt
@@ -67,7 +67,8 @@ if(ENABLE_SHARED_LIB)
     # The unrar shared library.
     add_library( clamunrar SHARED )
     set_target_properties(clamunrar PROPERTIES
-        VERSION "5.7.5" SOVERSION 5)
+        VERSION ${LIBCLAMAV_VERSION}
+        SOVERSION ${LIBCLAMAV_SOVERSION})
     target_sources( clamunrar
         PRIVATE
             ${UNRAR_SOURCES}


### PR DESCRIPTION
The libclamunrar (and libclamunrar_iface) SO versions tracked
libclamav's SO version in the old Autotools build system.

We accidentally rolled it backwards, setting it to be similar to UnRAR's
project version. Since the official UnRAR project doesn't have a Unix SO
version that we "should" match, and to prevent the theoretical
possibility of having a collision if an old and new clamav were
installed on the same box, we should make libclamunrar's version track
libclamav as it was before (and before 0.104 is released with CMake
being the stable, and only, build system).