### PR TITLE
CMake, Rust: Improve toolchain (target triple) selection

### DIFF
--- a/CMakeOptions.cmake
+++ b/CMakeOptions.cmake
@@ -117,3 +117,8 @@ option(ENABLE_UNRAR
 option(ENABLE_SYSTEMD
     "Install systemd service files if systemd is found."
     ${ENABLE_SYSTEMD_DEFAULT})
+
+# For reference determining target platform:
+#  Rust Targets:  https://doc.rust-lang.org/nightly/rustc/platform-support.html
+option(RUST_COMPILER_TARGET
+    "Use a custom target triple to build the Rust components. Needed for cross-compiling.")

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -514,6 +514,12 @@ The following is a complete list of CMake options unique to configuring ClamAV:
 
   _Default: not set_
 
+- `RUST_COMPILER_TARGET`: Use a custom target triple to build the Rust components.
+  Needed for cross-compiling. You must also have installed the target toolchain.
+  See: https://doc.rust-lang.org/nightly/rustc/platform-support.html
+
+  _Default: not set_
+
 ## External Library Depedency Configuration Options
 
 The CMake tooling is good about finding installed dependencies on POSIX systems
@@ -688,8 +694,30 @@ cmake .. -D BYTECODE_RUNTIME="none"
 
 ## Compiling For Multiple Architectures (Cross-Compiling)
 
-For cross-compling information, see the cmake-toolchains documentation in the
+Cross-compiling in ClamAV with CMake & Rust is experimental at this time.
+If you have a need to cross-compile, your help and feedback testing and
+validating cross-compilation support would be appreciated.
+
+The CMake cross-compiling documentation can be found here:
 [CMake Manual](https://cmake.org/cmake/help/latest/manual/cmake-toolchains.7.html)
+
+For a cross-build, the library dependencies must have also been built for the
+target platform, and the CMake options set to target these libraries.
+
+ClamAV's Rust toolchain integration also complicates the build.
+In addition to specifying the toolchain for C/C++ through the CMake options
+described in the CMake Manual, you will need to also select the target triple
+for the Rust compiler toolchain. If you have a mismatch of targets between the
+C and Rust toolchains, it will fail to compile properly.
+
+The ClamAV project provides a CMake option `-D RUST_COMPILER_TARGET=<triple>`
+that mimics the CMake option when using Clang to cross-compile.
+
+Rust installations typically only come with the target for your current system.
+So you will need to install the desired toolchain using `rustup target add`.
+Run `rustup target add --help` for help.
+For a list of available target triples, see:
+https://doc.rust-lang.org/nightly/rustc/platform-support.html
 
 ## Un-install
 

--- a/libclamav_rust/src/sys.rs
+++ b/libclamav_rust/src/sys.rs
@@ -1208,7 +1208,6 @@ pub struct cli_lsig_tdb {
     pub icongrp1: *const ::std::os::raw::c_char,
     pub icongrp2: *const ::std::os::raw::c_char,
     pub macro_ptids: *mut u32,
-    pub mempool: *mut mpool_t,
 }
 pub const lsig_type_CLI_LSIG_NORMAL: lsig_type = 0;
 pub const lsig_type_CLI_YARA_NORMAL: lsig_type = 1;
@@ -1272,7 +1271,6 @@ pub struct cli_matcher {
     pub bcomp_metas: u32,
     pub bcomp_metatable: *mut *mut cli_bcomp_meta,
     pub linked_bcs: u32,
-    pub mempool: *mut mpool_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]


### PR DESCRIPTION
The current method of trying to determine the target triple based
the architecture, operating system, etc. is difficult to get right
and maintain. In particular, I found that some installations like the
Alpine package will use "alpine" in the name of the triple instead of
"unknown".
E.g. "aarch64-alpine-linux-musl" instead of "aarch64-unknown-linux-musl".
This makes it nearly impossible to figure out the exact target name
based on target system specifications.

I believe it will be better to use the default target 99% of the time
and require users that which to cross-compile to use a new CMake
variable `-D RUST_TARGET_TRIPLE=<target>` to choose the target.