### PR TITLE
clamonacc: Harmonize signal handling on the different clamonacc threads.

### DIFF
--- a/clamonacc/inotif/inotif.c
+++ b/clamonacc/inotif/inotif.c
@@ -381,14 +381,16 @@ void *onas_ddd_th(void *arg)
     sigdelset(&sigset, SIGUSR1);
     sigdelset(&sigset, SIGUSR2);
     /* The behavior of a process is undefined after it ignores a
-	 * SIGFPE, SIGILL, SIGSEGV, or SIGBUS signal */
+     * SIGFPE, SIGILL, SIGSEGV, or SIGBUS signal */
     sigdelset(&sigset, SIGFPE);
     sigdelset(&sigset, SIGILL);
+    sigdelset(&sigset, SIGSEGV);
     sigdelset(&sigset, SIGTERM);
     sigdelset(&sigset, SIGINT);
 #ifdef SIGBUS
     sigdelset(&sigset, SIGBUS);
 #endif
+    pthread_sigmask(SIG_SETMASK, &sigset, NULL);
 
     logg("*ClamInotif: starting inotify event loop ...\n");
 

--- a/clamonacc/scan/onas_queue.c
+++ b/clamonacc/scan/onas_queue.c
@@ -150,7 +150,7 @@ void *onas_scan_queue_th(void *arg)
     sigfillset(&sigset);
     sigdelset(&sigset, SIGUSR2);
     /* The behavior of a process is undefined after it ignores a
-	 * SIGFPE, SIGILL, SIGSEGV, or SIGBUS signal */
+     * SIGFPE, SIGILL, SIGSEGV, or SIGBUS signal */
     sigdelset(&sigset, SIGFPE);
     sigdelset(&sigset, SIGILL);
     sigdelset(&sigset, SIGSEGV);
@@ -159,6 +159,7 @@ void *onas_scan_queue_th(void *arg)
 #ifdef SIGBUS
     sigdelset(&sigset, SIGBUS);
 #endif
+    pthread_sigmask(SIG_SETMASK, &sigset, NULL);
 
     logg("*ClamScanQueue: initializing event queue consumer ... (%d) threads in thread pool\n", ctx->maxthreads);
     onas_init_event_queue();


### PR DESCRIPTION
Explicit setting of pthread_sigmask in the individual threads
should not be necessary at all(?), since it is already done in
the main process/thread and should be inherited from there. But
since the sigfillset/sigdelset lines are already there, at least
they should be consistent with regard to the undefined behaviour
caused by ignoring SIGFPE, SIGILL, SIGSEGV, or SIGBUS signals.