### PR TITLE
1611 - add bounds checking to wdb pattern buffer

### DIFF
--- a/libclamav/regex_list.c
+++ b/libclamav/regex_list.c
@@ -763,6 +763,8 @@ cl_error_t regex_list_add_pattern(struct regex_matcher *matcher, char *pattern)
             len -= sizeof(remove_end) - 1;
             pattern[len++] = '/';
         }
+    }
+    if (len > sizeof(remove_end2)) {
         if (strncmp(&pattern[len - sizeof(remove_end2) + 1], remove_end2, sizeof(remove_end2) - 1) == 0) {
             len -= sizeof(remove_end2) - 1;
             pattern[len++] = '/';


### PR DESCRIPTION
During wdb load, it was possible to go beyond the bounds
of the pattern buffer due to two subsequent increment ops
with no bounds checking in between.

This issue was reported by external researchers and
they provided the fix as well.

Based on our own research, this is a defect but not a vulnerability.