### PR TITLE
CMake: Fix race condition with parallel builds

### DIFF
--- a/unit_tests/input/CMakeLists.txt
+++ b/unit_tests/input/CMakeLists.txt
@@ -62,6 +62,9 @@ if(ENABLE_UNRAR)
     )
 endif()
 
+add_custom_target(tgt_clamav_hdb_scanfiles ALL
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/clamav_hdb_scanfiles)
+
 # Decrypt test file
 function(decrypt_testfile test_file)
     add_custom_command(OUTPUT clamav_hdb_scanfiles/${test_file}
@@ -71,6 +74,7 @@ function(decrypt_testfile test_file)
                 --out_file ${CMAKE_CURRENT_BINARY_DIR}/clamav_hdb_scanfiles/${test_file}
         COMMENT "Decrypting test file ${test_file}...")
     add_custom_target(tgt_${test_file} ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/clamav_hdb_scanfiles/${test_file})
+    ADD_DEPENDENCIES(tgt_${test_file} tgt_clamav_hdb_scanfiles)
 endfunction()
 
 foreach(TESTFILE ${TESTFILES})

--- a/unit_tests/input/xor_testfile.py
+++ b/unit_tests/input/xor_testfile.py
@@ -53,9 +53,6 @@ def main():
 
     # Write out the result to the destination file.
     try:
-        if not out_file.parent.exists():
-            out_file.parent.mkdir()
-
         with out_file.open('w+b') as out_file_fd:
             out_file_fd.write(out_file_bytes)
 


### PR DESCRIPTION
If running multiple parallel processes of "xor_testfile.py" there was a
race condition between checking for the existence of the directory and
creating it. Now this is handled as a dependency in CMake.