### PR TITLE
mbox: do not use backtrace if using uClibc without backtrace support

### DIFF
--- a/libclamav/mbox.c
+++ b/libclamav/mbox.c
@@ -92,7 +92,7 @@
 #include <features.h>
 #endif
 
-#if __GLIBC__ == 2 && __GLIBC_MINOR__ >= 1
+#if __GLIBC__ == 2 && __GLIBC_MINOR__ >= 1 && !defined(__UCLIBC__) || defined(__UCLIBC_HAS_BACKTRACE__)
 #define HAVE_BACKTRACE
 #endif
 #endif


### PR DESCRIPTION
Since uClibc can be configured without support for backtrace, disable
the backtrace if we are building with a uClibc that was built without
backtrace.

This is a bit hacky, and would greatly benefit from a test in ./configure
instead, but does nicely as a quick fix for now.

Signed-off-by: "Yann E. MORIN" <yann.morin.1998@free.fr>
Signed-off-by: Bernd Kuhls <bernd.kuhls@t-online.de>
[Bernd: rebased for 0.103.0]
[Fabrice: retrieved from
https://git.buildroot.net/buildroot/tree/package/clamav/0002-mbox-do-not-use-backtrace-if-using-uClibc-without-ba.patch]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>