### PR TITLE
fuzz: Fix fuzz target race condition flakiness

### DIFF
--- a/fuzz/clamav_dbload_fuzzer.cpp
+++ b/fuzz/clamav_dbload_fuzzer.cpp
@@ -119,6 +119,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 
     fuzzdb = fopen(kClamAVState.tmp_db_name, "w");
     fwrite(data, size, 1, fuzzdb);
+    fflush(fuzzdb);
     fclose(fuzzdb);
 
     /* need new engine each time. can't add sigs to compiled engine */

--- a/fuzz/clamav_scanfile_fuzzer.cpp
+++ b/fuzz/clamav_scanfile_fuzzer.cpp
@@ -121,6 +121,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 
     fuzzfile = fopen(kClamAVState.tmp_file_name, "w");
     fwrite(data, size, 1, fuzzfile);
+    fflush(fuzzfile);
     fclose(fuzzfile);
 
     const char* virus_name = nullptr;


### PR DESCRIPTION
The fuzz targets that write a file before using the file are using a
buffered file writer that results in a race condition clamav when
reading the file during the scan/load test.

This commit flushes the FILE stream before running the test.