### PR TITLE
Clam 1576 clam 1240 clam 1584 memory leaks

### DIFF
--- a/libclamav/mbox.c
+++ b/libclamav/mbox.c
@@ -38,6 +38,7 @@
 #include <errno.h>
 #include <assert.h>
 #include <string.h>
+#include <stdbool.h>
 #ifdef HAVE_STRINGS_H
 #include <strings.h>
 #endif
@@ -113,21 +114,6 @@ static void print_trace(int use_syslog);
 #undef strtok_r
 #undef __strtok_r
 #define strtok_r(a, b, c) strtok(a, b)
-#endif
-
-#ifdef HAVE_STDBOOL_H
-#ifdef C_BEOS
-#include "SupportDefs.h"
-#else
-#include <stdbool.h>
-#endif
-#else
-#ifdef FALSE
-typedef unsigned char bool;
-#else
-typedef enum { FALSE = 0,
-               TRUE  = 1 } bool;
-#endif
 #endif
 
 typedef enum {
@@ -375,21 +361,18 @@ cli_parse_mbox(const char *dir, cli_ctx *ctx)
         /* empty message */
         return CL_CLEAN;
     }
+
 #ifdef CL_THREAD_SAFE
     pthread_mutex_lock(&tables_mutex);
 #endif
-    if (rfc821 == NULL) {
-        assert(subtype == NULL);
 
-        if (initialiseTables(&rfc821, &subtype) < 0) {
-            rfc821  = NULL;
-            subtype = NULL;
+    if (initialiseTables(&rfc821, &subtype) < 0) {
 #ifdef CL_THREAD_SAFE
-            pthread_mutex_unlock(&tables_mutex);
+        pthread_mutex_unlock(&tables_mutex);
 #endif
-            return CL_EMEM;
-        }
+        return CL_EMEM;
     }
+
 #ifdef CL_THREAD_SAFE
     pthread_mutex_unlock(&tables_mutex);
 #endif
@@ -442,7 +425,7 @@ cli_parse_mbox(const char *dir, cli_ctx *ctx)
         if (m == NULL)
             return CL_EMEM;
 
-        lastLineWasEmpty = FALSE;
+        lastLineWasEmpty = false;
         messagenumber    = 1;
         messageSetCTX(m, ctx);
 
@@ -454,7 +437,7 @@ cli_parse_mbox(const char *dir, cli_ctx *ctx)
                 /*
                  * End of a message in the mail box
                  */
-                bool heuristicFound = FALSE;
+                bool heuristicFound = false;
                 body                = parseEmailHeaders(m, rfc821, &heuristicFound);
                 if (body == NULL) {
                     messageReset(m);
@@ -514,7 +497,7 @@ cli_parse_mbox(const char *dir, cli_ctx *ctx)
 
         if (retcode == CL_SUCCESS) {
             cli_dbgmsg("Extract attachments from email %d\n", messagenumber);
-            bool heuristicFound = FALSE;
+            bool heuristicFound = false;
             body                = parseEmailHeaders(m, rfc821, &heuristicFound);
             if (heuristicFound) {
                 retcode = CL_VIRUS;
@@ -545,7 +528,7 @@ cli_parse_mbox(const char *dir, cli_ctx *ctx)
 
         buffer[sizeof(buffer) - 1] = '\0';
 
-        bool heuristicFound = FALSE;
+        bool heuristicFound = false;
         body                = parseEmailFile(map, &at, rfc821, buffer, dir, ctx, &heuristicFound);
         if (heuristicFound) {
             retcode = CL_VIRUS;
@@ -625,7 +608,7 @@ static ReadStruct *
 appendReadStruct(ReadStruct *rs, const char *const buffer)
 {
     if (NULL == rs) {
-        assert(rs && "Invalid argument");
+        cli_dbgmsg("appendReadStruct: Invalid argument\n");
         goto done;
     }
 
@@ -729,14 +712,14 @@ doContinueMultipleEmptyOptions(const char *const line, bool *lastWasOnlySemi)
 
         if (1 == doCont) {
             if (*lastWasOnlySemi) {
-                return TRUE;
+                return true;
             }
-            *lastWasOnlySemi = TRUE;
+            *lastWasOnlySemi = true;
         } else {
-            *lastWasOnlySemi = FALSE;
+            *lastWasOnlySemi = false;
         }
     }
-    return FALSE;
+    return false;
 }
 
 static bool
@@ -753,13 +736,13 @@ hitLineFoldCnt(const char *const line, size_t *lineFoldCnt, cli_ctx *ctx, bool *
         if ((*lineFoldCnt) >= HEURISTIC_EMAIL_MAX_LINE_FOLDS_PER_HEADER) {
             if (SCAN_HEURISTIC_EXCEEDS_MAX) {
                 cli_append_virus(ctx, "Heuristics.Limits.Exceeded.EmailLineFoldCnt");
-                *heuristicFound = TRUE;
+                *heuristicFound = true;
             }
 
-            return TRUE;
+            return true;
         }
     }
-    return FALSE;
+    return false;
 }
 
 static bool
@@ -769,12 +752,12 @@ haveTooManyHeaderBytes(size_t totalLen, cli_ctx *ctx, bool *heuristicFound)
     if (totalLen > HEURISTIC_EMAIL_MAX_HEADER_BYTES) {
         if (SCAN_HEURISTIC_EXCEEDS_MAX) {
             cli_append_virus(ctx, "Heuristics.Limits.Exceeded.EmailHeaderBytes");
-            *heuristicFound = TRUE;
+            *heuristicFound = true;
         }
 
-        return TRUE;
+        return true;
     }
-    return FALSE;
+    return false;
 }
 
 static bool
@@ -784,12 +767,12 @@ haveTooManyEmailHeaders(size_t totalHeaderCnt, cli_ctx *ctx, bool *heuristicFoun
     if (totalHeaderCnt > HEURISTIC_EMAIL_MAX_HEADERS) {
         if (SCAN_HEURISTIC_EXCEEDS_MAX) {
             cli_append_virus(ctx, "Heuristics.Limits.Exceeded.EmailHeaders");
-            *heuristicFound = TRUE;
+            *heuristicFound = true;
         }
 
-        return TRUE;
+        return true;
     }
-    return FALSE;
+    return false;
 }
 
 static bool
@@ -802,9 +785,9 @@ haveTooManyMIMEPartsPerMessage(size_t mimePartCnt, cli_ctx *ctx, mbox_status *rc
             *rc = VIRUS;
         }
 
-        return TRUE;
+        return true;
     }
-    return FALSE;
+    return false;
 }
 
 static bool
@@ -814,13 +797,13 @@ haveTooManyMIMEArguments(size_t argCnt, cli_ctx *ctx, bool *heuristicFound)
     if (argCnt >= HEURISTIC_EMAIL_MAX_ARGUMENTS_PER_HEADER) {
         if (SCAN_HEURISTIC_EXCEEDS_MAX) {
             cli_append_virus(ctx, "Heuristics.Limits.Exceeded.EmailMIMEArguments");
-            *heuristicFound = TRUE;
+            *heuristicFound = true;
         }
 
-        return TRUE;
+        return true;
     }
 
-    return FALSE;
+    return false;
 }
 
 /*
@@ -832,22 +815,22 @@ haveTooManyMIMEArguments(size_t argCnt, cli_ctx *ctx, bool *heuristicFound)
 static message *
 parseEmailFile(fmap_t *map, size_t *at, const table_t *rfc821, const char *firstLine, const char *dir, cli_ctx *ctx, bool *heuristicFound)
 {
-    bool inHeader     = TRUE;
-    bool bodyIsEmpty  = TRUE;
-    bool lastWasBlank = FALSE, lastBodyLineWasBlank = FALSE;
+    bool inHeader     = true;
+    bool bodyIsEmpty  = true;
+    bool lastWasBlank = false, lastBodyLineWasBlank = false;
     message *ret;
-    bool anyHeadersFound = FALSE;
+    bool anyHeadersFound = false;
     int commandNumber    = -1;
     char *boundary       = NULL;
     char buffer[RFC2821LENGTH + 1];
-    bool lastWasOnlySemi    = FALSE;
+    bool lastWasOnlySemi    = false;
     int err                 = 1;
     size_t totalHeaderBytes = 0;
     size_t totalHeaderCnt   = 0;
 
     size_t lineFoldCnt = 0;
 
-    *heuristicFound = FALSE;
+    *heuristicFound = false;
 
     ReadStruct *head = NULL;
     ReadStruct *curr = NULL;
@@ -884,10 +867,10 @@ parseEmailFile(fmap_t *map, size_t *at, const table_t *rfc821, const char *first
          * otherwise they'll be treated as the end of header marker
          */
         if (lastWasBlank) {
-            lastWasBlank = FALSE;
+            lastWasBlank = false;
             if (boundaryStart(buffer, boundary)) {
                 cli_dbgmsg("Found a header line with space that should be blank\n");
-                inHeader = FALSE;
+                inHeader = false;
             }
         }
         if (inHeader) {
@@ -942,7 +925,7 @@ parseEmailFile(fmap_t *map, size_t *at, const table_t *rfc821, const char *first
 
                     if (boundary ||
                         ((boundary = (char *)messageFindArgument(ret, "boundary")) != NULL)) {
-                        lastWasBlank = TRUE;
+                        lastWasBlank = true;
                         continue;
                     }
                 }
@@ -957,12 +940,12 @@ parseEmailFile(fmap_t *map, size_t *at, const table_t *rfc821, const char *first
                     continue;
 
                 cli_dbgmsg("End of header information\n");
-                inHeader    = FALSE;
-                bodyIsEmpty = TRUE;
+                inHeader    = false;
+                bodyIsEmpty = true;
             } else {
                 char *ptr;
                 const char *lookahead;
-                bool lineAdded = TRUE;
+                bool lineAdded = true;
 
                 if (0 == head->bufferLen) {
                     char cmd[RFC2821LENGTH + 1], out[RFC2821LENGTH + 1];
@@ -979,7 +962,7 @@ parseEmailFile(fmap_t *map, size_t *at, const table_t *rfc821, const char *first
                     if ((strchr(line, ':') == NULL) ||
                         (cli_strtokbuf(line, 0, ":", cmd) == NULL)) {
                         if (strncmp(line, "From ", 5) == 0)
-                            anyHeadersFound = TRUE;
+                            anyHeadersFound = true;
                         continue;
                     }
 
@@ -990,7 +973,7 @@ parseEmailFile(fmap_t *map, size_t *at, const table_t *rfc821, const char *first
                         case CONTENT_TRANSFER_ENCODING:
                         case CONTENT_DISPOSITION:
                         case CONTENT_TYPE:
-                            anyHeadersFound = TRUE;
+                            anyHeadersFound = true;
                             break;
                         default:
                             if (!anyHeadersFound)
@@ -1000,14 +983,14 @@ parseEmailFile(fmap_t *map, size_t *at, const table_t *rfc821, const char *first
                     curr = appendReadStruct(curr, line);
                     if (NULL == curr) {
                         if (ret) {
-                            ret->isTruncated = TRUE;
+                            ret->isTruncated = true;
                         }
                         break;
                     }
                 } else if (line != NULL) {
                     curr = appendReadStruct(curr, line);
                 } else {
-                    lineAdded = FALSE;
+                    lineAdded = false;
                 }
 
                 if (lineAdded) {
@@ -1069,7 +1052,7 @@ parseEmailFile(fmap_t *map, size_t *at, const table_t *rfc821, const char *first
              * Fast track visa to uudecode.
              * TODO: binhex, yenc
              */
-            bodyIsEmpty = FALSE;
+            bodyIsEmpty = false;
             if (uudecodeFile(ret, line, dir, map, at) < 0)
                 if (messageAddStr(ret, line) < 0)
                     break;
@@ -1085,7 +1068,7 @@ parseEmailFile(fmap_t *map, size_t *at, const table_t *rfc821, const char *first
                     cli_dbgmsg("Ignoring consecutive blank lines in the body\n");
                     continue;
                 }
-                lastBodyLineWasBlank = TRUE;
+                lastBodyLineWasBlank = true;
             } else {
                 if (bodyIsEmpty) {
                     /*
@@ -1096,9 +1079,9 @@ parseEmailFile(fmap_t *map, size_t *at, const table_t *rfc821, const char *first
                      */
                     if (newline_in_header(line))
                         continue;
-                    bodyIsEmpty = FALSE;
+                    bodyIsEmpty = false;
                 }
-                lastBodyLineWasBlank = FALSE;
+                lastBodyLineWasBlank = false;
             }
 
             if (messageAddStr(ret, line) < 0)
@@ -1110,7 +1093,7 @@ parseEmailFile(fmap_t *map, size_t *at, const table_t *rfc821, const char *first
 done:
     if (err) {
         cli_errmsg("parseEmailFile: ERROR parsing file\n");
-        ret->isTruncated = TRUE;
+        ret->isTruncated = true;
     }
 
     FREE(boundary);
@@ -1148,21 +1131,21 @@ done:
 static message *
 parseEmailHeaders(message *m, const table_t *rfc821, bool *heuristicFound)
 {
-    bool inHeader    = TRUE;
-    bool bodyIsEmpty = TRUE;
+    bool inHeader    = true;
+    bool bodyIsEmpty = true;
     text *t;
     message *ret;
-    bool anyHeadersFound  = FALSE;
+    bool anyHeadersFound  = false;
     int commandNumber     = -1;
     char *fullline        = NULL;
     size_t fulllinelength = 0;
-    bool lastWasOnlySemi  = FALSE;
+    bool lastWasOnlySemi  = false;
     size_t lineFoldCnt    = 0;
     size_t totalHeaderCnt = 0;
 
     cli_dbgmsg("parseEmailHeaders\n");
 
-    *heuristicFound = FALSE;
+    *heuristicFound = false;
 
     if (m == NULL)
         return NULL;
@@ -1198,11 +1181,11 @@ parseEmailHeaders(message *m, const table_t *rfc821, bool *heuristicFound)
                     cli_dbgmsg("Nothing interesting in the header\n");
                     break;
                 }
-                inHeader    = FALSE;
-                bodyIsEmpty = TRUE;
+                inHeader    = false;
+                bodyIsEmpty = true;
             } else {
                 char *ptr;
-                bool lineAdded = TRUE;
+                bool lineAdded = true;
 
                 if (fullline == NULL) {
                     char cmd[RFC2821LENGTH + 1];
@@ -1219,7 +1202,7 @@ parseEmailHeaders(message *m, const table_t *rfc821, bool *heuristicFound)
                     if ((strchr(line, ':') == NULL) ||
                         (cli_strtokbuf(line, 0, ":", cmd) == NULL)) {
                         if (strncmp(line, "From ", 5) == 0)
-                            anyHeadersFound = TRUE;
+                            anyHeadersFound = true;
                         continue;
                     }
 
@@ -1232,7 +1215,7 @@ parseEmailHeaders(message *m, const table_t *rfc821, bool *heuristicFound)
                         case CONTENT_TRANSFER_ENCODING:
                         case CONTENT_DISPOSITION:
                         case CONTENT_TYPE:
-                            anyHeadersFound = TRUE;
+                            anyHeadersFound = true;
                             break;
                         default:
                             if (!anyHeadersFound)
@@ -1249,9 +1232,9 @@ parseEmailHeaders(message *m, const table_t *rfc821, bool *heuristicFound)
                     fullline = ptr;
                     cli_strlcat(fullline, line, fulllinelength);
                 } else {
-                    lineAdded = FALSE;
+                    lineAdded = false;
                 }
-                assert(fullline != NULL);
+
                 /*continue doesn't seem right here, but that is what is done everywhere else when a malloc fails.*/
                 if (NULL == fullline) {
                     continue;
@@ -1306,7 +1289,7 @@ parseEmailHeaders(message *m, const table_t *rfc821, bool *heuristicFound)
                  */
                 if (newline_in_header(line))
                     continue;
-                bodyIsEmpty = FALSE;
+                bodyIsEmpty = false;
             }
             /*if(t->t_line && isuuencodebegin(t->t_line))
                 puts("FIXME: add fast visa here");*/
@@ -1648,13 +1631,13 @@ parseEmailBody(message *messageIn, text *textIn, mbox_ctx *mctx, unsigned int re
     text *aText          = textIn;
     message *mainMessage = messageIn;
     fileblob *fb;
-    bool infected                  = FALSE;
+    bool infected                  = false;
     const struct cl_engine *engine = mctx->ctx->engine;
     const int doPhishingScan       = engine->dboptions & CL_DB_PHISHING_URLS && (DCONF_PHISHING & PHISHING_CONF_ENGINE);
 #if HAVE_JSON
     json_object *saveobj = mctx->wrkobj;
 #endif
-    bool heuristicFound = FALSE;
+    bool heuristicFound = false;
 
     cli_dbgmsg("in parseEmailBody, %u files saved so far\n",
                mctx->files);
@@ -1704,7 +1687,13 @@ parseEmailBody(message *messageIn, text *textIn, mbox_ctx *mctx, unsigned int re
             cli_jsonstr(mctx->wrkobj, "MimeSubtype", mimeSubtype);
             cli_jsonstr(mctx->wrkobj, "EncodingType", getEncTypeStr(messageGetEncoding(mainMessage)));
             cli_jsonstr(mctx->wrkobj, "Disposition", messageGetDispositionType(mainMessage));
-            cli_jsonstr(mctx->wrkobj, "Filename", messageHasFilename(mainMessage) ? messageGetFilename(mainMessage) : "(inline)");
+            if (messageHasFilename(mainMessage)) {
+                char *filename = messageGetFilename(mainMessage);
+                cli_jsonstr(mctx->wrkobj, "Filename", filename);
+                free(filename);
+            } else {
+                cli_jsonstr(mctx->wrkobj, "Filename", "(inline)");
+            }
         }
 #endif
 
@@ -1759,7 +1748,7 @@ parseEmailBody(message *messageIn, text *textIn, mbox_ctx *mctx, unsigned int re
                      * html too, so scan them for phishing
                      */
                     if (rc == VIRUS)
-                        infected = TRUE;
+                        infected = true;
                 }
                 break;
             case MULTIPART:
@@ -1817,7 +1806,7 @@ parseEmailBody(message *messageIn, text *textIn, mbox_ctx *mctx, unsigned int re
                             if (exportBinhexMessage(mctx, mainMessage)) {
                                 /* virus found */
                                 rc       = VIRUS;
-                                infected = TRUE;
+                                infected = true;
                                 break;
                             }
                         } else if (t_line->t_next &&
@@ -1968,7 +1957,7 @@ parseEmailBody(message *messageIn, text *textIn, mbox_ctx *mctx, unsigned int re
                                 inhead = inMimeHead = 0;
                                 continue;
                             }
-                            inMimeHead = FALSE;
+                            inMimeHead = false;
                             messageAddArgument(aMessage, line);
                         } else if (inhead) { /* handling normal headers */
                             /*int quotes;*/
@@ -2051,9 +2040,17 @@ parseEmailBody(message *messageIn, text *textIn, mbox_ctx *mctx, unsigned int re
                                 continue;
                             }
 
-                            inMimeHead = FALSE;
+                            inMimeHead = false;
 
-                            assert(strlen(line) <= RFC2821LENGTH);
+                            if (strlen(line) > RFC2821LENGTH) {
+                                cli_dbgmsg("parseEmailBody: line length exceds RFC2821 maximum length (1000)\n");
+                                // We must skip this line because functions like rfc822comments() may accept output buffers
+                                // that [RFC2821LENGTH + 1] in and don't have any length checks to prevent exceeding that max.
+                                // E.g. See `boundaryStart()`.
+                                // TODO: A larger audit would be needed to remove this limitation, though frankly I recommend
+                                // fully re-writing the email parser (in Rust).
+                                continue;
+                            }
 
                             fullline = rfc822comments(line, NULL);
                             if (fullline == NULL)
@@ -2085,7 +2082,7 @@ parseEmailBody(message *messageIn, text *textIn, mbox_ctx *mctx, unsigned int re
                                      */
                                     cli_dbgmsg("Multipart %d: headers not terminated by blank line\n",
                                                multiparts);
-                                    inhead = FALSE;
+                                    inhead = false;
                                     break;
                                 }
 
@@ -2160,7 +2157,7 @@ parseEmailBody(message *messageIn, text *textIn, mbox_ctx *mctx, unsigned int re
                             }
                             --multiparts;
                             if (rc == VIRUS)
-                                infected = TRUE;
+                                infected = true;
                             break;
 
                         case RELATED:
@@ -2271,8 +2268,8 @@ parseEmailBody(message *messageIn, text *textIn, mbox_ctx *mctx, unsigned int re
                          * Have a look to see if there's HTML code
                          * which will need scanning
                          */
-                        aMessage = NULL;
-                        assert(multiparts > 0);
+
+                        // It's okay if multiparts == 0
 
                         htmltextPart = getTextPart(messages, multiparts);
 
@@ -2289,7 +2286,6 @@ parseEmailBody(message *messageIn, text *textIn, mbox_ctx *mctx, unsigned int re
                              */
                             for (i = 0; i < multiparts; i++) {
                                 if (messageGetMimeType(messages[i]) == MULTIPART) {
-                                    aMessage     = messages[i];
                                     htmltextPart = i;
                                     break;
                                 }
@@ -2302,15 +2298,14 @@ parseEmailBody(message *messageIn, text *textIn, mbox_ctx *mctx, unsigned int re
 #if HAVE_JSON
                             /* Send root HTML file for preclassification */
                             if (mctx->ctx->wrkproperty)
-                                (void)parseRootMHTML(mctx, aMessage, aText);
+                                (void)parseRootMHTML(mctx, messages[htmltextPart], aText);
 #endif
-                            rc = parseEmailBody(aMessage, aText, mctx, recursion_level + 1);
-                            if ((rc == OK) && aMessage) {
-                                assert(aMessage == messages[htmltextPart]);
-                                messageDestroy(aMessage);
+                            rc = parseEmailBody(messages[htmltextPart], aText, mctx, recursion_level + 1);
+                            if ((rc == OK) && messages[htmltextPart]) {
+                                messageDestroy(messages[htmltextPart]);
                                 messages[htmltextPart] = NULL;
                             } else if (rc == VIRUS) {
-                                infected = TRUE;
+                                infected = true;
                                 break;
                             }
                         }
@@ -2380,7 +2375,7 @@ parseEmailBody(message *messageIn, text *textIn, mbox_ctx *mctx, unsigned int re
                                                        messages, i, &rc, mctx,
                                                        messageIn, &aText, recursion_level + 1);
                             if (rc == VIRUS) {
-                                infected = TRUE;
+                                infected = true;
                                 break;
                             }
                             if (rc == MAXREC)
@@ -2569,7 +2564,7 @@ parseEmailBody(message *messageIn, text *textIn, mbox_ctx *mctx, unsigned int re
         /* Look for a bounce in the text (non mime encoded) portion */
         const text *t;
         /* isBounceStart() is expensive, reduce the number of calls */
-        bool lookahead_definately_is_bounce = FALSE;
+        bool lookahead_definately_is_bounce = false;
 
         for (t = aText; t && (rc != VIRUS); t = t->t_next) {
             const line_t *l = t->t_line;
@@ -2578,19 +2573,18 @@ parseEmailBody(message *messageIn, text *textIn, mbox_ctx *mctx, unsigned int re
             bool inheader;
 
             if (l == NULL) {
-                /* assert(lookahead_definately_is_bounce == FALSE) */
                 continue;
             }
 
             if (lookahead_definately_is_bounce)
-                lookahead_definately_is_bounce = FALSE;
+                lookahead_definately_is_bounce = false;
             else if (!isBounceStart(mctx, lineGetData(l)))
                 continue;
 
             lookahead = t->t_next;
             if (lookahead) {
                 if (isBounceStart(mctx, lineGetData(lookahead->t_line))) {
-                    lookahead_definately_is_bounce = TRUE;
+                    lookahead_definately_is_bounce = true;
                     /* don't save worthless header lines */
                     continue;
                 }
@@ -2671,14 +2665,14 @@ parseEmailBody(message *messageIn, text *textIn, mbox_ctx *mctx, unsigned int re
             fileblobAddData(fb, (const unsigned char *)"Received: by clamd (bounce)\n", 28);
             fileblobSetCTX(fb, mctx->ctx);
 
-            inheader    = TRUE;
+            inheader    = true;
             topofbounce = NULL;
             do {
                 l = t->t_line;
 
                 if (l == NULL) {
                     if (inheader) {
-                        inheader    = FALSE;
+                        inheader    = false;
                         topofbounce = t;
                     }
                 } else {
@@ -2695,7 +2689,7 @@ parseEmailBody(message *messageIn, text *textIn, mbox_ctx *mctx, unsigned int re
                     s = lineGetData(l);
                     if (isBounceStart(mctx, s)) {
                         cli_dbgmsg("Found the start of another bounce candidate (%s)\n", s);
-                        lookahead_definately_is_bounce = TRUE;
+                        lookahead_definately_is_bounce = true;
                         break;
                     }
                 }
@@ -2758,14 +2752,14 @@ parseEmailBody(message *messageIn, text *textIn, mbox_ctx *mctx, unsigned int re
                         rc = VIRUS;
                     mctx->files++;
                 }
-                saveIt = FALSE;
+                saveIt = false;
             } else
                 /*
                  * Save the entire text portion,
                  * since it it may be an HTML file with
                  * a JavaScript virus or a phish
                  */
-                saveIt = TRUE;
+                saveIt = true;
 
             if (saveIt) {
                 cli_dbgmsg("Saving text part to scan, rc = %d\n",
@@ -3010,6 +3004,8 @@ boundaryEnd(const char *line, const char *boundary)
 
 /*
  * Initialise the various lookup tables
+ *
+ * Only initializes the tables if not already initialized.
  */
 static int
 initialiseTables(table_t **rfc821Table, table_t **subtypeTable)
@@ -3019,27 +3015,38 @@ initialiseTables(table_t **rfc821Table, table_t **subtypeTable)
     /*
      * Initialise the various look up tables
      */
-    *rfc821Table = tableCreate();
-    assert(*rfc821Table != NULL);
+    if (NULL == *rfc821Table) {
+        *rfc821Table = tableCreate();
+        if (*rfc821Table == NULL) {
+            return -1;
+        }
 
-    for (tableinit = rfc821headers; tableinit->key; tableinit++)
-        if (tableInsert(*rfc821Table, tableinit->key, tableinit->value) < 0) {
+        for (tableinit = rfc821headers; tableinit->key; tableinit++) {
+            if (tableInsert(*rfc821Table, tableinit->key, tableinit->value) < 0) {
+                tableDestroy(*rfc821Table);
+                *rfc821Table = NULL;
+                return -1;
+            }
+        }
+    }
+    if (NULL == *subtypeTable) {
+        *subtypeTable = tableCreate();
+        if (*subtypeTable == NULL) {
             tableDestroy(*rfc821Table);
             *rfc821Table = NULL;
             return -1;
         }
 
-    *subtypeTable = tableCreate();
-    assert(*subtypeTable != NULL);
-
-    for (tableinit = mimeSubtypes; tableinit->key; tableinit++)
-        if (tableInsert(*subtypeTable, tableinit->key, tableinit->value) < 0) {
-            tableDestroy(*rfc821Table);
-            tableDestroy(*subtypeTable);
-            *rfc821Table  = NULL;
-            *subtypeTable = NULL;
-            return -1;
+        for (tableinit = mimeSubtypes; tableinit->key; tableinit++) {
+            if (tableInsert(*subtypeTable, tableinit->key, tableinit->value) < 0) {
+                tableDestroy(*rfc821Table);
+                tableDestroy(*subtypeTable);
+                *rfc821Table  = NULL;
+                *subtypeTable = NULL;
+                return -1;
+            }
         }
+    }
 
     return 0;
 }
@@ -3136,7 +3143,7 @@ parseMimeHeader(message *m, const char *cmd, const table_t *rfc821Table, const c
     int commandNumber;
     size_t argCnt = 0;
 
-    *heuristicFound = FALSE;
+    *heuristicFound = false;
 
     cli_dbgmsg("parseMimeHeader: cmd='%s', arg='%s'\n", cmd, arg);
 
@@ -3367,16 +3374,18 @@ rfc822comments(const char *in, char *out)
     char *optr;
     int backslash, inquote, commentlevel;
 
-    if (in == NULL)
+    if (in == NULL || out == in) {
+        cli_errmsg("rfc822comments: Invalid parameters.n");
         return NULL;
+    }
 
-    if (strchr(in, '(') == NULL)
+    if (strchr(in, '(') == NULL) {
         return NULL;
+    }
 
-    assert(out != in);
-
-    while (isspace((const unsigned char)*in))
+    while (isspace((const unsigned char)*in)) {
         in++;
+    }
 
     if (out == NULL) {
         out = cli_malloc(strlen(in) + 1);
@@ -3503,7 +3512,10 @@ rfc2047(const char *in)
         }
         in += 2;
         ptr = strstr(enctext, "?=");
-        assert(ptr != NULL);
+        if (NULL == ptr) {
+            free(enctext);
+            break;
+        }
         *ptr = '\0';
         /*cli_dbgmsg("Need to decode '%s' with method '%c'\n", enctext, encoding);*/
 
@@ -3513,7 +3525,10 @@ rfc2047(const char *in)
             break;
         }
         messageAddStr(m, enctext);
+
         free(enctext);
+        enctext = NULL;
+
         switch (encoding) {
             case 'q':
                 messageSetEncoding(m, "quoted-printable");
@@ -3915,7 +3930,7 @@ checkURLs(message *mainMessage, mbox_ctx *mctx, mbox_status *rc, int is_html)
                  *    encapsulated so we should not access
                  *    the members directly
                  */
-                mainMessage->isInfected = TRUE;
+                mainMessage->isInfected = true;
                 *rc                     = VIRUS;
                 cli_dbgmsg("PH:Phishing found\n");
             }
@@ -3974,17 +3989,17 @@ usefulHeader(int commandNumber, const char *cmd)
         case CONTENT_TRANSFER_ENCODING:
         case CONTENT_DISPOSITION:
         case CONTENT_TYPE:
-            return TRUE;
+            return true;
         default:
             if (strcasecmp(cmd, "From") == 0)
-                return TRUE;
+                return true;
             if (strcasecmp(cmd, "Received") == 0)
-                return TRUE;
+                return true;
             if (strcasecmp(cmd, "De") == 0)
-                return TRUE;
+                return true;
     }
 
-    return FALSE;
+    return false;
 }
 
 /*
@@ -4062,17 +4077,17 @@ isBounceStart(mbox_ctx *mctx, const char *line)
     size_t len;
 
     if (line == NULL)
-        return FALSE;
+        return false;
     if (*line == '\0')
-        return FALSE;
+        return false;
     /*if((strncmp(line, "From ", 5) == 0) && !isalnum(line[5]))
-        return FALSE;
+        return false;
     if((strncmp(line, ">From ", 6) == 0) && !isalnum(line[6]))
-        return FALSE;*/
+        return false;*/
 
     len = strlen(line);
     if ((len < 6) || (len >= 72))
-        return FALSE;
+        return false;
 
     if ((memcmp(line, "From ", 5) == 0) ||
         (memcmp(line, ">From ", 6) == 0)) {
@@ -4088,10 +4103,10 @@ isBounceStart(mbox_ctx *mctx, const char *line)
         while (*++line != '\0');
 
         if (numSpaces < 6)
-            return FALSE;
+            return false;
         if (numDigits < 11)
-            return FALSE;
-        return TRUE;
+            return false;
+        return true;
     }
     return (bool)(cli_compare_ftm_file((const unsigned char *)line, len, mctx->ctx->engine) == CL_TYPE_MAIL);
 }
@@ -4103,7 +4118,7 @@ isBounceStart(mbox_ctx *mctx, const char *line)
 static bool
 exportBinhexMessage(mbox_ctx *mctx, message *m)
 {
-    bool infected = FALSE;
+    bool infected = false;
     fileblob *fb;
 
     if (messageGetEncoding(m) == NOENCODING)
@@ -4116,7 +4131,7 @@ exportBinhexMessage(mbox_ctx *mctx, message *m)
                    fileblobGetFilename(fb));
 
         if (fileblobScanAndDestroy(fb) == CL_VIRUS)
-            infected = TRUE;
+            infected = true;
         mctx->files++;
     } else
         cli_errmsg("Couldn't decode binhex file to %s\n", mctx->dir);
@@ -4237,7 +4252,7 @@ static const char *getEncTypeStr(encoding_type enctype)
 static message *
 do_multipart(message *mainMessage, message **messages, int i, mbox_status *rc, mbox_ctx *mctx, message *messageIn, text **tptr, unsigned int recursion_level)
 {
-    bool addToText = FALSE;
+    bool addToText = false;
     const char *dtype;
 #ifndef SAVE_TO_DISC
     message *body;
@@ -4251,20 +4266,10 @@ do_multipart(message *mainMessage, message **messages, int i, mbox_status *rc, m
         json_object *multiobj = cli_jsonarray(mctx->wrkobj, "Multipart");
         if (multiobj == NULL) {
             cli_errmsg("Cannot get multipart preclass array\n");
-            *rc = -1;
-            return mainMessage;
-        }
-
-        thisobj = messageGetJObj(aMessage);
-        if (thisobj == NULL) {
+        } else if (NULL == (thisobj = messageGetJObj(aMessage))) {
             cli_dbgmsg("Cannot get message preclass object\n");
-            *rc = -1;
-            return mainMessage;
-        }
-        if (cli_json_addowner(multiobj, thisobj, NULL, -1) != CL_SUCCESS) {
+        } else if (CL_SUCCESS != cli_json_addowner(multiobj, thisobj, NULL, -1)) {
             cli_errmsg("Cannot assign message preclass object to multipart preclass array\n");
-            *rc = -1;
-            return mainMessage;
         }
     }
 #endif
@@ -4289,7 +4294,13 @@ do_multipart(message *mainMessage, message **messages, int i, mbox_status *rc, m
         cli_jsonstr(thisobj, "MimeSubtype", messageGetMimeSubtype(aMessage));
         cli_jsonstr(thisobj, "EncodingType", getEncTypeStr(messageGetEncoding(aMessage)));
         cli_jsonstr(thisobj, "Disposition", messageGetDispositionType(aMessage));
-        cli_jsonstr(thisobj, "Filename", messageHasFilename(aMessage) ? messageGetFilename(aMessage) : "(inline)");
+        if (messageHasFilename(aMessage)) {
+            char *filename = messageGetFilename(aMessage);
+            cli_jsonstr(thisobj, "Filename", filename);
+            free(filename);
+        } else {
+            cli_jsonstr(thisobj, "Filename", "(inline)");
+        }
     }
 #endif
 
@@ -4316,11 +4327,10 @@ do_multipart(message *mainMessage, message **messages, int i, mbox_status *rc, m
                     cli_dbgmsg("Found binhex message in multipart/mixed non mime part\n");
                     if (exportBinhexMessage(mctx, aMessage))
                         *rc = VIRUS;
-                    assert(aMessage == messages[i]);
                     messageReset(messages[i]);
                 }
             }
-            addToText = TRUE;
+            addToText = true;
             if (messageGetBody(aMessage) == NULL)
                 /*
                  * No plain text version
@@ -4350,7 +4360,7 @@ do_multipart(message *mainMessage, message **messages, int i, mbox_status *rc, m
                      */
                     if (!messageHasFilename(aMessage)) {
                         cli_dbgmsg("Adding part to main message\n");
-                        addToText = TRUE;
+                        addToText = true;
                     } else
                         cli_dbgmsg("Treating inline as attachment\n");
                 } else {
@@ -4385,7 +4395,6 @@ do_multipart(message *mainMessage, message **messages, int i, mbox_status *rc, m
                          * itself has been encoded
                          */
                         cli_dbgmsg("Unencoded multipart/message will not be scanned\n");
-                        assert(aMessage == messages[i]);
                         messageDestroy(messages[i]);
                         messages[i] = NULL;
                         return mainMessage;
@@ -4395,10 +4404,7 @@ do_multipart(message *mainMessage, message **messages, int i, mbox_status *rc, m
                     cli_dbgmsg("Encoded multipart/message will be scanned\n");
             }
 #endif
-#if 0
-            messageAddStrAtTop(aMessage,
-                "Received: by clamd (message/rfc822)");
-#endif
+
 #ifdef SAVE_TO_DISC
             /*
              * Save this embedded message
@@ -4406,7 +4412,6 @@ do_multipart(message *mainMessage, message **messages, int i, mbox_status *rc, m
              */
             if (saveTextPart(mctx, aMessage, 1) == CL_VIRUS)
                 *rc = VIRUS;
-            assert(aMessage == messages[i]);
             messageDestroy(messages[i]);
             messages[i] = NULL;
 #else
@@ -4424,7 +4429,6 @@ do_multipart(message *mainMessage, message **messages, int i, mbox_status *rc, m
              * message as a message.
              * This can save a lot of memory
              */
-            assert(aMessage == messages[i]);
             messageDestroy(messages[i]);
             messages[i]  = NULL;
 #if HAVE_JSON
@@ -4459,7 +4463,6 @@ do_multipart(message *mainMessage, message **messages, int i, mbox_status *rc, m
                  */
                 *rc = parseEmailBody(aMessage, *tptr, mctx, recursion_level + 1);
                 cli_dbgmsg("Finished recursion, rc = %d\n", (int)*rc);
-                assert(aMessage == messages[i]);
                 messageDestroy(messages[i]);
                 messages[i] = NULL;
             } else {
@@ -4563,10 +4566,10 @@ next_is_folded_header(const text *t)
     const char *data, *ptr;
 
     if (next == NULL)
-        return FALSE;
+        return false;
 
     if (next->t_line == NULL)
-        return FALSE;
+        return false;
 
     data = lineGetData(next->t_line);
 
@@ -4575,7 +4578,7 @@ next_is_folded_header(const text *t)
      * previous entry.
      */
     if (isblank(data[0]))
-        return TRUE;
+        return true;
 
     if (strchr(data, '=') == NULL)
         /*
@@ -4583,7 +4586,7 @@ next_is_folded_header(const text *t)
          *    Content-Type: text/html;
          *    Content-Transfer-Encoding: quoted-printable
          */
-        return FALSE;
+        return false;
 
     /*
      * Some are broken and don't fold headers lines
@@ -4607,16 +4610,16 @@ next_is_folded_header(const text *t)
     while (--ptr > data)
         switch (*ptr) {
             case ';':
-                return TRUE;
+                return true;
             case '\n':
             case ' ':
             case '\r':
             case '\t':
                 continue; /* white space at end of line */
             default:
-                return FALSE;
+                return false;
         }
-    return FALSE;
+    return false;
 }
 
 /*
@@ -4630,11 +4633,11 @@ newline_in_header(const char *line)
     cli_dbgmsg("newline_in_header, check \"%s\"\n", line);
 
     if (strncmp(line, "Message-Id: ", 12) == 0)
-        return TRUE;
+        return true;
     if (strncmp(line, "Date: ", 6) == 0)
-        return TRUE;
+        return true;
 
     cli_dbgmsg("newline_in_header, returning \"%s\"\n", line);
 
-    return FALSE;
+    return false;
 }

--- a/libclamav/message.h
+++ b/libclamav/message.h
@@ -33,8 +33,8 @@ typedef struct message {
     char **mimeArguments;
     char *mimeDispositionType; /* probably attachment */
     text *body_first, *body_last;
-    cli_ctx *ctx;          /* When set we can scan the message, otherwise NULL */
-    int numberOfArguments; /* count of mimeArguments */
+    cli_ctx *ctx;             /* When set we can scan the message, otherwise NULL */
+    size_t numberOfArguments; /* count of mimeArguments */
     int base64chars;
 
     /*
@@ -74,7 +74,6 @@ void messageSetEncoding(message *m, const char *enctype);
 encoding_type messageGetEncoding(const message *m);
 int messageAddLine(message *m, line_t *line);
 int messageAddStr(message *m, const char *data);
-int messageAddStrAtTop(message *m, const char *data);
 int messageMoveText(message *m, text *t, message *old_message);
 text *messageGetBody(message *m);
 unsigned char *base64Flush(message *m, unsigned char *buf);

--- a/libclamav/unzip.c
+++ b/libclamav/unzip.c
@@ -673,9 +673,11 @@ static unsigned int parse_local_file_header(
     }
 
     if (detect_encrypted && (LOCAL_HEADER_flags & F_ENCR) && SCAN_HEURISTIC_ENCRYPTED_ARCHIVE) {
+        cl_error_t fp_check;
         cli_dbgmsg("cli_unzip: Encrypted files found in archive.\n");
-        *ret = cli_append_virus(ctx, "Heuristics.Encrypted.Zip");
-        if ((*ret == CL_VIRUS && !SCAN_ALLMATCHES) || *ret != CL_CLEAN) {
+        fp_check = cli_append_virus(ctx, "Heuristics.Encrypted.Zip");
+        if ((fp_check == CL_VIRUS && !SCAN_ALLMATCHES) || fp_check != CL_CLEAN) {
+            *ret = fp_check;
             fmap_unneed_off(map, loff, SIZEOF_LOCAL_HEADER);
             goto done;
         }
@@ -734,6 +736,8 @@ static unsigned int parse_local_file_header(
             record->method              = LOCAL_HEADER_method;
             record->flags               = LOCAL_HEADER_flags;
             record->encrypted           = (LOCAL_HEADER_flags & F_ENCR) ? 1 : 0;
+
+            *ret = CL_SUCCESS;
         }
 
         zip += csize;
@@ -807,6 +811,8 @@ parse_central_directory_file_header(
     int last                      = 0;
     const uint8_t *central_header = NULL;
     int virus_found               = 0;
+
+    *ret = CL_EPARSE;
 
     if (!(central_header = fmap_need_off(map, coff, SIZEOF_CENTRAL_HEADER)) || CENTRAL_HEADER_magic != ZIP_MAGIC_CENTRAL_DIRECTORY_RECORD_BEGIN) {
         if (central_header) {
@@ -895,6 +901,7 @@ parse_central_directory_file_header(
                 }
             }
         }
+        *ret = CL_SUCCESS;
     }
 
 done:
@@ -994,16 +1001,28 @@ cl_error_t index_the_central_directory(
 
     cli_dbgmsg("cli_unzip: checking for non-recursive zip bombs...\n");
 
-    while (0 != (coff = parse_central_directory_file_header(map,
-                                                            coff,
-                                                            fsize,
-                                                            NULL, // num_files_unziped not required
-                                                            index + 1,
-                                                            &ret,
-                                                            ctx,
-                                                            NULL, // tmpd not required
-                                                            NULL,
-                                                            &(zip_catalogue[records_count])))) {
+    do {
+        coff = parse_central_directory_file_header(map,
+                                                   coff,
+                                                   fsize,
+                                                   NULL, // num_files_unziped not required
+                                                   index + 1,
+                                                   &ret,
+                                                   ctx,
+                                                   NULL, // tmpd not required
+                                                   NULL,
+                                                   &(zip_catalogue[records_count]));
+
+        if (CL_EPARSE != ret) {
+            // Found a record.
+            records_count++;
+        }
+
+        if (0 == coff) {
+            // No more files (previous was last).
+            break;
+        }
+
         if (ret == CL_VIRUS) {
             if (SCAN_ALLMATCHES)
                 virus_found = 1;
@@ -1029,9 +1048,10 @@ cl_error_t index_the_central_directory(
                                        // We still need to scan the files we found while reviewing the file records up to this limit.
             break;
         }
-        records_count++;
 
         if (records_count % ZIP_RECORDS_CHECK_BLOCKSIZE == 0) {
+            struct zip_record *zip_catalogue_new = NULL;
+
             cli_dbgmsg("   cli_unzip: Exceeded zip record block size, allocating more space...\n");
 
             /* allocate more space for zip records */
@@ -1042,16 +1062,19 @@ cl_error_t index_the_central_directory(
                 goto done;
             }
 
-            zip_catalogue = cli_realloc2(zip_catalogue, sizeof(struct zip_record) * ZIP_RECORDS_CHECK_BLOCKSIZE * (num_record_blocks + 1));
-            if (NULL == zip_catalogue) {
+            zip_catalogue_new = cli_realloc2(zip_catalogue, sizeof(struct zip_record) * ZIP_RECORDS_CHECK_BLOCKSIZE * (num_record_blocks + 1));
+            if (NULL == zip_catalogue_new) {
                 status = CL_EMEM;
                 goto done;
             }
+            zip_catalogue     = zip_catalogue_new;
+            zip_catalogue_new = NULL;
+
             num_record_blocks++;
             /* zero out the memory for the new records */
             memset(&(zip_catalogue[records_count]), 0, sizeof(struct zip_record) * (ZIP_RECORDS_CHECK_BLOCKSIZE * num_record_blocks - records_count));
         }
-    }
+    } while (1);
 
     if (ret == CL_VIRUS) {
         if (SCAN_ALLMATCHES)
@@ -1124,6 +1147,13 @@ done:
 
     if (CL_SUCCESS != status) {
         if (NULL != zip_catalogue) {
+            size_t i;
+            for (i = 0; i < records_count; i++) {
+                if (NULL != zip_catalogue[i].original_filename) {
+                    free(zip_catalogue[i].original_filename);
+                    zip_catalogue[i].original_filename = NULL;
+                }
+            }
             free(zip_catalogue);
             zip_catalogue = NULL;
         }


### PR DESCRIPTION

* Fix leak in email parser when using gen-json option

  The `mbox.c`::`messageGetFilename()` function returns a COPY of the filename, which must be `free()`'d.
  Fixes: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=31775

  Also fixed and issue where the email parser may fail to finish parsing some multipart emails when `--gen-json` is enabled if `messageGetJObj()` or `cli_json_addowner()` fail. These should be non-fatal failures. The rest of the (broken) email should be parsed.

  The email parser (`mbox.c` & `message.c`) also has a lot of assertions instead using if()'s for error handling.

  Because of the complexity of the email parser, it's unclear for many of the assertions if they could be triggered based on user input like scanning a malformed email. So to be safe, I've replaced all of the assertions in this parser with error handling to fail gracefully.

* Fix memory leak in zip parser error handling

  The zip parser may leak a string for a zip record filename if the
  the record in the central directory is the last record.

  This fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=31760

  It also appears that there may be a related record filename leak if an error occurred when indexing the files in the central directory header, but I don't have any test file for this but it was an obvious fix.
