### PR TITLE
Code cleanup: Refactor to clean up formatting issues

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -4,13 +4,15 @@ AccessModifierOffset: -2
 AlignAfterOpenBracket: Align
 AlignConsecutiveMacros: false
 AlignConsecutiveAssignments: true
+AlignConsecutiveBitFields: false
 AlignConsecutiveDeclarations: false
 AlignEscapedNewlines: Left
-AlignOperands:   true
+AlignOperands:   Align
 AlignTrailingComments: true
 AllowAllArgumentsOnNextLine: true
 AllowAllConstructorInitializersOnNextLine: true
 AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortEnumsOnASingleLine: true
 AllowShortBlocksOnASingleLine: Never
 AllowShortCaseLabelsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: Empty
@@ -26,7 +28,7 @@ BinPackParameters: true
 BraceWrapping:
   AfterCaseLabel:  false
   AfterClass:      true
-  AfterControlStatement: false
+  AfterControlStatement: Never
   AfterEnum:       false
   AfterFunction:   true
   AfterNamespace:  true
@@ -36,6 +38,8 @@ BraceWrapping:
   AfterExternBlock: false
   BeforeCatch:     false
   BeforeElse:      false
+  BeforeLambdaBody: false
+  BeforeWhile:     false
   IndentBraces:    false
   SplitEmptyFunction: true
   SplitEmptyRecord: true
@@ -79,10 +83,13 @@ IncludeCategories:
 IncludeIsMainRegex: '(Test)?$'
 IncludeIsMainSourceRegex: ''
 IndentCaseLabels: true
+IndentCaseBlocks: false
 IndentGotoLabels: true
 IndentPPDirectives: None
+IndentExternBlock: AfterExternBlock
 IndentWidth:     4
 IndentWrappedFunctionNames: false
+InsertTrailingCommas: None
 JavaScriptQuotes: Leave
 JavaScriptWrapImports: true
 KeepEmptyLinesAtTheStartOfBlocks: true
@@ -92,6 +99,7 @@ MaxEmptyLinesToKeep: 1
 NamespaceIndentation: None
 ObjCBinPackProtocolList: Auto
 ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
 ObjCSpaceAfterProperty: false
 ObjCSpaceBeforeProtocolList: true
 PenaltyBreakAssignment: 2
@@ -132,5 +140,9 @@ StatementMacros:
 TabWidth:        8
 UseCRLF:         false
 UseTab:          Never
+WhitespaceSensitiveMacros:
+  - STRINGIZE
+  - PP_STRINGIZE
+  - BOOST_PP_STRINGIZE
 ...
 

--- a/common/actions.c
+++ b/common/actions.c
@@ -350,23 +350,23 @@ static int traverse_to(const char *directory, bool want_directory_handle, HANDLE
             char *driveroot      = malloc(driveroot_len);
             snprintf(driveroot, driveroot_len + 1, "\\??\\%s\\", tokens[0]);
             next_handle = win32_openat(current_handle,
-                                               driveroot,
-                                               pNtCreateFile,
-                                               pRtlInitUnicodeString,
-                                               desiredAccess,
-                                               fileAttributes,
-                                               createOptions,
-                                               shareAccess);
+                                       driveroot,
+                                       pNtCreateFile,
+                                       pRtlInitUnicodeString,
+                                       desiredAccess,
+                                       fileAttributes,
+                                       createOptions,
+                                       shareAccess);
             free(driveroot);
         } else {
             next_handle = win32_openat(current_handle,
-                                               tokens[i],
-                                               pNtCreateFile,
-                                               pRtlInitUnicodeString,
-                                               desiredAccess,
-                                               fileAttributes,
-                                               createOptions,
-                                               shareAccess);
+                                       tokens[i],
+                                       pNtCreateFile,
+                                       pRtlInitUnicodeString,
+                                       desiredAccess,
+                                       fileAttributes,
+                                       createOptions,
+                                       shareAccess);
         }
         if (NULL == next_handle) {
             logg(LOGG_INFO, "traverse_to: Failed open %s\n", tokens[i]);

--- a/common/getopt.c
+++ b/common/getopt.c
@@ -193,9 +193,10 @@ static int _getopt_internal(int argc, char *argv[], const char *shortopts,
             if ((argv[i][0] == '-') &&
                 (argv[i][1] != '\0')) {
                 optind = i;
-                opt    = _getopt_internal(argc, argv, shortopts,
-                                          longopts, longind,
-                                          long_only);
+
+                opt = _getopt_internal(argc, argv, shortopts,
+                                       longopts, longind,
+                                       long_only);
                 while (i > j) {
                     tmp = argv[--i];
                     for (k = i; k + 1 < optind; k++)

--- a/libclamav/bytecode_api.c
+++ b/libclamav/bytecode_api.c
@@ -357,8 +357,9 @@ uint32_t cli_bcapi_pe_rawaddr(struct cli_bc_ctx *ctx, uint32_t rva)
     uint32_t ret;
     unsigned err                      = 0;
     const struct cli_pe_hook_data *pe = ctx->hooks.pedata;
-    ret                               = cli_rawaddr(rva, ctx->sections, pe->nsections, &err,
-                                                    ctx->file_size, pe->hdr_size);
+
+    ret = cli_rawaddr(rva, ctx->sections, pe->nsections, &err,
+                      ctx->file_size, pe->hdr_size);
     if (err) {
         cli_dbgmsg("bcapi_pe_rawaddr invalid rva: %u\n", rva);
         return PE_INVALID_RVA;
@@ -972,8 +973,9 @@ int32_t cli_bcapi_lzma_init(struct cli_bc_ctx *ctx, int32_t from, int32_t to)
     memset(&b->stream, 0, sizeof(b->stream));
 
     b->stream.avail_in = avail_in_orig;
-    b->stream.next_in  = (void *)cli_bcapi_buffer_pipe_read_get(ctx, b->from,
-                                                                b->stream.avail_in);
+
+    b->stream.next_in = (void *)cli_bcapi_buffer_pipe_read_get(ctx, b->from,
+                                                               b->stream.avail_in);
 
     if ((ret = cli_LzmaInit(&b->stream, 0)) != LZMA_RESULT_OK) {
         cli_dbgmsg("bytecode api: LzmaInit: Failed to initialize LZMA decompressor: %d!\n", ret);

--- a/libclamav/bytecode_api.h
+++ b/libclamav/bytecode_api.h
@@ -92,8 +92,8 @@ enum BytecodeKind {
 enum FunctionalityLevels {
     FUNC_LEVEL_096     = 51, /**< LibClamAV release 0.96.0: bytecode engine released */
     FUNC_LEVEL_096_dev = 52,
-    FUNC_LEVEL_096_1   = 53, /**< LibClamAV release 0.96.1: logical signature use of VI/macros
-                              * requires this minimum functionality level */
+    FUNC_LEVEL_096_1   = 53, /**< LibClamAV release 0.96.1: logical signature use of VI/macros requires this minimum functionality level */
+
     FUNC_LEVEL_096_1_dev = 54,
     FUNC_LEVEL_096_2     = 54, /**< LibClamAV release 0.96.2: PDF Hooks require this minimum level */
     FUNC_LEVEL_096_2_dev = 55,

--- a/libclamav/bytecode_hooks.h
+++ b/libclamav/bytecode_hooks.h
@@ -30,10 +30,10 @@
 #define BYTECODE_HOOKS_H
 
 struct cli_bc_hooks {
-	 const uint32_t* match_offsets;
-	 const uint16_t* kind;
-	 const uint32_t* match_counts;
-	 const uint32_t* filesize;
-	 const struct cli_pe_hook_data* pedata;
+    const uint32_t* match_offsets;
+    const uint16_t* kind;
+    const uint32_t* match_counts;
+    const uint32_t* filesize;
+    const struct cli_pe_hook_data* pedata;
 };
 #endif

--- a/libclamav/c++/bytecode2llvm.cpp
+++ b/libclamav/c++/bytecode2llvm.cpp
@@ -1175,9 +1175,10 @@ class LLVMCodegen
                 }
             }
             Constant *C = buildConstant(Ty, bc->globals[i], c);
-            GV          = new GlobalVariable(*M, Ty, true,
-                                             GlobalValue::InternalLinkage,
-                                             C, "glob" + Twine(i));
+
+            GV = new GlobalVariable(*M, Ty, true,
+                                    GlobalValue::InternalLinkage,
+                                    C, "glob" + Twine(i));
             globals.push_back(GV);
         }
         Function **Functions = new Function *[bc->num_func];
@@ -1190,10 +1191,8 @@ class LLVMCodegen
                 argTypes.push_back(mapType(func->types[a]));
             }
             Type *RetTy       = mapType(func->returnType);
-            FunctionType *FTy = FunctionType::get(RetTy, argTypes,
-                                                  false);
-            Functions[j]      = Function::Create(FTy, Function::InternalLinkage,
-                                                 BytecodeID + "f" + Twine(j), M);
+            FunctionType *FTy = FunctionType::get(RetTy, argTypes, false);
+            Functions[j]      = Function::Create(FTy, Function::InternalLinkage, BytecodeID + "f" + Twine(j), M);
             Functions[j]->setDoesNotThrow();
             Functions[j]->setCallingConv(CallingConv::Fast);
             Functions[j]->setLinkage(GlobalValue::InternalLinkage);
@@ -1240,10 +1239,8 @@ class LLVMCodegen
                         continue;
                     unsigned g      = bc->globals[i][1];
                     unsigned offset = GVoffsetMap[g];
-
-                    Constant *Idx  = ConstantInt::get(Type::getInt32Ty(Context),
-                                                      offset);
-                    Value *Idxs[2] = {
+                    Constant *Idx   = ConstantInt::get(Type::getInt32Ty(Context), offset);
+                    Value *Idxs[2]  = {
                         ConstantInt::get(Type::getInt32Ty(Context), 0),
                         Idx};
                     Value *GEP       = Builder.CreateInBoundsGEP(Ctx, ArrayRef<Value *>(Idxs, Idxs + 2));
@@ -1815,10 +1812,8 @@ static void addNoCapture(Function *pFunc)
 static void addFunctionProtos(struct CommonFunctions *CF, ExecutionEngine *EE, Module *M)
 {
     LLVMContext &Context = M->getContext();
-    FunctionType *FTy    = FunctionType::get(Type::getVoidTy(Context),
-                                             false);
-    CF->FHandler         = Function::Create(FTy, Function::ExternalLinkage,
-                                            "clamjit.fail", M);
+    FunctionType *FTy    = FunctionType::get(Type::getVoidTy(Context), false);
+    CF->FHandler         = Function::Create(FTy, Function::ExternalLinkage, "clamjit.fail", M);
     CF->FHandler->setDoesNotReturn();
     CF->FHandler->setDoesNotThrow();
     CF->FHandler->addFnAttr(Attribute::NoInline);
@@ -1832,11 +1827,8 @@ static void addFunctionProtos(struct CommonFunctions *CF, ExecutionEngine *EE, M
     args.push_back(Type::getInt32Ty(Context));
     args.push_back(Type::getInt32Ty(Context));
     args.push_back(Type::getInt1Ty(Context));
-    FunctionType *FuncTy_3 = FunctionType::get(Type::getVoidTy(Context),
-                                               args, false);
-    CF->FMemset            = Function::Create(FuncTy_3, GlobalValue::ExternalLinkage,
-                                              "llvm.memset.p0i8.i32",
-                                              M);
+    FunctionType *FuncTy_3 = FunctionType::get(Type::getVoidTy(Context), args, false);
+    CF->FMemset            = Function::Create(FuncTy_3, GlobalValue::ExternalLinkage, "llvm.memset.p0i8.i32", M);
     CF->FMemset->setDoesNotThrow();
     addNoCapture(CF->FMemset);
 
@@ -1846,44 +1838,35 @@ static void addFunctionProtos(struct CommonFunctions *CF, ExecutionEngine *EE, M
     args.push_back(Type::getInt32Ty(Context));
     args.push_back(Type::getInt32Ty(Context));
     args.push_back(Type::getInt1Ty(Context));
-    FunctionType *FuncTy_4 = FunctionType::get(Type::getVoidTy(Context),
-                                               args, false);
-    CF->FMemmove           = Function::Create(FuncTy_4, GlobalValue::ExternalLinkage,
-                                              "llvm.memmove.p0i8.i32",
-                                              M);
+    FunctionType *FuncTy_4 = FunctionType::get(Type::getVoidTy(Context), args, false);
+    CF->FMemmove           = Function::Create(FuncTy_4, GlobalValue::ExternalLinkage, "llvm.memmove.p0i8.i32", M);
     CF->FMemmove->setDoesNotThrow();
     addNoCapture(CF->FMemmove);
 
-    CF->FMemcpy = Function::Create(FuncTy_4, GlobalValue::ExternalLinkage,
-                                   "llvm.memcpy.p0i8.p0i8.i32",
-                                   M);
+    CF->FMemcpy = Function::Create(FuncTy_4, GlobalValue::ExternalLinkage, "llvm.memcpy.p0i8.p0i8.i32", M);
     CF->FMemcpy->setDoesNotThrow();
     addNoCapture(CF->FMemcpy);
 
     args.clear();
     args.push_back(Type::getInt16Ty(Context));
     FunctionType *FuncTy_5 = FunctionType::get(Type::getInt16Ty(Context), args, false);
-    CF->FBSwap16           = Function::Create(FuncTy_5, GlobalValue::ExternalLinkage,
-                                              "llvm.bswap.i16", M);
+    CF->FBSwap16           = Function::Create(FuncTy_5, GlobalValue::ExternalLinkage, "llvm.bswap.i16", M);
     CF->FBSwap16->setDoesNotThrow();
 
     args.clear();
     args.push_back(Type::getInt32Ty(Context));
     FunctionType *FuncTy_6 = FunctionType::get(Type::getInt32Ty(Context), args, false);
-    CF->FBSwap32           = Function::Create(FuncTy_6, GlobalValue::ExternalLinkage,
-                                              "llvm.bswap.i32", M);
+    CF->FBSwap32           = Function::Create(FuncTy_6, GlobalValue::ExternalLinkage, "llvm.bswap.i32", M);
     CF->FBSwap32->setDoesNotThrow();
 
     args.clear();
     args.push_back(Type::getInt64Ty(Context));
     FunctionType *FuncTy_7 = FunctionType::get(Type::getInt64Ty(Context), args, false);
-    CF->FBSwap64           = Function::Create(FuncTy_7, GlobalValue::ExternalLinkage,
-                                              "llvm.bswap.i64", M);
+    CF->FBSwap64           = Function::Create(FuncTy_7, GlobalValue::ExternalLinkage, "llvm.bswap.i64", M);
     CF->FBSwap64->setDoesNotThrow();
 
     FunctionType *DummyTy = FunctionType::get(Type::getVoidTy(Context), false);
-    CF->FRealmemset       = Function::Create(DummyTy, GlobalValue::ExternalLinkage,
-                                             "memset", M);
+    CF->FRealmemset       = Function::Create(DummyTy, GlobalValue::ExternalLinkage, "memset", M);
     sys::DynamicLibrary::AddSymbol(CF->FRealmemset->getName(), (void *)(intptr_t)memset);
     EE->getPointerToFunction(CF->FRealmemset);
     CF->FRealMemmove = Function::Create(DummyTy, GlobalValue::ExternalLinkage,
@@ -1899,8 +1882,7 @@ static void addFunctionProtos(struct CommonFunctions *CF, ExecutionEngine *EE, M
     args.push_back(PointerType::getUnqual(Type::getInt8Ty(Context)));
     args.push_back(PointerType::getUnqual(Type::getInt8Ty(Context)));
     args.push_back(EE->getDataLayout().getIntPtrType(Context));
-    FuncTy_5        = FunctionType::get(Type::getInt32Ty(Context),
-                                        args, false);
+    FuncTy_5        = FunctionType::get(Type::getInt32Ty(Context), args, false);
     CF->FRealmemcmp = Function::Create(FuncTy_5, GlobalValue::ExternalLinkage, "memcmp", M);
     sys::DynamicLibrary::AddSymbol(CF->FRealmemcmp->getName(), (void *)(intptr_t)memcmp);
     EE->getPointerToFunction(CF->FRealmemcmp);
@@ -1962,8 +1944,7 @@ static void *bytecode_watchdog(void *arg)
         item = watchdog_head;
         while (item == watchdog_head) {
             item->in_use = 1;
-            ret          = pthread_cond_timedwait(&watchdog_cond, &watchdog_mutex,
-                                                  &item->abstimeout);
+            ret          = pthread_cond_timedwait(&watchdog_cond, &watchdog_mutex, &item->abstimeout);
             if (ret == ETIMEDOUT)
                 break;
             if (ret) {
@@ -2195,8 +2176,7 @@ int cli_bytecode_prepare_jit(struct cli_all_bc *bcs)
                 for (unsigned i = 0; i < cli_apicall_maxapi; i++) {
                     const struct cli_apicall *api = &cli_apicalls[i];
                     FunctionType *FTy             = cast<FunctionType>(apiMap.get(69 + api->type, NULL, NULL));
-                    Function *F                   = Function::Create(FTy, Function::ExternalLinkage,
-                                                                     api->name, M);
+                    Function *F                   = Function::Create(FTy, Function::ExternalLinkage, api->name, M);
                     void *dest;
                     switch (api->kind) {
                         case 0:
@@ -2243,8 +2223,7 @@ int cli_bytecode_prepare_jit(struct cli_all_bc *bcs)
                 }
 
                 // stack protector
-                FunctionType *FTy     = FunctionType::get(Type::getVoidTy(M->getContext()),
-                                                          false);
+                FunctionType *FTy     = FunctionType::get(Type::getVoidTy(M->getContext()), false);
                 GlobalVariable *Guard = new GlobalVariable(*M, PointerType::getUnqual(Type::getInt8Ty(M->getContext())),
                                                            true, GlobalValue::ExternalLinkage, 0, "__stack_chk_guard");
                 unsigned plus         = 0;
@@ -2254,8 +2233,7 @@ int cli_bytecode_prepare_jit(struct cli_all_bc *bcs)
                 sys::DynamicLibrary::AddSymbol(Guard->getName(), (void *)(&bcs->engine->guard.b[plus]));
                 setGuard(bcs->engine->guard.b);
                 bcs->engine->guard.b[plus + sizeof(void *) - 1] = 0x00;
-                Function *SFail                                 = Function::Create(FTy, Function::ExternalLinkage,
-                                                                                   "__stack_chk_fail", M);
+                Function *SFail                                 = Function::Create(FTy, Function::ExternalLinkage, "__stack_chk_fail", M);
                 sys::DynamicLibrary::AddSymbol(SFail->getName(), (void *)(intptr_t)jit_ssp_handler);
                 EE->getPointerToFunction(SFail);
 

--- a/libclamav/c++/detect.cpp
+++ b/libclamav/c++/detect.cpp
@@ -151,7 +151,7 @@ void cli_detect_env_jit(struct cli_environment *env)
             CASE_OS(Minix, os_unknown);
     }
 
-    //mmap RWX
+    // mmap RWX
     std::error_code ec;
     sys::MemoryBlock memoryBlock = sys::Memory::allocateMappedMemory(4096, nullptr, sys::Memory::MF_READ | sys::Memory::MF_WRITE | sys::Memory::MF_EXEC, ec);
     if (ec) {

--- a/libclamav/mbox.c
+++ b/libclamav/mbox.c
@@ -422,8 +422,9 @@ cli_parse_mbox(const char *dir, cli_ctx *ctx)
         int messagenumber;
         message *m = messageCreate(); /*Create an empty email */
 
-        if (m == NULL)
+        if (m == NULL) {
             return CL_EMEM;
+        }
 
         lastLineWasEmpty = false;
         messagenumber    = 1;
@@ -478,21 +479,26 @@ cli_parse_mbox(const char *dir, cli_ctx *ctx)
                 messageSetCTX(m, ctx);
 
                 cli_dbgmsg("Finished processing message\n");
-            } else
+            } else {
                 lastLineWasEmpty = (bool)(buffer[0] == '\0');
+            }
 
             if (isuuencodebegin(buffer)) {
                 /*
                  * Fast track visa to uudecode.
                  * TODO: binhex, yenc
                  */
-                if (uudecodeFile(m, buffer, dir, map, &at) < 0)
-                    if (messageAddStr(m, buffer) < 0)
+                if (uudecodeFile(m, buffer, dir, map, &at) < 0) {
+                    if (messageAddStr(m, buffer) < 0) {
                         break;
-            } else
+                    }
+                }
+            } else {
                 /* at this point, the \n has been removed */
-                if (messageAddStr(m, buffer) < 0)
+                if (messageAddStr(m, buffer) < 0) {
                     break;
+                }
+            }
         } while (fmap_gets(map, buffer, &at, sizeof(buffer) - 1));
 
         if (retcode == CL_SUCCESS) {
@@ -503,8 +509,9 @@ cli_parse_mbox(const char *dir, cli_ctx *ctx)
                 retcode = CL_VIRUS;
             }
         }
-        if (m)
+        if (m) {
             messageDestroy(m);
+        }
     } else {
         /*
          * It's a single message, parse the headers then the body
@@ -515,16 +522,18 @@ cli_parse_mbox(const char *dir, cli_ctx *ctx)
              * blank line
              */
             while (fmap_gets(map, buffer, &at, sizeof(buffer) - 1) &&
-                   (strchr("\r\n", buffer[0]) == NULL))
+                   (strchr("\r\n", buffer[0]) == NULL)) {
                 ;
+            }
         /* getline_from_mbox could be using unlocked_stdio(3),
          * so lock file here */
         /*
          * Ignore any blank lines at the top of the message
          */
         while (strchr("\r\n", buffer[0]) &&
-               (getline_from_mbox(buffer, sizeof(buffer) - 1, map, &at) != NULL))
+               (getline_from_mbox(buffer, sizeof(buffer) - 1, map, &at) != NULL)) {
             ;
+        }
 
         buffer[sizeof(buffer) - 1] = '\0';
 
@@ -575,8 +584,9 @@ cli_parse_mbox(const char *dir, cli_ctx *ctx)
             }
         }
 
-        if (body->isTruncated && retcode == CL_SUCCESS)
+        if (body->isTruncated && retcode == CL_SUCCESS) {
             retcode = CL_EMEM;
+        }
         /*
          * Tidy up and quit
          */
@@ -585,7 +595,8 @@ cli_parse_mbox(const char *dir, cli_ctx *ctx)
 
     if ((retcode == CL_CLEAN) && ctx->found_possibly_unwanted &&
         (*ctx->virname == NULL || SCAN_ALLMATCHES)) {
-        retcode                      = cli_append_virus(ctx, "Heuristics.Phishing.Email");
+        retcode = cli_append_virus(ctx, "Heuristics.Phishing.Email");
+
         ctx->found_possibly_unwanted = 0;
     }
 

--- a/libclamav/qsort.c
+++ b/libclamav/qsort.c
@@ -36,6 +36,7 @@
 #include "platform.h"
 #include "others.h"
 
+// clang-format off
 static inline char *med3(char *, char *, char *, int (*)(const void *, const void *));
 static inline char *med3_r(void *, char *, char *, char *, int (*)(const void *, const void *, const void *));
 static inline void swapfunc(char *, char *, int, int);
@@ -88,9 +89,7 @@ int n, swaptype;
 #define MED3_R(arg, a, b, c, d) (d ? (med3_r(arg, a, b, c, d)) : (CMP1(a, b) < 0 ? (CMP1(b, c) < 0 ? (b) : (CMP1(a, c) < 0 ? (c) : (a))) : (CMP1(b, c) > 0 ? (b) : (CMP1(a, c) < 0 ? (a) : (c)))))
 
 static inline char *
-med3(a, b, c, cmp)
-char *a,
-    *b, *c;
+    med3(a, b, c, cmp) char *a, *b, *c;
 int (*cmp)(const void *, const void *);
 {
     return CMP(a, b) < 0 ? (CMP(b, c) < 0 ? b : (CMP(a, c) < 0 ? c : a))
@@ -263,3 +262,4 @@ loop:
     }
     /*		cli_qsort_r(pn - r, r / es, es, cmp);*/
 }
+// clang-format on

--- a/libclamav/vba_extract.c
+++ b/libclamav/vba_extract.c
@@ -2231,10 +2231,8 @@ cli_wm_readdir(int fd)
     vba_project = create_vba_project(macro_info.count, "", NULL);
 
     if (vba_project) {
-        vba_project->length = (uint32_t *)cli_malloc(sizeof(uint32_t) *
-                                                     macro_info.count);
-        vba_project->key    = (unsigned char *)cli_malloc(sizeof(unsigned char) *
-                                                          macro_info.count);
+        vba_project->length = (uint32_t *)cli_malloc(sizeof(uint32_t) * macro_info.count);
+        vba_project->key    = (unsigned char *)cli_malloc(sizeof(unsigned char) * macro_info.count);
         if ((vba_project->length != NULL) &&
             (vba_project->key != NULL)) {
             int i;

--- a/libclamav/xz_iface.c
+++ b/libclamav/xz_iface.c
@@ -73,8 +73,10 @@ int cli_XzDecode(struct CLI_XZ *XZ)
 
     inbytes  = XZ->avail_in;
     outbytes = XZ->avail_out;
-    res      = XzUnpacker_Code(&XZ->state, XZ->next_out, &outbytes,
-                               XZ->next_in, &inbytes, CODER_FINISH_ANY, &XZ->status);
+
+    res = XzUnpacker_Code(&XZ->state, XZ->next_out, &outbytes,
+                          XZ->next_in, &inbytes, CODER_FINISH_ANY, &XZ->status);
+
     XZ->avail_in -= inbytes;
     XZ->next_in += inbytes;
     XZ->avail_out -= outbytes;

--- a/libclamav/yara_compiler.c
+++ b/libclamav/yara_compiler.c
@@ -420,64 +420,73 @@ int _yr_compiler_compile_rules(
 
     if (result == ERROR_SUCCESS) {
         compiler->automaton_arena = NULL;
-        result                    = yr_arena_append(
-                               arena,
-                               compiler->code_arena);
+
+        result = yr_arena_append(
+            arena,
+            compiler->code_arena);
     }
 
     if (result == ERROR_SUCCESS) {
         compiler->code_arena = NULL;
-        result               = yr_arena_append(
-                          arena,
-                          compiler->re_code_arena);
+
+        result = yr_arena_append(
+            arena,
+            compiler->re_code_arena);
     }
 
     if (result == ERROR_SUCCESS) {
         compiler->re_code_arena = NULL;
-        result                  = yr_arena_append(
-                             arena,
-                             compiler->rules_arena);
+
+        result = yr_arena_append(
+            arena,
+            compiler->rules_arena);
     }
 
     if (result == ERROR_SUCCESS) {
         compiler->rules_arena = NULL;
-        result                = yr_arena_append(
-                           arena,
-                           compiler->strings_arena);
+
+        result = yr_arena_append(
+            arena,
+            compiler->strings_arena);
     }
 
     if (result == ERROR_SUCCESS) {
         compiler->strings_arena = NULL;
-        result                  = yr_arena_append(
-                             arena,
-                             compiler->externals_arena);
+
+        result = yr_arena_append(
+            arena,
+            compiler->externals_arena);
     }
 
     if (result == ERROR_SUCCESS) {
         compiler->externals_arena = NULL;
-        result                    = yr_arena_append(
-                               arena,
-                               compiler->namespaces_arena);
+
+        result = yr_arena_append(
+            arena,
+            compiler->namespaces_arena);
     }
 
     if (result == ERROR_SUCCESS) {
         compiler->namespaces_arena = NULL;
-        result                     = yr_arena_append(
-                                arena,
-                                compiler->metas_arena);
+
+        result = yr_arena_append(
+            arena,
+            compiler->metas_arena);
     }
 
     if (result == ERROR_SUCCESS) {
         compiler->metas_arena = NULL;
-        result                = yr_arena_append(
-                           arena,
-                           compiler->sz_arena);
+
+        result = yr_arena_append(
+            arena,
+            compiler->sz_arena);
     }
 
     if (result == ERROR_SUCCESS) {
         compiler->sz_arena             = NULL;
         compiler->compiled_rules_arena = arena;
-        result                         = yr_arena_coalesce(arena);
+
+        result = yr_arena_coalesce(arena);
     }
 
     return result;


### PR DESCRIPTION
Refactored the clamscan code that determines 'what to scan' in order
to clean up some very messy logic and also to get around a difference in
how vscode and clang-format handle formatting #ifdef blocks in the
middle of an else/if.

In addition to refactoring, there is a slight behavior improvement. With
this change, doing `clamscan blah -` will now scan `blah` and then also
scan `stdin`.  You can even do `clamscan - blah` to now scan `stdin` and
then scan `blah`. Before, The `-` had to be the only "filename" argument
in order to scan from stdin.

In addition, added a bunch of extra empty lines or changing multi-line
function calls to single-line function calls in order to get around a
bug in clang-format with these two options do not playing nice together:
- AlignConsecutiveAssignments: true
- AlignAfterOpenBracket: true

AlignAfterOpenBracket is not taking account the spaces inserted by
AlignConsecutiveAssignments, so you end up with stuff like this:
```c
    bleeblah = 1;
    blah     = function(arg1,
                    arg2,
                    arg3);

                //  ^--- these args 4-left from where they should be.
```

VSCode, meanwhile, somehow fixes this whitespace issue so code that is
correctly formatted by VSCode doesn't have this bug, meaning that:

1. The clang-format check in GH Actions fails.
2. We'd all have to stop using format-on-save in VSCode and accept the
  bug if we wanted those GH Actions tests to pass.

Adding an empty line before variable assignments from multi-line
function calls evades the buggy behavior.

This commit should resolve the clang-format github action test failures,
for now.