### PR TITLE
Docker: Fix build after CMake/CPack changes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,10 +1,5 @@
 build/
-configure.ac
-COPYING*
 examples/
 INSTALL*
 Jenkinsfile
-Makefile.am
-m4/
-README.md
 win32/


### PR DESCRIPTION
Remove the README and COPYING entries from the .dockerignore file.
These are now required by CPack for the build to succeed.

Also removed the autotools entries, since they no longer exist.