### PR TITLE
OLE2: Fix benign heap buffer overflow read

### DIFF
--- a/libclamav/msdoc.c
+++ b/libclamav/msdoc.c
@@ -64,8 +64,19 @@ ole2_convert_utf(summary_ctx_t *sctx, char *begin, size_t sz, const char *encodi
 #else
     UNUSEDPARAM(encoding);
 #endif
+
+    if (NULL == begin) {
+        cli_dbgmsg("ole2_convert_utf: invalid parameter\n");
+        return NULL;
+    }
+
+    if (sz == 0) {
+        cli_dbgmsg("ole2_convert_utf: converting empty string\n");
+        return cli_calloc(1, 1); // Just send back an empty NULL-terminated string.
+    }
+
     /* applies in the both case */
-    if (sctx->codepage == 20127 || sctx->codepage == CODEPAGE_UTF8) {
+    if (sctx->codepage == CODEPAGE_US_7BIT_ASCII || sctx->codepage == CODEPAGE_UTF8) {
         char *track;
         size_t bcnt, scnt;
 


### PR DESCRIPTION
A heap buffer over-read may occur in the OLE2 parser if the --gen-json
option is enabled (the CL_SCAN_GENERAL_COLLECT_METADATA scan option).

The issue occurs because a string input is not checked to verify if it
is empty (zero-byte length) prior to use.

We determined that this issue is not exploitable to cause a crash or to
do anything malicious. The overflow (er... underflow?) is 1 byte before
a malloc'ed buffer.

This commit adds checks to the function parameters in case the original
pointer itself is NULL, and to account for conversion of an empty string.

Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=39673