### PR TITLE
cmake: Fix Windows .msi installer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -319,8 +319,7 @@ if (WIN32)
         FILES
             ${CMAKE_CURRENT_SOURCE_DIR}/NEWS.md
             ${CMAKE_CURRENT_SOURCE_DIR}/README.md
-        DESTINATION "."
-        COMPONENT documentation)
+        DESTINATION ".")
 
 elseif(APPLE)
     set(CPACK_GENERATOR productbuild)


### PR DESCRIPTION
At present the .msi installer is only installing documentation component
files and the vcredist files but fails to install clamav libraries,
programs, and dependencies.

It appears that explicitly installing the NEWS & README files under the
documentation component before calling "include(CPack)" was causing the
MSI installer to think it needed to install the documentation component
but nothing else.

This commit removes the component name, since we don't want to use
components in the Windows MSI installer anyways. This appears to resolve
the issue so that the MSI installer installs all the desired files.