### PR TITLE
Fix relative bounds checking in regex_list.c

### DIFF
--- a/libclamav/regex_list.c
+++ b/libclamav/regex_list.c
@@ -499,7 +499,7 @@ cl_error_t load_regex_matcher(struct cl_engine *engine, struct regex_matcher *ma
         /* '-3' to leave room for the '/' and null being
          * appended below.
          */
-        if (pattern_len < (FILEBUFF - 3)) {
+        if ((pattern - buffer) + pattern_len < (FILEBUFF - 3)) {
             pattern[pattern_len]     = '/';
             pattern[pattern_len + 1] = '\0';
         } else {


### PR DESCRIPTION
The check of pattern_len against FILEBUF is largely meaningless since
pattern is derived from a strchr() call against buffer (with length FILEBUFF)

This fix ensures that the relative size is checked against max buffer size
which prevents overwriting stack memory with a single null byte