### PR TITLE
Win32: Add fmap exports (0.103)

### DIFF
--- a/win32/libclamav.def
+++ b/win32/libclamav.def
@@ -77,6 +77,9 @@ EXPORTS cl_hash_destroy @69
 EXPORTS cl_engine_stats_enable @70
 EXPORTS cl_engine_set_clcb_virus_found @71
 EXPORTS cl_engine_get_str @72
+EXPORTS cl_scanmap_callback @73
+EXPORTS cl_fmap_close @74
+EXPORTS cl_fmap_open_memory @75
 
 ; path variables
 ; --------------


### PR DESCRIPTION
Adds missing exports for new fmap features that may be used by downstream applications. 

Note: This change not required in 0.104+ because we tossed out the `.def` file with the visual studio solution (for better or for worse).  I think with the CMake builds all symbols are exported. So, we may find out later that we need to bring back .def files, or preferably find a cross-platform way to export some symbols but not all symbols.  Anyways... This PR is needed for just 0.103(.6).