### PR TITLE
freshclam, clamd: Increase max config line length

### DIFF
--- a/common/optparser.c
+++ b/common/optparser.c
@@ -914,7 +914,7 @@ struct optstruct *optparse(const char *cfgfile, int argc, char **argv, int verbo
     const char *name = NULL, *arg;
     int i, err = 0, lc = 0, sc = 0, opt_index, line = 0, ret;
     struct optstruct *opts = NULL, *opts_last = NULL, *opt;
-    char buffer[512], *buff;
+    char buffer[1024], *buff;
     struct option longopts[MAXCMDOPTS];
     char shortopts[MAXCMDOPTS];
     regex_t regex;


### PR DESCRIPTION
ClamAV's option parser, used for `freshclam.conf`, `clamd.conf`,
and `clamav-milter.conf` has a max line length of 512 characters.

By request, this commit increases the line length to 1024 to accommodate
very long DatabaseMirror URI's when using very long access tokens in the
URI.

Resolves: https://github.com/Cisco-Talos/clamav/issues/281