### PR TITLE
PE parser: fix recently introduced NULL dereference crash

### DIFF
--- a/libclamav_rust/src/sys.rs
+++ b/libclamav_rust/src/sys.rs
@@ -1311,13 +1311,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " @brief Connect to a signing server, send the data to be signed, and return the digital signature."]
+    #[doc = ""]
+    #[doc = " Caller is responsible for freeing the returned dsig."]
+    #[doc = ""]
+    #[doc = " @param host"]
+    #[doc = " @param user"]
+    #[doc = " @param data"]
+    #[doc = " @param datalen"]
+    #[doc = " @param mode"]
+    #[doc = " @return char*"]
     pub fn cli_getdsig(
         host: *const ::std::os::raw::c_char,
         user: *const ::std::os::raw::c_char,
         data: *const ::std::os::raw::c_uchar,
         datalen: ::std::os::raw::c_uint,
         mode: ::std::os::raw::c_ushort,
-    ) -> *const ::std::os::raw::c_char;
+    ) -> *mut ::std::os::raw::c_char;
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]


### PR DESCRIPTION
Commit f82492aef4e6b7b30e892a298e0d799ae99ef684 fixed a crash in Windows
debug builds but in so doing accidentally introduced a possible crash
when scanning PE files that lack import tables.  The issue being that
the openssl hashing functions try to "finish" a hash that was never
started.

This commit fixes the issue by returning CL_BREAK instead of CL_SUCCESS
when the import table doesn't exist or RVA is invalid so that we can
differentiate between successfully calculating the hashes and
successfully skipping the hashing process.