### PR TITLE
Fix edgecase daily database symlink crash

### DIFF
--- a/libclamav/readdb.c
+++ b/libclamav/readdb.c
@@ -4747,6 +4747,10 @@ static cl_error_t cli_loaddbdir(const char *dirname, struct cl_engine *engine, u
 
                 /* Successfully opened the daily CLD file and read the header info. */
                 engine->num_total_signatures += daily_cld->sigs;
+            } else {
+                free(dbfile);
+                dbfile = NULL;
+                continue;
             }
 
         } else if (!strcmp(dent->d_name, "daily.cvd")) {
@@ -4761,6 +4765,10 @@ static cl_error_t cli_loaddbdir(const char *dirname, struct cl_engine *engine, u
                 }
                 /* Successfully opened the daily CVD file and ready the header info. */
                 engine->num_total_signatures += daily_cvd->sigs;
+            } else {
+                free(dbfile);
+                dbfile = NULL;
+                continue;
             }
 
         } else if (!strcmp(dent->d_name, "local.gdb")) {


### PR DESCRIPTION
Resolves https://bugzilla.clamav.net/show_bug.cgi?id=12592

A null-dereference crash happens if the database directory contains:
  a good `daily.cvd` symlink
  a broken `daily.cld` symlink

or:
  a broken `daily.cvd` symlink
  a good `daily.cld` symlink

You're not supposed to have both a .cvd and .cld for the same file
at the same time. And making individual symlinks for the database
files is also unexpected.
That is to say that this is not an intended or supported use case
for the database directory. But it's a fairly simple bug to fix.

The issue is that a bad symlink is still added to the database load-
list after the access check fails. This commit skips daily databases
that fail the access check.