### PR TITLE
docker: make clamd listen on IPv4 and v6 ADDR_ANY

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ RUN apk add --no-cache \
         -e "s|.*\(PidFile\) .*|\1 /run/lock/clamd.pid|" \
         -e "s|.*\(LocalSocket\) .*|\1 /run/clamav/clamd.sock|" \
         -e "s|.*\(TCPSocket\) .*|\1 3310|" \
-        -e "s|.*\(TCPAddr\) .*|\1 0.0.0.0|" \
+        -e "s|.*\(TCPAddr\) .*|#\1 0.0.0.0|" \
         -e "s|.*\(User\) .*|\1 clamav|" \
         -e "s|^\#\(LogFile\) .*|\1 /var/log/clamav/clamd.log|" \
         -e "s|^\#\(LogTime\).*|\1 yes|" \


### PR DESCRIPTION
Fix #505 by making clamd listen to all addresses available (IPv4 and IPv6). This is the default behavior of clamd meaning that commenting out the `TCPAddr 0.0.0.0` in `/etc/clamav/clamd.conf` should work.