### PR TITLE
CMake, Windows: install News, Readme, and html as UserManual

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -315,6 +315,13 @@ if (WIN32)
     SET(CPACK_WIX_CMAKE_PACKAGE_REGISTRY ClamAV)
     set(CPACK_PACKAGE_INSTALL_DIRECTORY  "ClamAV")
 
+    install(
+        FILES
+            ${CMAKE_CURRENT_SOURCE_DIR}/NEWS.md
+            ${CMAKE_CURRENT_SOURCE_DIR}/README.md
+        DESTINATION "."
+        COMPONENT documentation)
+
 elseif(APPLE)
     set(CPACK_GENERATOR productbuild)
     set(CPACK_PACKAGE_FILE_NAME ${CPACK_PACKAGE_FILE_NAME}.macos.universal)

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -109,8 +109,8 @@ endif()
 # which is exported from the clamav-faq repo.
 if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/html/index.html)
     if(WIN32)
-        install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/html
-            DESTINATION .
+        install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/html/
+            DESTINATION ./UserManual
             COMPONENT documentation)
     else()
         install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/html


### PR DESCRIPTION
For Windows to match 0.103 installer behavior, include NEWS.md and
README.md and rename the html directory to UserManual during the
install.

Unfortunately I can't match the behavior for the main page for the
user manual. It is now called index.html instead of UserManual.html
and is inside the UserManual directory instead of at the top level.