### PR TITLE
Dev/docker updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -109,6 +109,6 @@ COPY --from=builder "/clamav" "/"
 COPY "./dockerfiles/clamdcheck.sh" "/usr/local/bin/"
 COPY "./dockerfiles/docker-entrypoint.sh" "/init"
 
-HEALTHCHECK CMD "clamdcheck.sh"
+HEALTHCHECK --start-period=6m CMD "clamdcheck.sh"
 
 ENTRYPOINT [ "/init" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -87,6 +87,8 @@ LABEL maintainer="ClamAV bugs <clamav-bugs@external.cisco.com>"
 EXPOSE 3310
 EXPOSE 7357
 
+ENV TZ Etc/UTC
+
 RUN apk add --no-cache \
         fts \
         json-c \
@@ -99,6 +101,7 @@ RUN apk add --no-cache \
         ncurses-libs \
         pcre2 \
         tini \
+        tzdata \
         zlib \
     && \
     addgroup -S "clamav" && \

--- a/README.Docker.md
+++ b/README.Docker.md
@@ -85,6 +85,10 @@ Do not use `--pull always` with the larger ClamAV images.
 
 > _Tip_: It's common to see `-it` instead of `--interactive --tty`.
 
+In some situations it may be desirable to set (any of) the containers to a
+specific timezone. The `--env` parameter can be used to set the `TZ` variable
+to change the default of `Etc/UTC`.
+
 ### Running ClamD using a Locally Built Image
 
 You can run a container using an image built locally

--- a/README.Docker.md
+++ b/README.Docker.md
@@ -363,6 +363,10 @@ occasion send a `ping` to `clamd` on the default port and wait for the pong
 from `clamd`. If `clamd` fails to respond, Docker will treat this as an error.
 The healthcheck results can be viewed with `docker inspect`.
 
+When the container starts up, the health-check also starts up. As loading the
+virus database can take some time, there is a delay configured in the
+`Dockerfile` to try and avoid this race condition.
+
 ## Performance
 
 The performance impact of running `clamd` in Docker is negligible. Docker is


### PR DESCRIPTION
A couple of small updates to the docker contianer.

* Delay healthcheck to reduce false positives at start
* Add default timezone to the container (user-overriddable)

Contributes to mailu/mailu#2059

With these changes, mailu could use our container, which includes the base virus database, which could significantly reduce the load on clamav's database servers.