### PR TITLE
bb12576: allmatch hash based signatures

### DIFF
--- a/libclamav/matcher.c
+++ b/libclamav/matcher.c
@@ -1297,7 +1297,7 @@ cl_error_t cli_scan_fmap(cli_ctx *ctx, cli_file_t ftype, uint8_t ftonly, struct 
             if (found % 2) {
                 viruses_found = 1;
                 ret           = cli_append_virus(ctx, virname);
-                if (!SCAN_ALLMATCHES || ret != CL_CLEAN)
+                if (ret != CL_CLEAN && !SCAN_ALLMATCHES)
                     break;
                 virname = NULL;
             }
@@ -1305,7 +1305,7 @@ cl_error_t cli_scan_fmap(cli_ctx *ctx, cli_file_t ftype, uint8_t ftonly, struct 
             if (found > 1) {
                 viruses_found = 1;
                 ret           = cli_append_virus(ctx, virname_w);
-                if (!SCAN_ALLMATCHES || ret != CL_CLEAN)
+                if (ret != CL_CLEAN && !SCAN_ALLMATCHES)
                     break;
             }
         }

--- a/libclamav/pe.c
+++ b/libclamav/pe.c
@@ -2846,13 +2846,17 @@ int cli_scanpe(cli_ctx *ctx)
             if ((DCONF & PE_CONF_MD5SECT) && ctx->engine->hm_mdb) {
                 ret = scan_pe_mdb(ctx, &(peinfo->sections[i]));
                 if (ret != CL_CLEAN) {
-                    // TODO Handle allmatch
-                    if (ret != CL_VIRUS)
+                    if (ret == CL_VIRUS && !SCAN_ALLMATCHES) {
+                        cli_dbgmsg("------------------------------------\n");
+                        cli_exe_info_destroy(peinfo);
+                        return ret;
+                    } else if (ret != CL_VIRUS) {
                         cli_errmsg("cli_scanpe: scan_pe_mdb failed: %s!\n", cl_strerror(ret));
 
-                    cli_dbgmsg("------------------------------------\n");
-                    cli_exe_info_destroy(peinfo);
-                    return ret;
+                        cli_dbgmsg("------------------------------------\n");
+                        cli_exe_info_destroy(peinfo);
+                        return ret;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Resolves: https://bugzilla.clamav.net/show_bug.cgi?id=12576

* Fix bug with allmatch mode and hash-based signatures

All-match mode is presently not working if you have multiple hash-based
signatures for the same file.  That is, only the first signature will
alert before moving on to other parts of the scan.

Our current all-match implementation adds checked into every file parser
(often at multiple layers in the scanning process) to make sure that the
scan continued even if an alert is found, but only when in all-match mode.
This is clearly an error-prone approach.

Instead, I would like to change it so that every alert appends to an alert
list. When in all-match mode, the scan status would continue with "clean"
until the very end when the process is complete and the list of alerts is
evaluated.

Unfortunately, that's a much bigger job. For this specific bug, it is
simple enough to fix the broken logic that aborts the hash scanning
early. In the future, we should rework all of this logic throughout
libclamav, as described above.

* Fix all-match mode bug in PE section hash scans

The PE section hash scanning code didn't implement the all-match check.
While this check isn't the ideal implementation for all-match mode...
(see the commit message for the previous commit)
...it's simple enough to add the all-match check here for now.

* Test: Test all-match mode works for all hash sigs

Adds a clamscan test to verify that --allmatch mode works for the
clam.exe program when loading MD5, SHA1, SHA256, PE-section, & PE-import
hash signatures.
