### PR TITLE
Use all the link line from ncurses pkg-config

### DIFF
--- a/cmake/FindCURSES.cmake
+++ b/cmake/FindCURSES.cmake
@@ -58,11 +58,7 @@ if(NCURSES_NOT_FOUND EQUAL -1)
     set(HAVE_LIBNCURSES 1)
     set(CURSES_INCLUDE "<ncurses.h>")
 
-    find_library(CURSES_LIBRARY
-      NAMES ncurses
-      PATHS ${PC_NCurses_LIBRARY_DIRS}
-    )
-
+    set(CURSES_LIBRARY ${PC_NCurses_LINK_LIBRARIES})
     set(CURSES_VERSION ${PC_NCurses_VERSION})
 
     include(FindPackageHandleStandardArgs)


### PR DESCRIPTION
Otherwise it would fail at link time if ncurses has a stand alone tinfo library.