### PR TITLE
Minor fixes: remove a couple of unused variables

### DIFF
--- a/clamonacc/scan/onas_queue.c
+++ b/clamonacc/scan/onas_queue.c
@@ -158,7 +158,6 @@ void *onas_scan_queue_th(void *arg)
     /* not a ton of use for context right now, but perhaps in the future we can pass in more options */
     struct onas_context *ctx = (struct onas_context *)arg;
     sigset_t sigset;
-    int ret;
 
     /* ignore all signals except SIGUSR2 */
     sigfillset(&sigset);

--- a/libclamav/png.c
+++ b/libclamav/png.c
@@ -98,8 +98,6 @@ cl_error_t cli_parsepng(cli_ctx *ctx)
     uint64_t offset              = 8;
     fmap_t *map                  = NULL;
 
-    int err = Z_OK;
-
     cli_dbgmsg("in cli_parsepng()\n");
 
     if (NULL == ctx) {


### PR DESCRIPTION
Removing `err` from *libclamav/png.c* and `ret` from *clamav/clamonacc/scan/onas_queue.c* gets rid of a couple of compile-time warnings. The changes should be trivial to review and merge.