### PR TITLE
Clam 1624 max config line length 0.104

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,9 @@ ClamAV 0.104.2 is a critical patch release with the following fixes:
   Note: Internally, the max file size is still set to 2 GiB. Disabling the limit
   for a scan will fall back on the internal 2 GiB limitation.
 
+- Increased the maximum line length for ClamAV config files from 512 bytes to
+  1024 bytes to allow for longer config option strings.
+
 Special thanks to the following for code contributions and bug reports:
 
 ## 0.104.1

--- a/common/optparser.c
+++ b/common/optparser.c
@@ -906,7 +906,7 @@ struct optstruct *optparse(const char *cfgfile, int argc, char **argv, int verbo
     const char *name = NULL, *arg;
     int i, err = 0, lc = 0, sc = 0, opt_index, line = 0, ret;
     struct optstruct *opts = NULL, *opts_last = NULL, *opt;
-    char buffer[512], *buff;
+    char buffer[1024], *buff;
     struct option longopts[MAXCMDOPTS];
     char shortopts[MAXCMDOPTS];
     regex_t regex;


### PR DESCRIPTION
Copy of https://github.com/Cisco-Talos/clamav/pull/411 plus news entry.