### PR TITLE
Clam 1590 phash logical subsignatures cleanup prep

### DIFF
--- a/libclamav/matcher-ac.h
+++ b/libclamav/matcher-ac.h
@@ -132,9 +132,30 @@ struct cli_ac_result {
 
 #include "matcher.h"
 
+/**
+ * @brief Add a simple sub-pattern into the AC trie.
+ *
+ * Simple sub-patterns may not include any wildcards or [a-b] anchored byte ranges.
+ */
 cl_error_t cli_ac_addpatt(struct cli_matcher *root, struct cli_ac_patt *pattern);
+
 cl_error_t cli_ac_initdata(struct cli_ac_data *data, uint32_t partsigs, uint32_t lsigs, uint32_t reloffsigs, uint8_t tracklen);
-cl_error_t lsig_sub_matched(const struct cli_matcher *root, struct cli_ac_data *mdata, uint32_t lsigid1, uint32_t lsigid2, uint32_t realoff, int partial);
+
+/**
+ * @brief Increment the count for a subsignature of a logical signature.
+ *
+ * Increment a logical signature subsignature match count.
+ *
+ * @param root      The root storing all pattern matching data. I.e. "the database in memory."
+ * @param mdata     Match result data
+ * @param lsig_id   The current logical signature id
+ * @param subsig_id The current subsignature id
+ * @param realoff   Offset where the match occured
+ * @param partial   0 if whole pattern, or >0 for a partial-patterns. That is one split with wildcards like * or {n-m}.
+ * @return cl_error_t
+ */
+cl_error_t lsig_sub_matched(const struct cli_matcher *root, struct cli_ac_data *mdata, uint32_t lsig_id, uint32_t subsig_id, uint32_t realoff, int partial);
+
 cl_error_t cli_ac_chkmacro(struct cli_matcher *root, struct cli_ac_data *data, unsigned lsigid1);
 int cli_ac_chklsig(const char *expr, const char *end, uint32_t *lsigcnt, unsigned int *cnt, uint64_t *ids, unsigned int parse_only);
 void cli_ac_freedata(struct cli_ac_data *data);
@@ -143,6 +164,13 @@ cl_error_t cli_ac_buildtrie(struct cli_matcher *root);
 cl_error_t cli_ac_init(struct cli_matcher *root, uint8_t mindepth, uint8_t maxdepth, uint8_t dconf_prefiltering);
 cl_error_t cli_ac_caloff(const struct cli_matcher *root, struct cli_ac_data *data, const struct cli_target_info *info);
 void cli_ac_free(struct cli_matcher *root);
+
+/**
+ * @brief Add a complex sub-pattern into the AC trie.
+ *
+ * Complex sub-patterns are the body content between `{n-m}` and `{*}` wildcards in content match signatures.
+ * And `{n}` wildcards should have already been replaced with `??` characters and are included in the patterns.
+ */
 cl_error_t cli_ac_addsig(struct cli_matcher *root, const char *virname, const char *hexsig, uint8_t sigopts, uint32_t sigid, uint16_t parts, uint16_t partno, uint16_t rtype, uint16_t type, uint32_t mindist, uint32_t maxdist, const char *offset, const uint32_t *lsigid, unsigned int options);
 
 #endif

--- a/libclamav/mpool.h
+++ b/libclamav/mpool.h
@@ -29,7 +29,6 @@
 #ifdef USE_MPOOL
 
 #include "clamav-types.h"
-#include "readdb.h"
 
 typedef struct MP mpool_t;
 struct cl_engine;

--- a/libclamav/str.c
+++ b/libclamav/str.c
@@ -859,6 +859,7 @@ size_t cli_ldbtokenize(char *buffer, const char delim, const size_t token_count,
 {
     size_t tokens_found, i;
     int within_pcre = 0;
+    char *start     = buffer;
 
     for (tokens_found = 0; tokens_found < token_count;) {
         tokens[tokens_found++] = buffer;
@@ -866,7 +867,8 @@ size_t cli_ldbtokenize(char *buffer, const char delim, const size_t token_count,
         while (*buffer != '\0') {
             if (!within_pcre && (*buffer == delim))
                 break;
-            else if ((tokens_found > token_skip) && (*(buffer - 1) != '\\') &&
+            else if ((tokens_found > token_skip) &&
+                     ((buffer > start) && (*(buffer - 1) != '\\')) &&
                      (*buffer == '/'))
                 within_pcre = !within_pcre;
             buffer++;

--- a/sigtool/sigtool.c
+++ b/sigtool/sigtool.c
@@ -195,7 +195,7 @@ static int hashpe(const char *filename, unsigned int class, int type)
         goto done;
     }
 
-    if (cli_parse_add(engine->root[0], "test", "deadbeef", 0, 0, 0, "*", 0, NULL, 0) != CL_SUCCESS) {
+    if (cli_add_content_match_pattern(engine->root[0], "test", "deadbeef", 0, 0, 0, "*", 0, NULL, 0) != CL_SUCCESS) {
         mprintf(LOGG_ERROR, "hashpe: Can't parse signature\n");
         goto done;
     }
@@ -1977,7 +1977,7 @@ static void matchsig(const char *sig, const char *offset, int fd)
         goto done;
     }
 
-    if (cli_parse_add(engine->root[0], "test", sig, 0, 0, 0, "*", 0, NULL, 0) != CL_SUCCESS) {
+    if (cli_add_content_match_pattern(engine->root[0], "test", sig, 0, 0, 0, "*", 0, NULL, 0) != CL_SUCCESS) {
         mprintf(LOGG_ERROR, "matchsig: Can't parse signature\n");
         goto done;
     }
@@ -3188,7 +3188,7 @@ static int dumpcerts(const struct optstruct *opts)
         goto done;
     }
 
-    if (cli_parse_add(engine->root[0], "test", "deadbeef", 0, 0, 0, "*", 0, NULL, 0) != CL_SUCCESS) {
+    if (cli_add_content_match_pattern(engine->root[0], "test", "deadbeef", 0, 0, 0, "*", 0, NULL, 0) != CL_SUCCESS) {
         mprintf(LOGG_ERROR, "dumpcerts: Can't parse signature\n");
         goto done;
     }

--- a/sigtool/vba.c
+++ b/sigtool/vba.c
@@ -76,7 +76,7 @@ cli_ctx *convenience_ctx(int fd)
         goto done;
     }
 
-    if (cli_parse_add(engine->root[0], "test", "deadbeef", 0, 0, 0, "*", 0, NULL, 0) != CL_SUCCESS) {
+    if (cli_add_content_match_pattern(engine->root[0], "test", "deadbeef", 0, 0, 0, "*", 0, NULL, 0) != CL_SUCCESS) {
         printf("convenience_ctx: Can't parse signature\n");
         goto done;
     }

--- a/unit_tests/check_bytecode.c
+++ b/unit_tests/check_bytecode.c
@@ -145,7 +145,7 @@ static void runtest(const char *file, uint64_t expected, int fail, int nojit,
 
     if (rc == CL_SUCCESS) {
         v = cli_bytecode_context_getresult_int(ctx);
-        ck_assert_msg(v == expected, "Invalid return value from bytecode run, expected: %llx, have: %llx\n",
+        ck_assert_msg(v == expected, "Invalid return value from bytecode run, expected: " STDx64 ", have: " STDx64 "\n",
                       expected, v);
     }
     if (infile && expectedvirname) {

--- a/unit_tests/check_disasm.c
+++ b/unit_tests/check_disasm.c
@@ -215,7 +215,7 @@ START_TEST(test_disasm_basic)
 
     };
     uint8_t *d;
-    off_t size;
+    ssize_t size;
     STATBUF st;
 
     ck_assert_msg(fd != -1, "mkstemp failed");
@@ -223,10 +223,10 @@ START_TEST(test_disasm_basic)
     ck_assert_msg(FSTAT(ref, &st) != -1, "fstat failed");
     disasmbuf(buf, sizeof(buf), fd);
     size = lseek(fd, 0, SEEK_CUR);
-    ck_assert_msg(size == st.st_size, "disasm size mismatch(value %u, expected: %u)", size, st.st_size);
+    ck_assert_msg(size == st.st_size, "disasm size mismatch(value %zd, expected: %zd)", size, (ssize_t)st.st_size);
     lseek(fd, 0, SEEK_SET);
     d = malloc(size * 2);
-    ck_assert_msg(d != NULL, "disasm malloc(%u) failed", size);
+    ck_assert_msg(d != NULL, "disasm malloc(%zd) failed", size * 2);
     ck_assert_msg(read(ref, d, size) == size, "disasm reference read failed");
     ck_assert_msg(read(fd, d + size, size) == size, "disasm read failed");
     close(fd);

--- a/unit_tests/check_matchers.c
+++ b/unit_tests/check_matchers.c
@@ -217,8 +217,8 @@ START_TEST(test_ac_scanbuff)
     ck_assert_msg(ret == CL_SUCCESS, "cli_ac_init() failed");
 
     for (i = 0; ac_testdata[i].data; i++) {
-        ret = cli_parse_add(root, ac_testdata[i].virname, ac_testdata[i].hexsig, 0, 0, 0, "*", 0, NULL, 0);
-        ck_assert_msg(ret == CL_SUCCESS, "cli_parse_add() failed");
+        ret = cli_add_content_match_pattern(root, ac_testdata[i].virname, ac_testdata[i].hexsig, 0, 0, 0, "*", 0, NULL, 0);
+        ck_assert_msg(ret == CL_SUCCESS, "cli_add_content_match_pattern failed");
     }
 
     ret = cli_ac_buildtrie(root);
@@ -260,8 +260,8 @@ START_TEST(test_ac_scanbuff_allscan)
     ck_assert_msg(ret == CL_SUCCESS, "cli_ac_init() failed");
 
     for (i = 0; ac_testdata[i].data; i++) {
-        ret = cli_parse_add(root, ac_testdata[i].virname, ac_testdata[i].hexsig, 0, 0, 0, "*", 0, NULL, 0);
-        ck_assert_msg(ret == CL_SUCCESS, "cli_parse_add() failed");
+        ret = cli_add_content_match_pattern(root, ac_testdata[i].virname, ac_testdata[i].hexsig, 0, 0, 0, "*", 0, NULL, 0);
+        ck_assert_msg(ret == CL_SUCCESS, "cli_add_content_match_pattern failed");
     }
 
     ret = cli_ac_buildtrie(root);
@@ -390,12 +390,12 @@ START_TEST(test_bm_scanbuff)
     ret = cli_bm_init(root);
     ck_assert_msg(ret == CL_SUCCESS, "cli_bm_init() failed");
 
-    ret = cli_parse_add(root, "Sig1", "deadbabe", 0, 0, 0, "*", 0, NULL, 0);
-    ck_assert_msg(ret == CL_SUCCESS, "cli_parse_add() failed");
-    ret = cli_parse_add(root, "Sig2", "deadbeef", 0, 0, 0, "*", 0, NULL, 0);
-    ck_assert_msg(ret == CL_SUCCESS, "cli_parse_add() failed");
-    ret = cli_parse_add(root, "Sig3", "babedead", 0, 0, 0, "*", 0, NULL, 0);
-    ck_assert_msg(ret == CL_SUCCESS, "cli_parse_add() failed");
+    ret = cli_add_content_match_pattern(root, "Sig1", "deadbabe", 0, 0, 0, "*", 0, NULL, 0);
+    ck_assert_msg(ret == CL_SUCCESS, "cli_add_content_match_pattern failed");
+    ret = cli_add_content_match_pattern(root, "Sig2", "deadbeef", 0, 0, 0, "*", 0, NULL, 0);
+    ck_assert_msg(ret == CL_SUCCESS, "cli_add_content_match_pattern failed");
+    ret = cli_add_content_match_pattern(root, "Sig3", "babedead", 0, 0, 0, "*", 0, NULL, 0);
+    ck_assert_msg(ret == CL_SUCCESS, "cli_add_content_match_pattern failed");
 
     ctx.options->general &= ~CL_SCAN_GENERAL_ALLMATCHES; /* make sure all-match is disabled */
     ret = cli_bm_scanbuff((const unsigned char *)"blah\xde\xad\xbe\xef", 12, &virname, NULL, root, 0, NULL, NULL, NULL);
@@ -419,12 +419,12 @@ START_TEST(test_bm_scanbuff_allscan)
     ret = cli_bm_init(root);
     ck_assert_msg(ret == CL_SUCCESS, "cli_bm_init() failed");
 
-    ret = cli_parse_add(root, "Sig1", "deadbabe", 0, 0, 0, "*", 0, NULL, 0);
-    ck_assert_msg(ret == CL_SUCCESS, "cli_parse_add() failed");
-    ret = cli_parse_add(root, "Sig2", "deadbeef", 0, 0, 0, "*", 0, NULL, 0);
-    ck_assert_msg(ret == CL_SUCCESS, "cli_parse_add() failed");
-    ret = cli_parse_add(root, "Sig3", "babedead", 0, 0, 0, "*", 0, NULL, 0);
-    ck_assert_msg(ret == CL_SUCCESS, "cli_parse_add() failed");
+    ret = cli_add_content_match_pattern(root, "Sig1", "deadbabe", 0, 0, 0, "*", 0, NULL, 0);
+    ck_assert_msg(ret == CL_SUCCESS, "cli_add_content_match_pattern failed");
+    ret = cli_add_content_match_pattern(root, "Sig2", "deadbeef", 0, 0, 0, "*", 0, NULL, 0);
+    ck_assert_msg(ret == CL_SUCCESS, "cli_add_content_match_pattern failed");
+    ret = cli_add_content_match_pattern(root, "Sig3", "babedead", 0, 0, 0, "*", 0, NULL, 0);
+    ck_assert_msg(ret == CL_SUCCESS, "cli_add_content_match_pattern failed");
 
     ctx.options->general |= CL_SCAN_GENERAL_ALLMATCHES; /* enable all-match */
     ret = cli_bm_scanbuff((const unsigned char *)"blah\xde\xad\xbe\xef", 12, &virname, NULL, root, 0, NULL, NULL, NULL);
@@ -461,8 +461,8 @@ START_TEST(test_pcre_scanbuff)
         strncat(hexsig, PCRE_BYPASS, hexlen);
         strncat(hexsig, pcre_testdata[i].hexsig, hexlen);
 
-        ret = cli_parse_add(root, pcre_testdata[i].virname, hexsig, pcre_testdata[i].sigopts, 0, 0, pcre_testdata[i].offset, 0, NULL, 0);
-        ck_assert_msg(ret == CL_SUCCESS, "[pcre] cli_parse_add() failed");
+        ret = readdb_parse_ldb_subsignature(root, pcre_testdata[i].virname, hexsig, pcre_testdata[i].offset, 0, NULL, 0, 0, 0, NULL);
+        ck_assert_msg(ret == CL_SUCCESS, "[pcre] readdb_parse_ldb_subsignature failed");
         free(hexsig);
     }
 
@@ -515,8 +515,8 @@ START_TEST(test_pcre_scanbuff_allscan)
         strncat(hexsig, PCRE_BYPASS, hexlen);
         strncat(hexsig, pcre_testdata[i].hexsig, hexlen);
 
-        ret = cli_parse_add(root, pcre_testdata[i].virname, hexsig, 0, 0, 0, pcre_testdata[i].offset, 0, NULL, 0);
-        ck_assert_msg(ret == CL_SUCCESS, "[pcre] cli_parse_add() failed");
+        ret = readdb_parse_ldb_subsignature(root, pcre_testdata[i].virname, hexsig, pcre_testdata[i].offset, 0, NULL, 0, 0, 1, NULL);
+        ck_assert_msg(ret == CL_SUCCESS, "[pcre] readdb_parse_ldb_subsignature failed");
         free(hexsig);
     }
 

--- a/unit_tests/check_regex.c
+++ b/unit_tests/check_regex.c
@@ -122,10 +122,10 @@ static cl_error_t cb_expect_multi(void *cbdata, const char *suffix, size_t len, 
     ck_assert_msg(!!exp, "expected data");
     exp++;
     ck_assert_msg(!!*exp, "expected no suffix, got: %s\n", suffix);
-    ck_assert_msg(!!exp[cb_called], "expected less suffixes, but already got: %d\n", cb_called);
+    ck_assert_msg(!!exp[cb_called], "expected less suffixes, but already got: %zu\n", cb_called);
     ck_assert_msg(strcmp(exp[cb_called], suffix) == 0,
                   "suffix mismatch, was: %s, expected: %s\n", suffix, exp[cb_called]);
-    ck_assert_msg(strlen(suffix) == len, "incorrect suffix len, expected: %d, got: %d\n", strlen(suffix), len);
+    ck_assert_msg(strlen(suffix) == len, "incorrect suffix len, expected: %zu, got: %zu\n", strlen(suffix), len);
     cb_called++;
     return CL_SUCCESS;
 }
@@ -148,7 +148,7 @@ START_TEST(test_suffix)
     p++;
     while (*p++) n++;
     ck_assert_msg(cb_called == n,
-                  "suffix number mismatch, expected: %d, was: %d\n", n, cb_called);
+                  "suffix number mismatch, expected: %zu, was: %zu\n", n, cb_called);
 }
 END_TEST
 


### PR DESCRIPTION
Some cleanup for readdb and matcher-ac that I did while trying to understand this code.  would be good to review and merge before https://github.com/Cisco-Talos/clamav/pull/466

This PR shouldn't break anything and doesn't _exactly_ fix anything, except in that it makes it that NDB and other ac-matching signatures (FTM?) don't call the same function we use for handling an LDB subsig.  