### PR TITLE
Docs: Fix BZip2 variable name in INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -530,7 +530,7 @@ But if you:
 
 ```sh
   -D BZIP2_INCLUDE_DIR="_filepath of bzip2 header directory_"
-  -D BZIP2_LIBRARIES="_filepath of bzip2 library_"
+  -D BZIP2_LIBRARY_RELEASE="_filepath of bzip2 library_"
 ```
 
 ### `zlib`


### PR DESCRIPTION
Setting `BZIP2_LIBRARIES` does not work and you must instead set `BZIP2_LIBRARY_RELEASE`.

Using `BZIP2_LIBRARY` also doesn't work and may instead find another copy of the library like a shared lib version instead of the requested version. 

If anyone wants to volunteer to fix it in CMake's sources, CMake is also open source and the module is here: https://github.com/Kitware/CMake/blob/master/Modules/FindBZip2.cmake

See original report from our mailing list, here: https://lists.clamav.net/pipermail/clamav-users/2022-January/012250.html