### PR TITLE
clamonacc: Added workaround for inotify watch descriptor leak in clamonacc-ddd thread.

### DIFF
--- a/clamonacc/inotif/inotif.c
+++ b/clamonacc/inotif/inotif.c
@@ -293,7 +293,7 @@ static int onas_ddd_unwatch_hierarchy(const char *pathname, size_t len, int fd, 
     if (type & ONAS_IN) {
         wd = hnode->wd;
 
-        if (!inotify_rm_watch(fd, wd)) return CL_EARG;
+        if (!inotify_rm_watch(fd, wd) && errno != ENOENT ) return CL_EARG;
 
         /* Unlink the hash node from the watch descriptor lookup table */
         hnode->wd = 0;

--- a/clamonacc/inotif/inotif.c
+++ b/clamonacc/inotif/inotif.c
@@ -381,14 +381,16 @@ void *onas_ddd_th(void *arg)
     sigdelset(&sigset, SIGUSR1);
     sigdelset(&sigset, SIGUSR2);
     /* The behavior of a process is undefined after it ignores a
-	 * SIGFPE, SIGILL, SIGSEGV, or SIGBUS signal */
+     * SIGFPE, SIGILL, SIGSEGV, or SIGBUS signal */
     sigdelset(&sigset, SIGFPE);
     sigdelset(&sigset, SIGILL);
+    sigdelset(&sigset, SIGSEGV);
     sigdelset(&sigset, SIGTERM);
     sigdelset(&sigset, SIGINT);
 #ifdef SIGBUS
     sigdelset(&sigset, SIGBUS);
 #endif
+    pthread_sigmask(SIG_SETMASK, &sigset, NULL);
 
     logg("*ClamInotif: starting inotify event loop ...\n");
 

--- a/clamonacc/scan/onas_queue.c
+++ b/clamonacc/scan/onas_queue.c
@@ -150,7 +150,7 @@ void *onas_scan_queue_th(void *arg)
     sigfillset(&sigset);
     sigdelset(&sigset, SIGUSR2);
     /* The behavior of a process is undefined after it ignores a
-	 * SIGFPE, SIGILL, SIGSEGV, or SIGBUS signal */
+     * SIGFPE, SIGILL, SIGSEGV, or SIGBUS signal */
     sigdelset(&sigset, SIGFPE);
     sigdelset(&sigset, SIGILL);
     sigdelset(&sigset, SIGSEGV);
@@ -159,6 +159,7 @@ void *onas_scan_queue_th(void *arg)
 #ifdef SIGBUS
     sigdelset(&sigset, SIGBUS);
 #endif
+    pthread_sigmask(SIG_SETMASK, &sigset, NULL);
 
     logg("*ClamScanQueue: initializing event queue consumer ... (%d) threads in thread pool\n", ctx->maxthreads);
     onas_init_event_queue();


### PR DESCRIPTION
The clamonacc-ddd thread (```clamonacc/inotif/inotif.c```) currently and in-
discriminately stops processing of inotify watch descriptors in the
function "```onas_ddd_unwatch_hierarchy```" upon any error returned from the
call to "```inotify_rm_watch```". This in turn also prevents further updates
and cleanup of the internal data structures "```ddd_ht```" and "```wdlt```", which
leads to a invalid value of the "```path```" variable.
This causes a leak of inotify watch descriptors in the case of e.g. a
move of a directory containing a hierarchy of watched subdirectories.
See the inotify watch descriptor ("wd:") values in the section "Example
and reproducer" below.
This commit adds a workaround for this issue by specifically ignoring
the "```ENOENT```" errno in case the call to "```inotify_rm_watch```" results in
a non-zero return code. This allows the cleanup to properly proceed
for all children.

Example and reproducer:
 - Starting point:
   Log:
    ```ClamInotif: created watch descriptor (wd:1) for path: /clamonacc/monitored
    [...]
    ClamInotif: created watch descriptor (wd:129637) for path: /clamonacc/monitored/[...]```
 - Initial directory and subdirectory creation:
    ```mkdir -p /clamonacc/monitored/.test_ff/{1,2,3,4,5}```
   Log:
    ```ClamInotif: inotify event wd:1, mask:1073742080, cookie:0, length:16, child:.test_ff
    ClamInotif: inotify event path: /clamonacc/monitored
    ClamInotif: CREATE - adding /clamonacc/monitored/.test_ff to /clamonacc/monitored with wd:1
    ClamInotif: created watch descriptor (wd:129638) for path: /clamonacc/monitored/.test_ff
    ClamInotif: created watch descriptor (wd:129639) for path: /clamonacc/monitored/.test_ff/3
    ClamInotif: created watch descriptor (wd:129640) for path: /clamonacc/monitored/.test_ff/4
    ClamInotif: created watch descriptor (wd:129641) for path: /clamonacc/monitored/.test_ff/1
    ClamInotif: created watch descriptor (wd:129642) for path: /clamonacc/monitored/.test_ff/5
    ClamInotif: created watch descriptor (wd:129643) for path: /clamonacc/monitored/.test_ff/2```
 - Move / rename of the parent directory:
    ```mv -i /clamonacc/monitored/.test_ff/ /clamonacc/monitored/test_ff```
   Log:
    ```ClamInotif: inotify event wd:1, mask:1073741888, cookie:12094045, length:16, child:.test_ff
    ClamInotif: inotify event path: /clamonacc/monitored
    ClamInotif: MOVED_FROM - removing /clamonacc/monitored/.test_ff from /clamonacc/monitored with wd:1
    ERROR: ClamInotif: error removing watch descriptor (wd:129638) for path: /clamonacc/monitored/.test_ff, No such file or directory
    ClamInotif: inotify event wd:1, mask:1073741952, cookie:12094045, length:16, child:test_ff
    ClamInotif: inotify event path: /clamonacc/monitored
    ClamInotif: MOVED_TO - adding /clamonacc/monitored/test_ff to /clamonacc/monitored with wd:1
    ClamInotif: created watch descriptor (wd:129644) for path: /clamonacc/monitored/test_ff
    ClamInotif: created watch descriptor (wd:129639) for path: /clamonacc/monitored/test_ff/3
    ClamInotif: created watch descriptor (wd:129640) for path: /clamonacc/monitored/test_ff/4
    ClamInotif: created watch descriptor (wd:129641) for path: /clamonacc/monitored/test_ff/1
    ClamInotif: created watch descriptor (wd:129642) for path: /clamonacc/monitored/test_ff/5
    ClamInotif: created watch descriptor (wd:129643) for path: /clamonacc/monitored/test_ff/2```
 - Removal of the parent directory unter the new name:
    ```rm -r /clamonacc/monitored/test_ff```
   Log:
    ```ClamInotif: inotify event wd:129644, mask:1073742336, cookie:0, length:16, child:3
    ClamInotif: inotify event path: /clamonacc/monitored/test_ff
    ClamInotif: DELETE - removing /clamonacc/monitored/test_ff/3 from /clamonacc/monitored/test_ff with wd:129644
    ClamInotif: removed watch descriptor (wd:129639) for path: /clamonacc/monitored/test_ff/3
    ClamInotif: inotify event wd:129644, mask:1073742336, cookie:0, length:16, child:4
    ClamInotif: inotify event path: /clamonacc/monitored/test_ff
    ClamInotif: DELETE - removing /clamonacc/monitored/test_ff/4 from /clamonacc/monitored/test_ff with wd:129644
    ClamInotif: removed watch descriptor (wd:129640) for path: /clamonacc/monitored/test_ff/4
    ClamInotif: inotify event wd:129644, mask:1073742336, cookie:0, length:16, child:1
    ClamInotif: inotify event path: /clamonacc/monitored/test_ff
    ClamInotif: DELETE - removing /clamonacc/monitored/test_ff/1 from /clamonacc/monitored/test_ff with wd:129644
    ClamInotif: removed watch descriptor (wd:129641) for path: /clamonacc/monitored/test_ff/1
    ClamInotif: inotify event wd:129644, mask:1073742336, cookie:0, length:16, child:5
    ClamInotif: inotify event path: /clamonacc/monitored/test_ff
    ClamInotif: DELETE - removing /clamonacc/monitored/test_ff/5 from /clamonacc/monitored/test_ff with wd:129644
    ClamInotif: removed watch descriptor (wd:129642) for path: /clamonacc/monitored/test_ff/5
    ClamInotif: inotify event wd:129644, mask:1073742336, cookie:0, length:16, child:2
    ClamInotif: inotify event path: /clamonacc/monitored/test_ff
    ClamInotif: DELETE - removing /clamonacc/monitored/test_ff/2 from /clamonacc/monitored/test_ff with wd:129644
    ClamInotif: removed watch descriptor (wd:129643) for path: /clamonacc/monitored/test_ff/2
    ClamInotif: inotify event wd:1, mask:1073742336, cookie:0, length:16, child:test_ff
    ClamInotif: inotify event path: /clamonacc/monitored
    ClamInotif: DELETE - removing /clamonacc/monitored/test_ff from /clamonacc/monitored with wd:1
    ClamInotif: removed watch descriptor (wd:129644) for path: /clamonacc/monitored/test_ff```