### PR TITLE
Fix segfault for signatures with pattern bytes >= 0x80 when using UTF-8 locale

### DIFF
--- a/libclamav/matcher-ac.c
+++ b/libclamav/matcher-ac.c
@@ -351,7 +351,7 @@ static int cli_ac_addpatt_recursive(struct cli_matcher *root, struct cli_ac_patt
     /* if pattern is nocase, we need to enumerate all the combinations if applicable
      * it's why this function was re-written to be recursive
      */
-    if ((pattern->sigopts & ACPATT_OPTION_NOCASE) && isalpha(pattern->pattern[i] & 0xff)) {
+    if ((pattern->sigopts & ACPATT_OPTION_NOCASE) && (pattern->pattern[i] & 0xff) < 0x80 && isalpha((unsigned char)(pattern->pattern[i] & 0xff))) {
         next = pt->trans[CLI_NOCASEI((unsigned char)(pattern->pattern[i] & 0xff))];
         if (!next)
             next = add_new_node(root, i, len);


### PR DESCRIPTION
I got this segfault on clamav 0.103.3 (also tested on `main` branch):
```
$ lldb bin/clamscan -- -d ~/signatures

(lldb) target create "bin/clamscan"
Current executable set to '/Users/username/clamav-0.103.3/build/install/bin/clamscan' (x86_64).

(lldb) settings set -- target.run-args  "-d" "/Users/username/signatures"

(lldb) run
Process 61912 launched: '/Users/username/clamav-0.103.3/build/install/bin/clamscan' (x86_64)
LibClamAV Warning: cli_loadyara: empty database file
Process 61912 stopped
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0x1060410e0)
    frame #0: 0x0000000100139117 libclamav.9.dylib`cli_ac_addpatt_recursive(root=0x0000000100cdc8c8, pattern=0x000000010603f2d8, pt=0x000000010603f3e0, i=1, len=3) at matcher-ac.c:355:16
   352       * it's why this function was re-written to be recursive
   353       */
   354      if ((pattern->sigopts & ACPATT_OPTION_NOCASE) && isalpha(pattern->pattern[i] & 0xff)) {
-> 355          next = pt->trans[CLI_NOCASEI((unsigned char)(pattern->pattern[i] & 0xff))];
   356          if (!next)
   357              next = add_new_node(root, i, len);
   358          if (!next)
Target 0: (clamscan) stopped.

(lldb) bt
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0x1060410e0)
  * frame #0: 0x0000000100139117 libclamav.9.dylib`cli_ac_addpatt_recursive(root=0x0000000100cdc8c8, pattern=0x000000010603f2d8, pt=0x000000010603f3e0, i=1, len=3) at matcher-ac.c:355:16
    frame #1: 0x000000010013928c libclamav.9.dylib`cli_ac_addpatt_recursive(root=0x0000000100cdc8c8, pattern=0x000000010603f2d8, pt=0x0000000100cdca60, i=0, len=3) at matcher-ac.c:376:12
    frame #2: 0x0000000100138feb libclamav.9.dylib`cli_ac_addpatt(root=0x0000000100cdc8c8, pattern=0x000000010603f2d8) at matcher-ac.c:411:12
    frame #3: 0x000000010013f37d libclamav.9.dylib`cli_ac_addsig(root=0x0000000100cdc8c8, virname="LetsTriggerTheBug", hexsig="a1b5bbefb8b5bb90a29f9198beb4bbe3a0b29594bf8c8594afb281e2b1b781e2b18493ef829f", sigopts='\x81', sigid=0, parts=0, partno=0, rtype=0, type=0, mindist=0, maxdist=0, offset="*", lsigid=0x00007ffeefbf4558, options=10250) at matcher-ac.c:2905:16
    frame #4: 0x000000010015056e libclamav.9.dylib`cli_parse_add(root=0x0000000100cdc8c8, virname="LetsTriggerTheBug", hexsig="a1b5bbefb8b5bb90a29f9198beb4bbe3a0b29594bf8c8594afb281e2b1b781e2b18493ef829f", sigopts='\x81', rtype=0, type=0, offset="*", target='\0', lsigid=0x00007ffeefbf4558, options=10250) at readdb.c:606:34
    frame #5: 0x000000010014f457 libclamav.9.dylib`cli_sigopts_handler(root=0x0000000100cdc8c8, virname="LetsTriggerTheBug", hexsig="a1b5bbefb8b5bb90a29f9198beb4bbe3a0b29594bf8c8594afb281e2b1b781e2b18493ef829f", sigopts='\x81', rtype=0, type=0, offset="*", target='\0', lsigid=0x00007ffeefbf4558, options=10250) at readdb.c:306:11
    frame #6: 0x000000010016381a libclamav.9.dylib`load_oneldb(buffer="LetsTriggerTheBug", chkpua=0, engine=0x0000000102008200, options=10250, dbname="test.ldb", line=2649, sigs=0x00007ffeefbf4838, bc_idx=0, buffer_cpy="LetsTriggerTheBug;Engine:81-255,Target:0;(0|1|2|3);a4b0beeabdb0be95a79a949dbbb1bee6a5b79091ba898091aab784e7b4b284e7b48196ea879a::i;a3b7b9edbab7b992a09d939abcb6b9e1a2b09796bd8e8796adb083e0b3b583e0b38691ed809d::i;a2b6b8ecbbb6b893a19c929bbdb7b8e0a3b19697bc8f8697acb182e1b2b482e1b28790ec819c::i;a1b5bbefb8b5bb90a29f9198beb4bbe3a0b29594bf8c8594afb281e2b1b781e2b18493ef829f::i", skip=0x0000000000000000) at readdb.c:1874:19
    frame #7: 0x0000000100154c94 libclamav.9.dylib`cli_loadldb(fs=0x00007fff9591cb60, engine=0x0000000102008200, signo=0x00000001000244c8, options=10250, dbio=0x0000000000000000, dbname="test.ldb") at readdb.c:1923:15
    frame #8: 0x0000000100151c55 libclamav.9.dylib`cli_load(filename="/Users/username/signatures/test.ldb", engine=0x0000000102008200, signo=0x00000001000244c8, options=10250, dbio=0x0000000000000000) at readdb.c:4404:15
    frame #9: 0x000000010015b2b8 libclamav.9.dylib`cli_loaddbdir(dirname="/Users/username/signatures", engine=0x0000000102008200, signo=0x00000001000244c8, options=10250) at readdb.c:4676:15
    frame #10: 0x000000010015a54b libclamav.9.dylib`cl_load(path="/Users/username/signatures", engine=0x0000000102008200, signo=0x00000001000244c8, dboptions=8202) at readdb.c:4783:19
    frame #11: 0x000000010000401c clamscan`scanmanager(opts=0x0000000100b04270) at manager.c:839:24
    frame #12: 0x0000000100002976 clamscan`main(argc=3, argv=0x00007ffeefbff2d8) at clamscan.c:171:11
    frame #13: 0x00007fff6f21fcc9 libdyld.dylib`start + 1
    frame #14: 0x00007fff6f21fcc9 libdyld.dylib`start + 1

(lldb) p/x pattern->pattern[i]
(uint16_t) $0 = 0x10b5
```

`clamscan` is explicitly setting the default locale here. On my macos system that is `en_US.UTF-8`.
https://github.com/Cisco-Talos/clamav/blob/clamav-0.103.3/clamscan/clamscan.c#L80-L89

This is easily reproducible with a small test program:
```
$ cat test.c && gcc -o test test.c && ./test
#include <stdio.h>
#include <ctype.h>
#include <locale.h>

int main(int argc, char *argv[])
{
    printf("Locale: %s\n", setlocale(LC_CTYPE, NULL));
    printf("isalpha((unsigned char) (0x10b5 & 0xff)): %x\n", isalpha((unsigned char) (0x10b5 & 0xff)));
    printf("toupper((unsigned char) (0x10b5 & 0xff)): %x\n", toupper((unsigned char) (0x10b5 & 0xff)));
    printf("\n");

    setlocale(LC_CTYPE, "");

    printf("Locale: %s\n", setlocale(LC_CTYPE, NULL));
    printf("isalpha((unsigned char) (0x10b5 & 0xff)): %x\n", isalpha((unsigned char) (0x10b5 & 0xff)));
    printf("toupper((unsigned char) (0x10b5 & 0xff)): %x\n", toupper((unsigned char) (0x10b5 & 0xff)));
    printf("\n");

    return 0;
}

Locale: C
isalpha((unsigned char) (0x10b5 & 0xff)): 0
toupper((unsigned char) (0x10b5 & 0xff)): b5

Locale: en_US.UTF-8
isalpha((unsigned char) (0x10b5 & 0xff)): 1
toupper((unsigned char) (0x10b5 & 0xff)): 39c
```

`0xb5` happens to be a greek letter and so it passes the `isalpha()` check; then `CLI_NOCASEI()` (macro for `toupper()`) converts it to uppercase mu, but that is higher than 256 so it _can_ fall out of the allocated range when accessing `pt->trans[]`.

- U+00B5 is the Micro Sign (also known as Mu)
- U+03BC is the Greek Small Letter Mu
- U+039C is the Greek Capital Letter Mu