### PR TITLE
CLAM-1567 empty cdiff support 0.103.4

### DIFF
--- a/libfreshclam/libfreshclam_internal.c
+++ b/libfreshclam/libfreshclam_internal.c
@@ -2329,7 +2329,7 @@ fc_error_t updatedb(
 
             ret = getcvd(remoteFilename, tmpfile, server, localTimestamp, remoteVersion, logerr);
             if (FC_SUCCESS != ret) {
-                if (FC_EMIRRORNOTSYNC == status) {
+                if (FC_EMIRRORNOTSYNC == ret) {
                     /* Note: We can't retry with CDIFF's if FC_EMIRRORNOTSYNC happened here.
                      * If we did there could be an infinite loop.
                      * Best option is to accept the older CVD.

--- a/libfreshclam/libfreshclam_internal.c
+++ b/libfreshclam/libfreshclam_internal.c
@@ -1284,7 +1284,11 @@ static fc_error_t downloadFile(
     switch (http_code) {
         case 200:
         case 206: {
-            status = FC_SUCCESS;
+            if (0 == receivedFile.size) {
+                status = FC_EEMPTYFILE;
+            } else {
+                status = FC_SUCCESS;
+            }
             break;
         }
         case 304: {
@@ -2407,8 +2411,8 @@ fc_error_t updatedb(
      */
 #ifdef _WIN32
     if (!access(newLocalFilename, R_OK) && unlink(newLocalFilename)) {
-        logg("!updatedb: Can't delete old database %s. Please fix the problem manually and try again.\n", newLocalFilename);
-        status = FC_EEMPTYFILE;
+        logg("!Update failed. Can't delete the old database %s to replace it with a new database. Please fix the problem manually and try again.\n", newLocalFilename);
+        status = FC_EDBDIRACCESS;
         goto done;
     }
 #endif
@@ -2594,7 +2598,7 @@ fc_error_t updatecustomdb(
         }
         snprintf(tmpfile_with_extension, tmpfile_with_extension_len + 1, "%s-%s", tmpfile, databaseName);
         if (rename(tmpfile, tmpfile_with_extension) == -1) {
-            logg("!updatecustomdb: Can't rename %s to %s: %s\n", tmpfile, tmpfile_with_extension, strerror(errno));
+            logg("!Custom database update failed: Can't rename %s to %s: %s\n", tmpfile, tmpfile_with_extension, strerror(errno));
             free(tmpfile_with_extension);
             status = FC_EDBDIRACCESS;
             goto done;
@@ -2617,8 +2621,8 @@ fc_error_t updatecustomdb(
      */
 #ifdef _WIN32
     if (!access(databaseName, R_OK) && unlink(databaseName)) {
-        logg("!updatecustomdb: Can't delete old database %s. Please fix the problem manually and try again.\n", databaseName);
-        status = FC_EEMPTYFILE;
+        logg("!Custom database update failed. Can't delete the old database %s to replace it with a new database. Please fix the problem manually and try again.\n", databaseName);
+        status = FC_EDBDIRACCESS;
         goto done;
     }
 #endif


### PR DESCRIPTION
2 freshclam bugs in 0.103.3 combined with the Cloudflare CDN serving yesterdays daily (caching issue) may result in an infinite loop of sorts if we serve a zero-byte cdiff or if the user is on a CVD version more than 90 days old and we're no longer serving the CDIFF they need.  

The resulting bad behavior is that freshclam may download daily.cvd 3x in a row and "fail" each time. The next time you run it again, provided that the CDN is still serving yesterday's daily, is the same. The consequence is A) using a ton of data and B) getting the user rate-limited (hopefully before it uses up their monthly internet data quota, for those with crappy ISP's).

The commits in this PR resolve both bugs.

What you can do to test this is seed your clamav database directory with an older version of `daily.cvd` and use `cvdupdate` with some manual edits to serve up a zero-byte `.cdiff` and to serve a `daily.cvd` that is older than what DNS advertises.  Be sure to have extra copies of the CVD files because the testing process will update/replace the ones in your clamav database directory.

1. For `cvdupdate`, you will need the daily CDIFFs at least as far back as the `daily.cvd` in your clamav database directory. 
2. Replace one of the `.cdiff` files in `~/.cvdupdate/database` with an empty file so that as `freshclam` is updating, it will encounter the empty one.  
3. Make sure that `~/.cvdupdate/database/daily.cvd` is not the current `daily.cvd` advertised by DNS.  If you don't have an older one, you can just run `cvd update` and then wait a day for a newer one to exist... or I can get you a specific version.   
4. Point the `freshclam.conf`'s `DatabaseMirror` option at `http://localhost:8000` and start `cvd serve`.  
5. Run `freshclam` and watch to see if it correctly identifies the empty file and behaves properly. 
- If 1 real `.cdiff` is downloaded and applied, it may take a second run of `freshclam` to update to the latest version. 
- If no `.cdiff`s are applied before hitting the empty `.cdiff` (that is, if the first `.cdiff` downloaded is the empty one), it should download a whole `daily.cvd` and then update using additional `.cdiff` patches.  

Either way, you should be fully up to date after no more than 2 runs of `freshclam`. 
If testing clamav before the fix, I would expect this behavior:
- 0.103.3: The first run may update to the version right before the zero-byte patch. The second run will download daily.cvd 3x and fail. Subsequent runs will be the same as the second (infinite loop of sorts).
- 0.104.0 or main: The first run may update to the version before the zero-byte patch. The second will download daily.cvd and succeed but not update all the way. The third will update the rest of the way.