### PR TITLE
PR-386 rebase: clamonacc: Added workaround for NULL-pointer usage in clamonacc-ddd thread.

### DIFF
--- a/clamonacc/c-thread-pool/thpool.c
+++ b/clamonacc/c-thread-pool/thpool.c
@@ -471,14 +471,14 @@ static struct job* jobqueue_pull(jobqueue* jobqueue_p){
 		  			break;
 
 		case 1:  /* if one job in queue */
-					logg("*jobqueue_pull: Thread %d pulled last job from queue.\n", syscall(SYS_gettid));
+					logg(LOGG_DEBUG_NV, "jobqueue_pull: Thread %d pulled last job from queue.\n", syscall(SYS_gettid));
 					jobqueue_p->front = NULL;
 					jobqueue_p->rear  = NULL;
 					jobqueue_p->len = 0;
 					break;
 
 		default: /* if >1 jobs in queue */
-					logg("*jobqueue_pull: Thread %d pulled a job from queue.\n", syscall(SYS_gettid));
+					logg(LOGG_DEBUG_NV, "jobqueue_pull: Thread %d pulled a job from queue.\n", syscall(SYS_gettid));
 					jobqueue_p->front = job_p->prev;
 					jobqueue_p->len--;
 					/* more than one job in queue -> post it */

--- a/clamonacc/inotif/inotif.c
+++ b/clamonacc/inotif/inotif.c
@@ -646,7 +646,10 @@ void *onas_ddd_th(void *arg)
 
                 event = (const struct inotify_event *)p;
                 wd    = event->wd;
-                path  = wdlt[wd];
+                if (wd >= 0)
+                    path = wdlt[wd];
+                else
+                    path = NULL;
                 child = event->name;
 
                 if (path == NULL) {

--- a/clamonacc/scan/onas_queue.c
+++ b/clamonacc/scan/onas_queue.c
@@ -152,7 +152,7 @@ void *onas_scan_queue_th(void *arg)
 #elif defined(__APPLE__) && defined(__MACH__)
     pthread_setname_np(thread_name);
 #else
-    logg("^ClamScanQueue: Setting of the thread name is currently not supported on this system\n");
+    logg(LOGG_WARNING, "ClamScanQueue: Setting of the thread name is currently not supported on this system\n");
 #endif
 
     /* not a ton of use for context right now, but perhaps in the future we can pass in more options */


### PR DESCRIPTION
This rebases https://github.com/Cisco-Talos/clamav/pull/386 and updates it, fixing a build issue introduced because of internal API changes made by the `logg` PR. 