### PR TITLE
sigtool --fuzzy-img FILES

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -69,6 +69,10 @@ ClamAV 0.105.0 includes the following improvements and changes.
 
   To generate the image fuzzy hash you can run this command:
   ```
+  sigtool --fuzzy-img FILE(S)
+  ```
+  Or you may generate it through `clamscan` like this:
+  ```
   clamscan --gen-json --debug /path/to/file
   ```
   The hash will appear in the JSON above the "SCAN SUMMARY" under the object

--- a/common/optparser.c
+++ b/common/optparser.c
@@ -158,6 +158,7 @@ const struct clam_option __clam_options[] = {
     {NULL, "sha256", 0, CLOPT_TYPE_BOOL, MATCH_BOOL, 0, NULL, 0, OPT_SIGTOOL, "", ""},
     {NULL, "mdb", 0, CLOPT_TYPE_BOOL, MATCH_BOOL, 0, NULL, 0, OPT_SIGTOOL, "", ""},
     {NULL, "imp", 0, CLOPT_TYPE_BOOL, MATCH_BOOL, 0, NULL, 0, OPT_SIGTOOL, "", ""},
+    {NULL, "fuzzy-img", 0, CLOPT_TYPE_BOOL, MATCH_BOOL, 0, NULL, 0, OPT_SIGTOOL, "", ""},
     {NULL, "print-certs", 0, CLOPT_TYPE_STRING, NULL, -1, NULL, 0, OPT_SIGTOOL, "", ""},
     {NULL, "html-normalise", 0, CLOPT_TYPE_STRING, NULL, -1, NULL, 0, OPT_SIGTOOL, "", ""},
     {NULL, "ascii-normalise", 0, CLOPT_TYPE_STRING, NULL, -1, NULL, 0, OPT_SIGTOOL, "", ""},

--- a/libclamav/dsig.c
+++ b/libclamav/dsig.c
@@ -114,7 +114,7 @@ static unsigned char *cli_decodesig(const char *sig, unsigned int plen, fp_int e
     return plain;
 }
 
-const char *cli_getdsig(const char *host, const char *user, const unsigned char *data, unsigned int datalen, unsigned short mode)
+char *cli_getdsig(const char *host, const char *user, const unsigned char *data, unsigned int datalen, unsigned short mode)
 {
     char buff[512], cmd[128], pass[31], *pt;
     struct sockaddr_in server;

--- a/libclamav/dsig.h
+++ b/libclamav/dsig.h
@@ -31,6 +31,19 @@
 
 int cli_versig(const char *md5, const char *dsig);
 int cli_versig2(const unsigned char *sha256, const char *dsig_str, const char *n_str, const char *e_str);
-const char *cli_getdsig(const char *host, const char *user, const unsigned char *data, unsigned int datalen, unsigned short mode);
+
+/**
+ * @brief Connect to a signing server, send the data to be signed, and return the digital signature.
+ *
+ * Caller is responsible for freeing the returned dsig.
+ *
+ * @param host
+ * @param user
+ * @param data
+ * @param datalen
+ * @param mode
+ * @return char*
+ */
+char *cli_getdsig(const char *host, const char *user, const unsigned char *data, unsigned int datalen, unsigned short mode);
 
 #endif

--- a/sigtool/sigtool.c
+++ b/sigtool/sigtool.c
@@ -699,7 +699,7 @@ static int build(const struct optstruct *opts)
     STATBUF foo;
     unsigned char buffer[FILEBUFF];
     char *tarfile, header[513], smbuff[32], builder[33], *pt, olddb[512];
-    char patch[32], broken[32], dbname[32], dbfile[32];
+    char patch[50], broken[57], dbname[32], dbfile[36];
     const char *newcvd, *localdbdir = NULL;
     struct cl_engine *engine;
     FILE *cvd, *fh;
@@ -2445,7 +2445,7 @@ static int decodehex(const char *hexsig)
 {
     char *pt, *hexcpy, *start, *n, *decoded, *wild;
     int asterisk = 0;
-    unsigned int i, j, hexlen, dlen, parts = 0, bw;
+    unsigned int i, j, hexlen, dlen, parts = 0;
     int mindist = 0, maxdist = 0, error = 0;
 
     hexlen = strlen(hexsig);
@@ -2573,7 +2573,7 @@ static int decodehex(const char *hexsig)
                 free(hexcpy);
                 return -1;
             }
-            bw = write(1, decoded, dlen);
+            (void)write(1, decoded, dlen);
             free(decoded);
 
             if (i == parts)
@@ -2654,7 +2654,7 @@ static int decodehex(const char *hexsig)
                 free(pt);
                 return -1;
             }
-            bw = write(1, decoded, dlen);
+            (void)write(1, decoded, dlen);
             free(decoded);
             if (i < parts)
                 mprintf(LOGG_INFO, "{WILDCARD_ANY_STRING}");
@@ -2666,7 +2666,7 @@ static int decodehex(const char *hexsig)
             mprintf(LOGG_ERROR, "Decoding failed\n");
             return -1;
         }
-        bw = write(1, decoded, dlen);
+        (void)write(1, decoded, dlen);
         free(decoded);
     }
 
@@ -3148,7 +3148,7 @@ static int diffdirs(const char *old, const char *new, const char *patch)
 
 static int makediff(const struct optstruct *opts)
 {
-    char *odir, *ndir, name[32], broken[32], dbname[32];
+    char *odir, *ndir, name[32], broken[39], dbname[32];
     struct cl_cvd *cvd;
     unsigned int oldver, newver;
     int ret;

--- a/sigtool/sigtool.c
+++ b/sigtool/sigtool.c
@@ -326,6 +326,97 @@ static int hashsig(const struct optstruct *opts, unsigned int class, int type)
     return 0;
 }
 
+static int fuzzy_img_file(char *filename)
+{
+    int status = -1;
+
+    int target_fd                   = -1;
+    FFIError *fuzzy_hash_calc_error = NULL;
+    uint8_t *mem                    = NULL;
+
+    image_fuzzy_hash_t hash = {0};
+    STATBUF st;
+    ssize_t bytes_read;
+
+    if ((target_fd = open(filename, O_RDONLY)) == -1) {
+        mprintf(LOGG_ERROR, "%s: Can't open file\n", basename(filename));
+        goto done;
+    }
+
+    if (FSTAT(target_fd, &st)) {
+        mprintf(LOGG_ERROR, "%s: fstat() failed.\n", basename(filename));
+        goto done;
+    }
+
+    if (NULL == (mem = malloc((size_t)st.st_size))) {
+        mprintf(LOGG_ERROR, "%s: Malloc failed, buffer size: %zu\n", basename(filename), (size_t)st.st_size);
+        goto done;
+    }
+
+    bytes_read = read(target_fd, mem, (size_t)st.st_size);
+    if (bytes_read != (ssize_t)st.st_size) {
+        mprintf(LOGG_ERROR, "%s: Failed to read file.\n", basename(filename));
+        goto done;
+    }
+
+    if (!fuzzy_hash_calculate_image(mem, (size_t)st.st_size, hash.hash, 8, &fuzzy_hash_calc_error)) {
+        mprintf(LOGG_ERROR, "%s: Failed to calculate image fuzzy hash: %s\n",
+                basename(filename),
+                ffierror_fmt(fuzzy_hash_calc_error));
+        goto done;
+    }
+
+    char hashstr[17];
+    snprintf(hashstr, 17, "%02x%02x%02x%02x%02x%02x%02x%02x",
+             hash.hash[0], hash.hash[1], hash.hash[2], hash.hash[3],
+             hash.hash[4], hash.hash[5], hash.hash[6], hash.hash[7]);
+    mprintf(LOGG_INFO, "%s: %s\n", basename(filename), hashstr);
+
+    status = 0;
+
+done:
+
+    if (NULL != mem) {
+        free(mem);
+    }
+
+    if (NULL != fuzzy_hash_calc_error) {
+        ffierror_free(fuzzy_hash_calc_error);
+    }
+
+    if (target_fd != -1) {
+        close(target_fd);
+    }
+
+    return status;
+}
+
+static int fuzzy_img(const struct optstruct *opts)
+{
+    int status = 0;
+    int ret;
+
+    size_t i;
+
+    if (!opts->filename) {
+        mprintf(LOGG_ERROR, "You must provide one or more files to generate a hash.");
+        status = -1;
+        goto done;
+    }
+
+    for (i = 0; opts->filename[i]; i++) {
+        ret = fuzzy_img_file(opts->filename[i]);
+        if (ret != 0) {
+            // report failure if any of the files fail
+            status = -1;
+        }
+    }
+
+done:
+
+    return status;
+}
+
 static int htmlnorm(const struct optstruct *opts)
 {
     int fd;
@@ -3300,6 +3391,7 @@ static void help(void)
     mprintf(LOGG_INFO, "                                           or SHA256 sigs for FILES\n");
     mprintf(LOGG_INFO, "    --mdb [FILES]                          Generate .mdb (section hash) sigs\n");
     mprintf(LOGG_INFO, "    --imp [FILES]                          Generate .imp (import table hash) sigs\n");
+    mprintf(LOGG_INFO, "    --fuzzy-img FILE(S)                    Generate image fuzzy hash for each file\n");
     mprintf(LOGG_INFO, "    --html-normalise=FILE                  Create normalised parts of HTML file\n");
     mprintf(LOGG_INFO, "    --ascii-normalise=FILE                 Create normalised text file from ascii source\n");
     mprintf(LOGG_INFO, "    --utf16-decode=FILE                    Decode UTF16 encoded files\n");
@@ -3397,6 +3489,8 @@ int main(int argc, char **argv)
         ret = hashsig(opts, 1, 1);
     else if (optget(opts, "imp")->enabled)
         ret = hashsig(opts, 2, 1);
+    else if (optget(opts, "fuzzy-img")->enabled)
+        ret = fuzzy_img(opts);
     else if (optget(opts, "html-normalise")->enabled)
         ret = htmlnorm(opts);
     else if (optget(opts, "ascii-normalise")->enabled)


### PR DESCRIPTION
Added a new sigtool option `--fuzzy-img` to generate the image fuzzy hash for used in the new `fuzzy_img` logical subsignatures.

You can pass it a list of files if you want, like this:
```
❯ ./install/bin/sigtool --fuzzy-img ~/Downloads/*.png
cisco.png: 9463944473afd82f
clam-gears.png: ffa896c0df02489e
inosuke.png: 85914e78772cf1c6
mamayaga.png: c74b32c337644ab5
```

This should be more convenient than having to run `clamscan --gen-json --debug <file>`