### PR TITLE
0.105 release prep: Set version suffix to '-rc2'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,4 @@
+
 # Copyright (C) 2019-2022 Cisco Systems, Inc. and/or its affiliates. All rights reserved.
 
 if(WIN32)
@@ -18,7 +19,7 @@ cmake_policy(SET CMP0087 NEW) # support generator expressions in install(CODE) a
 #  For release candidate:     set(VERSION_SUFFIX "-rc")
 #  For release:               set(VERSION_SUFFIX "")
 string(TIMESTAMP TODAY "%Y%m%d")
-set(VERSION_SUFFIX "-rc")
+set(VERSION_SUFFIX "-rc2")
 
 project( ClamAV
          VERSION "0.105.0"

--- a/NEWS.md
+++ b/NEWS.md
@@ -180,6 +180,10 @@ ClamAV 0.105.0 includes the following improvements and changes.
   - Set the default time zone to `Etc/UTC`. The `--env` parameter can be used to
     customize the time zone by setting `TZ` environment variable.
     Patch courtesy of Olliver Schinagl.
+  - Fixed an issue where ClamD would listen only for IPv4 connections in 
+    environments where IPv6 is preferred. ClamD will now listen to all
+    addresses available (IPv4 and IPv6). This is the default behavior of ClamD.
+    Patch courtesy of Andre Breiler.
 
 - Added support for detecting the curses library dependency even when the
   associated pkg-config file is not present. This resolves a build issue on some
@@ -192,6 +196,7 @@ ClamAV 0.105.0 includes the following improvements and changes.
 The ClamAV team thanks the following individuals for their code submissions:
 - Ahmon Dancy
 - Alexander Sulfrian
+- Andre Breiler
 - Carlos Velasco
 - Bernd Kuhls
 - David Korczynski


### PR DESCRIPTION
Also update release notes in the NEWS to describe and credit
the IPv6 compatibility fix.