### PR TITLE
Yara: Fix support for regex strings

### DIFF
--- a/libclamav/readdb.c
+++ b/libclamav/readdb.c
@@ -644,10 +644,6 @@ static cl_error_t readdb_parse_yara_string(struct cli_matcher *root, const char 
          * Looks like a pcre subsignature.
          */
         ret = readdb_load_regex_subsignature(root, virname, hexsig, offset, lsigid, options);
-        if (CL_SUCCESS != ret) {
-            status = ret;
-            goto done;
-        }
 
     } else {
         /*
@@ -658,11 +654,11 @@ static cl_error_t readdb_parse_yara_string(struct cli_matcher *root, const char 
         } else {
             ret = cli_add_content_match_pattern(root, virname, hexsig, 0, 0, 0, offset, target, lsigid, options);
         }
+    }
 
-        if (CL_SUCCESS != ret) {
-            status = ret;
-            goto done;
-        }
+    if (CL_SUCCESS != ret) {
+        status = ret;
+        goto done;
     }
 
     status = CL_SUCCESS;


### PR DESCRIPTION
In 0.104 and prior, the function for adding a logical subsignature
was being used for NDB sigs, FTM, sigs, *and* Yara strings.

When cleaning up the logic for handling different types of logical
sig subsignatures, we accidentally broke support for regex strings in
yara rules.

This commit adds new logic for recording if the Yara string is a regex
string, by adding a regex subsig opt. Then in a new function for adding
different types of Yara strings, we check if it's a regex string or not
before adding as either a PCRE pattern or as an AC/BM pattern.

Resolves: https://github.com/Cisco-Talos/clamav/issues/494