### PR TITLE
clamonacc: fix systemd service file

### DIFF
--- a/clamonacc/clamav-clamonacc.service.in
+++ b/clamonacc/clamav-clamonacc.service.in
@@ -11,7 +11,7 @@ After=clamav-daemon.service syslog.target network.target
 Type=simple
 User=root
 ExecStartPre=/bin/bash -c "while [ ! -S /run/clamav/clamd.ctl ]; do sleep 1; done"
-ExecStart=@prefix@/sbin/clamonacc -F --config-file=@APP_CONFIG_DIRECTORY@/clamd.conf --log=/var/log/clamav/clamonacc.log --move=/root/quarantine
+ExecStart=@prefix@/sbin/clamonacc -F --log=/var/log/clamav/clamonacc.log --move=/root/quarantine
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The clamonacc systemd service file includes a variable that would be
filled out by CMake but not Autotools. In 0.104 we actually don't even
use this option anyways as it's not required to find the default clamd
config filepath.

Resolves: https://bugzilla.clamav.net/show_bug.cgi?id=12761