### PR TITLE
Fix byte-compare subsignature premature alert

### DIFF
--- a/libclamav/matcher-byte-comp.h
+++ b/libclamav/matcher-byte-comp.h
@@ -62,7 +62,7 @@ struct cli_bcomp_comp {
 };
 
 cl_error_t cli_bcomp_addpatt(struct cli_matcher *root, const char *virname, const char *hexsig, const uint32_t *lsigid, unsigned int options);
-cl_error_t cli_bcomp_scanbuf(const unsigned char *buffer, size_t buffer_length, const char **virname, struct cli_ac_result **res, const struct cli_matcher *root, struct cli_ac_data *mdata, cli_ctx *ctx);
+cl_error_t cli_bcomp_scanbuf(const unsigned char *buffer, size_t buffer_length, struct cli_ac_result **res, const struct cli_matcher *root, struct cli_ac_data *mdata, cli_ctx *ctx);
 cl_error_t cli_bcomp_compare_check(const unsigned char *f_buffer, size_t buffer_length, int offset, struct cli_bcomp_meta *bm);
 void cli_bcomp_freemeta(struct cli_matcher *root, struct cli_bcomp_meta *bm);
 uint16_t cli_bcomp_chk_hex(const unsigned char *buffer, uint16_t opt, uint32_t len, uint32_t check_only);

--- a/libclamav/matcher.c
+++ b/libclamav/matcher.c
@@ -182,17 +182,9 @@ static inline cl_error_t matcher_run(const struct cli_matcher *root,
     }
 
     if (root->bcomp_metas) {
-        ret = cli_bcomp_scanbuf(orig_buffer, orig_length, virname, acres, root, mdata, ctx);
+        ret = cli_bcomp_scanbuf(orig_buffer, orig_length, acres, root, mdata, ctx);
         if (ret != CL_CLEAN) {
-            if (ret == CL_VIRUS) {
-                if (SCAN_ALLMATCHES)
-                    viruses_found = 1;
-                else {
-                    ret = cli_append_virus(ctx, *virname);
-                    if (ret != CL_CLEAN)
-                        return ret;
-                }
-            } else if (ret > CL_TYPENO && acmode & AC_SCAN_VIR)
+            if (ret > CL_TYPENO && acmode & AC_SCAN_VIR)
                 saved_ret = ret;
             else
                 return ret;


### PR DESCRIPTION
The byte compare feature in logical signatures will cause the rule to
alert if it successfully matches regardless of the rest of the logical
signature.

An easy way to test this is with a logical signature that has two
bcomp subsigantures and requires both to match for the rule to alert.

In the following example, we have 4 signatures where
- the first will match both bcomp subsigs.
- the second will match neither.
- the last two match just one bcomp subsig.

In an --allmatch test, you'll find that the 3 of these match, with the
first one matching *twice*, once for each bcomp subsig.

test.ldb:
```
bcomp.both;Engine:51-255,Target:0;0&1&2&3;4141;0(>>5#hb2#=123);4242;2(>>5#hb2#=255)
bcomp.neither;Engine:51-255,Target:0;0&1&2&3;4141;0(>>5#hb2#=124);4242;2(>>5#hb2#=254)
bcomp.second;Engine:51-255,Target:0;0&1&2&3;4141;0(>>5#hb2#=124);4242;2(>>5#hb2#=255)
bcomp.first;Engine:51-255,Target:0;0&1&2&3;4141;0(>>5#hb2#=123);4242;2(>>5#hb2#=254)
```

test.sample:
```
AA = 7B; BB = FF
```

You can also try a similar test to compare the behavior with regular
ac-pattern-match subsigs with this lsig-test.ldb:
```
pattern.both;Engine:51-255,Target:0;0&1;4141;4242
pattern.neither;Engine:51-255,Target:0;0&1;4140;4241
pattern.second;Engine:51-255,Target:0;0&1;4140;4242
pattern.first;Engine:51-255,Target:0;0&1;4141;4241
```

This commit fixes the issue by replacing incrementing the logical
subsignature count for each bcomp subsig match instead of appending an
alert for each bcomp match.

Also removed call to `lsig_sub_matched()` that didn't do anything.