### PR TITLE
Fix invalid format string type conversion character

### DIFF
--- a/libclamav/message.c
+++ b/libclamav/message.c
@@ -1377,7 +1377,7 @@ messageExport(message *m, const char *dir, void *(*create)(void), void (*destroy
             if (datasize >= sizeof(smallbuf)) {
                 data = bigbuf = (unsigned char *)cli_malloc(datasize);
                 if (NULL == data) {
-                    cli_dbgmsg("Failed to allocate data buffer of size %z\n", datasize);
+                    cli_dbgmsg("Failed to allocate data buffer of size %zu\n", datasize);
                     break;
                 }
             } else {


### PR DESCRIPTION
Accidentally introduced an invalid format string character, which is
apparently just a warning. ¯\_(ツ)_/¯

But Coverity really didn't like it, and now that I know about it,
neither do I...