### PR TITLE
Fix ability to disable filesize limit with libclamav C API

### DIFF
--- a/libclamav/others.h
+++ b/libclamav/others.h
@@ -179,7 +179,7 @@ typedef struct cli_ctx_tag {
     unsigned long int *scanned;
     const struct cli_matcher *root;
     const struct cl_engine *engine;
-    unsigned long scansize;
+    uint64_t scansize;
     struct cl_scan_options *options;
     unsigned int scannedfiles;
     unsigned int found_possibly_unwanted;

--- a/libclamav/scanners.c
+++ b/libclamav/scanners.c
@@ -5462,7 +5462,7 @@ cl_error_t cl_scandesc_callback(int desc, const char *filename, const char **vir
         status = CL_CLEAN;
         goto done;
     }
-    if ((uint64_t)sb.st_size > engine->maxfilesize) {
+    if ((engine->maxfilesize > 0) && ((uint64_t)sb.st_size > engine->maxfilesize)) {
         cli_dbgmsg("cl_scandesc_callback: File too large (" STDu64 " bytes), ignoring\n", (uint64_t)sb.st_size);
         if (scanoptions->heuristic & CL_SCAN_HEURISTIC_EXCEEDS_MAX) {
             if (engine->cb_virus_found)
@@ -5499,7 +5499,7 @@ done:
 
 cl_error_t cl_scanmap_callback(cl_fmap_t *map, const char *filename, const char **virname, unsigned long int *scanned, const struct cl_engine *engine, struct cl_scan_options *scanoptions, void *context)
 {
-    if (map->len > engine->maxfilesize) {
+    if ((engine->maxfilesize > 0) && (map->len > engine->maxfilesize)) {
         cli_dbgmsg("cl_scandesc_callback: File too large (%zu bytes), ignoring\n", map->len);
         if (scanoptions->heuristic & CL_SCAN_HEURISTIC_EXCEEDS_MAX) {
             if (engine->cb_virus_found)


### PR DESCRIPTION

You should be able to disable the maxfilesize limit by setting it to
zero. When "disabled", ClamAV should defer to inherent limitations, which
at this time is UINT_MAX - 2 bytes.

This works okay for ClamScan and ClamD because our option parser
converts max-filesize=0 to 4294967295 (4GB). But it is presently broken
for other applications using the libclamav C API, like this:
```c
    cl_engine_set_num(engine, CL_ENGINE_MAX_FILESIZE, 0);
```

The limit checks added for cl_scanmap_callback and cl_scanfile_callback
in 0.103.4 and 0.104.1 broke this ability because we forgot to check if
the `maxfilesize > 0` before enforcing it.

This commit adds that guard so you can disable by setting to `0`.

While working on this, I also found that the `max_size` variables in our
libmspack scanner code are using an `off_t` type, which is a SIGNED integer
that may be 32bit width even on some 64bit platforms, or may be a 64bit
width. AND the default `max_size` when `maxfilesize == 0` was being set to
UINT_MAX (0xffffffff), aka `-1` when `off_t` is 32bits.

This commit addresses this related issue by:
    - changing the `max_size` to use `uint64_t`, like our other limits.
    - verifying that `maxfilesize > 0` before using it.
    - checking that using `UINT32_MAX` as a backup will not exceed the
    max-scansize in the same way that we do with the maxfilesize.