### PR TITLE
Changed free to MPOOL_FREE

### DIFF
--- a/libclamav/matcher-ac.c
+++ b/libclamav/matcher-ac.c
@@ -2668,7 +2668,7 @@ cl_error_t cli_ac_addsig(struct cli_matcher *root, const char *virname, const ch
 
         hexnewsz = strlen(hexsig) + 1;
         if (!(hexnew = (char *)cli_calloc(1, hexnewsz))) {
-            free(new);
+            MPOOL_FREE(root->mempool, new);
             free(hexcpy);
             return CL_EMEM;
         }


### PR DESCRIPTION
'new' is allocated by mpool, so should be freed by the mpool free
function.