### PR TITLE
Fix byte-compare subsignature premature alert (0.103.6)

### DIFF
--- a/libclamav/matcher-byte-comp.c
+++ b/libclamav/matcher-byte-comp.c
@@ -460,7 +460,7 @@ cl_error_t cli_bcomp_addpatt(struct cli_matcher *root, const char *virname, cons
 cl_error_t cli_bcomp_scanbuf(const unsigned char *buffer, size_t buffer_length, const char **virname, struct cli_ac_result **res, const struct cli_matcher *root, struct cli_ac_data *mdata, cli_ctx *ctx)
 {
 
-    int64_t i = 0, ret = CL_SUCCESS;
+    int64_t i = 0, val = 0, ret = CL_SUCCESS;
     uint32_t lsigid, ref_subsigid;
     uint32_t offset              = 0;
     uint8_t viruses_found        = 0;
@@ -488,8 +488,14 @@ cl_error_t cli_bcomp_scanbuf(const unsigned char *buffer, size_t buffer_length, 
             snprintf(subsigid, 3, "%hu", bcomp->ref_subsigid);
 
             /* verify the ref_subsigid */
-            if (cli_ac_chklsig(subsigid, subsigid + strlen(subsigid),
-                               mdata->lsigcnt[bcomp->lsigid[1]], &evalcnt, &evalids, 0) != 1) {
+            val = cli_ac_chklsig(subsigid, subsigid + strlen(subsigid), mdata->lsigcnt[bcomp->lsigid[1]], &evalcnt, &evalids, 0);
+
+            if (subsigid) {
+                free(subsigid);
+                subsigid = NULL;
+            }
+
+            if (val != 1) {
                 bcm_dbgmsg("cli_bcomp_scanbuf: could not verify a match for lsig reference subsigid (%s)\n", subsigid);
                 continue;
             }
@@ -544,11 +550,6 @@ cl_error_t cli_bcomp_scanbuf(const unsigned char *buffer, size_t buffer_length, 
                 ret = cli_append_virus(ctx, (const char *)bcomp->virname);
             }
         }
-    }
-
-    if (subsigid) {
-        free(subsigid);
-        subsigid = NULL;
     }
 
     if (ret == CL_SUCCESS && viruses_found) {

--- a/libclamav/matcher-byte-comp.c
+++ b/libclamav/matcher-byte-comp.c
@@ -469,7 +469,7 @@ cl_error_t cli_bcomp_scanbuf(const unsigned char *buffer, size_t buffer_length, 
 
     uint32_t evalcnt = 0;
     uint64_t evalids = 0;
-    char *subsigid   = NULL;
+    char subsigid[3];
 
     if (!(root) || !(root->bcomp_metas) || !(root->bcomp_metatable) || !(mdata) || !(mdata->offmatrix) || !(ctx)) {
         return CL_SUCCESS;
@@ -484,16 +484,10 @@ cl_error_t cli_bcomp_scanbuf(const unsigned char *buffer, size_t buffer_length, 
         /* check to see if we are being run in sigtool or not */
         if (bcomp->lsigid[0]) {
 
-            subsigid = cli_calloc(3, sizeof(char));
             snprintf(subsigid, 3, "%hu", bcomp->ref_subsigid);
 
             /* verify the ref_subsigid */
             val = cli_ac_chklsig(subsigid, subsigid + strlen(subsigid), mdata->lsigcnt[bcomp->lsigid[1]], &evalcnt, &evalids, 0);
-
-            if (subsigid) {
-                free(subsigid);
-                subsigid = NULL;
-            }
 
             if (val != 1) {
                 bcm_dbgmsg("cli_bcomp_scanbuf: could not verify a match for lsig reference subsigid (%s)\n", subsigid);

--- a/libclamav/matcher-byte-comp.h
+++ b/libclamav/matcher-byte-comp.h
@@ -62,7 +62,7 @@ struct cli_bcomp_comp {
 };
 
 cl_error_t cli_bcomp_addpatt(struct cli_matcher *root, const char *virname, const char *hexsig, const uint32_t *lsigid, unsigned int options);
-cl_error_t cli_bcomp_scanbuf(const unsigned char *buffer, size_t buffer_length, const char **virname, struct cli_ac_result **res, const struct cli_matcher *root, struct cli_ac_data *mdata, cli_ctx *ctx);
+cl_error_t cli_bcomp_scanbuf(const unsigned char *buffer, size_t buffer_length, struct cli_ac_result **res, const struct cli_matcher *root, struct cli_ac_data *mdata, cli_ctx *ctx);
 cl_error_t cli_bcomp_compare_check(const unsigned char *f_buffer, size_t buffer_length, int offset, struct cli_bcomp_meta *bm);
 void cli_bcomp_freemeta(struct cli_matcher *root, struct cli_bcomp_meta *bm);
 uint16_t cli_bcomp_chk_hex(const unsigned char *buffer, uint16_t opt, uint32_t len, uint32_t check_only);

--- a/libclamav/matcher.c
+++ b/libclamav/matcher.c
@@ -182,17 +182,9 @@ static inline cl_error_t matcher_run(const struct cli_matcher *root,
     }
 
     if (root->bcomp_metas) {
-        ret = cli_bcomp_scanbuf(orig_buffer, orig_length, virname, acres, root, mdata, ctx);
+        ret = cli_bcomp_scanbuf(orig_buffer, orig_length, acres, root, mdata, ctx);
         if (ret != CL_CLEAN) {
-            if (ret == CL_VIRUS) {
-                if (SCAN_ALLMATCHES)
-                    viruses_found = 1;
-                else {
-                    ret = cli_append_virus(ctx, *virname);
-                    if (ret != CL_CLEAN)
-                        return ret;
-                }
-            } else if (ret > CL_TYPENO && acmode & AC_SCAN_VIR)
+            if (ret > CL_TYPENO && acmode & AC_SCAN_VIR)
                 saved_ret = ret;
             else
                 return ret;


### PR DESCRIPTION
This backport PR brought in 2 extra cherry-pick commits supporting this fix.

---

The byte compare feature in logical signatures will cause the rule to
alert if it successfully matches regardless of the rest of the logical
signature.

An easy way to test this is with a logical signature that has two
bcomp subsignatures and requires both to match for the rule to alert.

In the following example, we have 4 signatures where
- the first will match both bcomp subsigs.
- the second will match neither.
- the last two match just one bcomp subsig.

In an --allmatch test, you'll find that the 3 of these match, with the
first one matching *twice*, once for each bcomp subsig.

test.ldb:
```
bcomp.both;Engine:51-255,Target:0;0&1&2&3;4141;0(>>5#hb2#=123);4242;2(>>5#hb2#=255)
bcomp.neither;Engine:51-255,Target:0;0&1&2&3;4141;0(>>5#hb2#=124);4242;2(>>5#hb2#=254)
bcomp.second;Engine:51-255,Target:0;0&1&2&3;4141;0(>>5#hb2#=124);4242;2(>>5#hb2#=255)
bcomp.first;Engine:51-255,Target:0;0&1&2&3;4141;0(>>5#hb2#=123);4242;2(>>5#hb2#=254)
```

test.sample:
```
AA = 7B; BB = FF
```

You can also try a similar test to compare the behavior with regular
ac-pattern-match subsigs with this lsig-test.ldb:
```
pattern.both;Engine:51-255,Target:0;0&1;4141;4242
pattern.neither;Engine:51-255,Target:0;0&1;4140;4241
pattern.second;Engine:51-255,Target:0;0&1;4140;4242
pattern.first;Engine:51-255,Target:0;0&1;4141;4241
```

This commit fixes the issue by incrementing the logical subsignature
count for each bcomp subsig match instead of appending an alert for
each bcomp match.

Also removed call to `lsig_sub_matched()` that didn't do anything.