### PR TITLE
Make idle-timeout to control running process

### DIFF
--- a/clamd/thrmgr.c
+++ b/clamd/thrmgr.c
@@ -700,10 +700,10 @@ static void *thrmgr_worker(void *arg)
             exit(-2);
         }
         if (job_data) {
-            threadpool->handler(job_data);
-        } else if (must_exit) {
-            break;
-        }
+            if (must_exit) {
+                break;
+            }                
+        } 
     }
     if (pthread_mutex_lock(&(threadpool->pool_mutex)) != 0) {
         /* Fatal error */


### PR DESCRIPTION
clamd thread won't killed or exited if client disconnect while process still scan so process won't run longer than idle-timeout limit since both ReadTimeout and CommandReadTimeout setting can't control the process if it still scanning.