### PR TITLE
GH ACtions: Store windows portable installer as artifact

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -79,7 +79,7 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           name: windows-build
-          path: ${{runner.workspace}}/build/clamav-*.zip
+          path: ${{runner.workspace}}/build/
 
       - name: Test
         working-directory: ${{runner.workspace}}/build

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -72,15 +72,20 @@ jobs:
           vcpkgTriplet: ${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_TRIPLET_OUT }}
           buildDirectory: "${{runner.workspace}}/build"
 
+      - name: Create Installer
+        working-directory: ${{runner.workspace}}/build
+        run: cpack -C ${{ env.BUILD_TYPE }}
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: windows-build
+          path: ${{runner.workspace}}/build/clamav-*.zip
+
       - name: Test
         working-directory: ${{runner.workspace}}/build
         # Execute tests defined by the CMake configuration.
         # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
         run: ctest -C ${{ env.BUILD_TYPE }} -V
-
-      - name: Create Installer
-        working-directory: ${{runner.workspace}}/build
-        run: cpack -C ${{ env.BUILD_TYPE }}
 
   build-macos:
     runs-on: macos-latest


### PR DESCRIPTION
This PR to figure out why windows builds are failing in GH Actions now.