### PR TITLE
docker: omit freshclam.dat file from image

### DIFF
--- a/dockerfiles/update_db_image.sh
+++ b/dockerfiles/update_db_image.sh
@@ -82,7 +82,7 @@ clamav_db_update()
 	for _tag in ${clamav_docker_tags}; do
 		{
 			echo "FROM ${docker_registry}/${clamav_docker_image}:${_tag}"
-			echo "RUN freshclam --foreground --stdout"
+			echo "RUN freshclam --foreground --stdout && rm /var/lib/clamav/freshclam.dat"
 		} | docker image build --pull --rm --tag "${docker_registry}/${clamav_docker_image}:${_tag%%_base}" -
 		docker image push "${docker_registry}/${clamav_docker_image}:${_tag%%_base}"
 	done


### PR DESCRIPTION
The freshclam.dat file shouldn't be in the Docker images or else
everyone using the image will have the same UUID.

This commit deletes it after each update.