### PR TITLE
Docker: Enable db update script to work with older versions

### DIFF
--- a/dockerfiles/update_db_image.sh
+++ b/dockerfiles/update_db_image.sh
@@ -82,7 +82,7 @@ clamav_db_update()
 	for _tag in ${clamav_docker_tags}; do
 		{
 			echo "FROM ${docker_registry}/${clamav_docker_image}:${_tag}"
-			echo "RUN freshclam --foreground --stdout && rm /var/lib/clamav/freshclam.dat"
+			echo "RUN freshclam --foreground --stdout && rm /var/lib/clamav/freshclam.dat || rm /var/lib/clamav/mirrors.dat || true"
 		} | docker image build --pull --rm --tag "${docker_registry}/${clamav_docker_image}:${_tag%%_base}" -
 		docker image push "${docker_registry}/${clamav_docker_image}:${_tag%%_base}"
 	done


### PR DESCRIPTION
The database update script has a line to delete freshclam.dat after the
update, but this fails when attempting to update older images that have
mirrors.dat or no dat file at all. This issue is compounded by a bug
where the -t (--tags) option doesn't work so it tries to update all
images every time, and then of course fails on the older ones.

This commit has the script try removing freshclam.dat or mirrors.dat and
allows it to succeed even if neither exist.