### PR TITLE
Remove Heuristics.PNG.CVE-2010-1205 detection

### DIFF
--- a/libclamav/png.c
+++ b/libclamav/png.c
@@ -75,15 +75,6 @@ typedef struct __attribute__((packed)) {
 #pragma pack
 #endif
 
-#define BUFFER_SIZE 128000 /* size of read block  */
-
-typedef enum {
-    PNG_IDAT_NOT_FOUND_YET,
-    PNG_IDAT_DECOMPRESSION_IN_PROGRESS,
-    PNG_IDAT_DECOMPRESSION_COMPLETE,
-    PNG_IDAT_DECOMPRESSION_FAILED,
-} png_idat_state;
-
 cl_error_t cli_parsepng(cli_ctx *ctx)
 {
     cl_error_t status = CL_ERROR;
@@ -94,11 +85,9 @@ cl_error_t cli_parsepng(cli_ctx *ctx)
     uint32_t chunk_data_length_u32 = 0;
     bool have_IEND                 = false;
     bool have_PLTE                 = false;
-    uint64_t zhead                 = 1; /* 0x10000 indicates both zlib header bytes read */
 
-    int64_t num_chunks = 0;
-    uint64_t width     = 0;
-    uint64_t height    = 0;
+    uint64_t width  = 0;
+    uint64_t height = 0;
 
     uint32_t sample_depth = 0, bit_depth = 0, interlace_method = 0;
     uint64_t num_palette_entries = 0;
@@ -109,16 +98,7 @@ cl_error_t cli_parsepng(cli_ctx *ctx)
     uint64_t offset              = 8;
     fmap_t *map                  = NULL;
 
-    uint64_t image_size = 0;
-
-    int err                    = Z_OK;
-    uint8_t *decompressed_data = NULL;
-
-    bool zstrm_initialized = false;
-    z_stream zstrm;
-    size_t decompressed_data_len = 0;
-
-    png_idat_state idat_state = PNG_IDAT_NOT_FOUND_YET;
+    int err = Z_OK;
 
     cli_dbgmsg("in cli_parsepng()\n");
 
@@ -155,7 +135,6 @@ cl_error_t cli_parsepng(cli_ctx *ctx)
         /* GRR:  add 4-character EBCDIC conversion here (chunk_type) */
 
         chunk_type[4] = '\0';
-        ++num_chunks;
 
         cli_dbgmsg("Chunk Type: %s, Data Length: " STDu64 " bytes\n", chunk_type, chunk_data_length);
 
@@ -263,108 +242,7 @@ cl_error_t cli_parsepng(cli_ctx *ctx)
             /*------*
              | IDAT |
              *------*/
-
-            /*
-             * Note from pngcheck:
-             *   GRR 20000304:  data dump not yet compatible with interlaced images.
-             */
-
-            if (idat_state == PNG_IDAT_NOT_FOUND_YET) {
-                unsigned zlib_windowbits = 15;
-
-                /* Dump the zlib header from the first two bytes. */
-                if (zhead < 0x10000 && chunk_data_length > 0) {
-                    zhead = (zhead << 8) + ptr[0];
-                    if (chunk_data_length > 1 && zhead < 0x10000)
-                        zhead = (zhead << 8) + ptr[1];
-                    if (zhead >= 0x10000) {
-                        unsigned int CINFO = (zhead & 0xf000) >> 12;
-                        zlib_windowbits    = CINFO + 8;
-                    }
-                }
-
-                decompressed_data = (uint8_t *)malloc(BUFFER_SIZE);
-                if (NULL == decompressed_data) {
-                    cli_errmsg("Failed to allocation memory for decompressed PNG data.\n");
-                    goto done;
-                }
-
-                /* initialize zlib and bit/byte/line variables if not already done */
-                zstrm.zalloc = (alloc_func)Z_NULL;
-                zstrm.zfree  = (free_func)Z_NULL;
-                zstrm.opaque = (voidpf)Z_NULL;
-                if ((err = inflateInit2(&zstrm, zlib_windowbits)) != Z_OK) {
-                    cli_dbgmsg("PNG: zlib: can't initialize (error = %d)\n", err);
-
-                    idat_state = PNG_IDAT_DECOMPRESSION_FAILED;
-                } else {
-                    zstrm_initialized = true;
-                    uint64_t cur_width, cur_linebytes;
-                    int64_t cur_xoff  = 0;
-                    int64_t cur_xskip = interlace_method ? 8 : 1;
-                    cur_width         = (width - cur_xoff + cur_xskip - 1) / cur_xskip; /* round up */
-                    cur_linebytes     = ((cur_width * sample_depth + 7) >> 3) + 1;      /* round, fltr */
-                    image_size        = cur_linebytes * height;
-                    cli_dbgmsg("  Image Size:            " STDu64 "\n", image_size);
-
-                    idat_state = PNG_IDAT_DECOMPRESSION_IN_PROGRESS;
-                }
-            }
-
-            /* skip scans of image data > max scan size. */
-            if (image_size > ctx->engine->maxscansize) {
-                idat_state = PNG_IDAT_DECOMPRESSION_COMPLETE;
-            }
-
-            if (idat_state == PNG_IDAT_DECOMPRESSION_IN_PROGRESS) {
-                /*
-                 * We'll decompress the image data, but we don't _actually_ scan it.
-                 * We just want to know how much data comes out, so we can alert on the file
-                 * if it exceeds the image size calculated above (CVE-2010-1205).
-                 * Therefore, we'll use a static buffer and won't preserve the decompressed data.
-                 * This will prevent realloc errors from exceeding CLI_MAX_ALLOCATION,
-                 * will reduce RAM usage, and should be a wee bit faster.
-                 */
-                zstrm.next_in  = ptr;
-                zstrm.avail_in = chunk_data_length;
-
-                while (err != Z_STREAM_END) {
-                    if (zstrm.avail_in == 0) {
-                        // Ran out of data before zstream ended... Additional IDAT chunks expected.
-                        idat_state = PNG_IDAT_DECOMPRESSION_IN_PROGRESS;
-                        break;
-                    }
-
-                    /* Just keep overwriting our buffer, we don't need to save the PNG image data. */
-                    zstrm.next_out  = decompressed_data;
-                    zstrm.avail_out = BUFFER_SIZE;
-
-                    /* inflate! */
-                    err = inflate(&zstrm, Z_NO_FLUSH);
-                    decompressed_data_len += BUFFER_SIZE - zstrm.avail_out;
-                    if (err != Z_OK && err != Z_STREAM_END) {
-                        cli_dbgmsg("PNG: zlib: inflate error: %d, Image decompression failed!\n", err);
-                        inflateEnd(&zstrm);
-                        zstrm_initialized = false;
-                        idat_state        = PNG_IDAT_DECOMPRESSION_FAILED;
-                        break;
-                    }
-                }
-
-                if (err == Z_STREAM_END) {
-                    cli_dbgmsg("  TOTAL decompressed:    %zu\n", decompressed_data_len);
-                    inflateEnd(&zstrm);
-                    zstrm_initialized = false;
-                    idat_state        = PNG_IDAT_DECOMPRESSION_COMPLETE;
-
-                    if ((decompressed_data_len > image_size) && (SCAN_HEURISTIC_BROKEN_MEDIA)) {
-                        status = cli_append_virus(ctx, "Heuristics.PNG.CVE-2010-1205");
-                        goto done;
-                    }
-                } else {
-                    cli_dbgmsg("  Decompressed so far:   %zu  (Additional IDAT chunks expected)\n", decompressed_data_len);
-                }
-            }
+            cli_dbgmsg("  IDAT chunk: image data decompression no longer performed in PNG CVE checker.\n");
         } else if (strcmp(chunk_type, "IEND") == 0) {
             /*------*
              | IEND |
@@ -417,10 +295,6 @@ cl_error_t cli_parsepng(cli_ctx *ctx)
         cli_dbgmsg("PNG: EOF before IEND chunk!\n");
     }
 
-    if (idat_state == PNG_IDAT_DECOMPRESSION_IN_PROGRESS) {
-        cli_dbgmsg("PNG: EOF before Image data decompression completed, truncated or malformed file?\n");
-    }
-
 scan_overlay:
     if (status == CL_EPARSE) {
         /* We added with cli_append_possibly_unwanted so it will alert at the end if nothing else matches. */
@@ -437,12 +311,6 @@ scan_overlay:
     status = CL_CLEAN;
 
 done:
-    if (NULL != decompressed_data) {
-        free(decompressed_data);
-    }
-    if (zstrm_initialized) {
-        inflateEnd(&zstrm);
-    }
 
     return status;
 }


### PR DESCRIPTION
We received a high FP report rate for Heuristics.PNG.CVE-2010-1205.
This is a 11 year old CVE and is likely no longer relevant anyways.

In 0.103.3 we moved the detection behind "alert-broken-media", but since
it's actually common for "okay" images, we should remove this detection entirely.

Removing Heuristics.PNG.CVE-2010-1205 also means there is no longer any point
decompressing the PNG image data in the PNG CVE checker. Removing image
data decompression in the CVE checker should improve PNG image scan
times.