### PR TITLE
Clam 1782 utf8 win32 issues

### DIFF
--- a/libclamav/bytecode_api.c
+++ b/libclamav/bytecode_api.c
@@ -165,7 +165,8 @@ uint32_t cli_bcapi_debug_print_uint(struct cli_bc_ctx *ctx, uint32_t a)
     // return 0;
     if (!cli_debug_flag)
         return 0;
-    return fprintf(stderr, "%d", a);
+
+    return cli_eprintf("%d", a);
 }
 
 /*TODO: compiler should make sure that only constants are passed here, and not

--- a/libclamav/libmspack.c
+++ b/libclamav/libmspack.c
@@ -20,6 +20,7 @@
 #include "fmap.h"
 #include "scanners.h"
 #include "others.h"
+#include "clamav_rust.h"
 
 enum mspack_type {
     FILETYPE_DUNNO,
@@ -290,7 +291,7 @@ static void mspack_fmap_message(struct mspack_file *file, const char *fmt, ...)
         buff[strlen(buff)]     = '\n';
         buff[strlen(buff) + 1] = '\0';
 
-        cli_eprintf(buff);
+        clrs_eprint(buff);
     }
 }
 

--- a/libclamav/libmspack.c
+++ b/libclamav/libmspack.c
@@ -290,7 +290,7 @@ static void mspack_fmap_message(struct mspack_file *file, const char *fmt, ...)
         buff[strlen(buff)]     = '\n';
         buff[strlen(buff) + 1] = '\0';
 
-        fputs(buff, stderr);
+        cli_eprintf(buff);
     }
 }
 

--- a/libclamav/others.h
+++ b/libclamav/others.h
@@ -865,6 +865,12 @@ void cli_dbgmsg_no_inline(const char *str, ...) __attribute__((format(printf, 1,
 void cli_dbgmsg_no_inline(const char *str, ...);
 #endif
 
+#ifdef __GNUC__
+size_t cli_eprintf(const char *str, ...) __attribute__((format(printf, 1, 2)));
+#else
+size_t cli_eprintf(const char *str, ...);
+#endif
+
 #ifdef HAVE_CLI_GETPAGESIZE
 #undef HAVE_CLI_GETPAGESIZE
 #endif

--- a/libclamav/others_common.c
+++ b/libclamav/others_common.c
@@ -1349,7 +1349,7 @@ cl_error_t cli_get_filepath_from_handle(HANDLE hFile, char **filepath)
 
     if (0 == wcsncmp(L"\\\\?\\UNC", long_evaluated_filepathW, wcslen(L"\\\\?\\UNC"))) {
         conv_result = cli_codepage_to_utf8(
-            long_evaluated_filepathW,
+            (char *)long_evaluated_filepathW,
             (wcslen(long_evaluated_filepathW)) * sizeof(WCHAR),
             CODEPAGE_UTF16_LE,
             &evaluated_filepath,
@@ -1361,7 +1361,7 @@ cl_error_t cli_get_filepath_from_handle(HANDLE hFile, char **filepath)
         }
     } else {
         conv_result = cli_codepage_to_utf8(
-            long_evaluated_filepathW + wcslen(L"\\\\?\\"),
+            (char *)long_evaluated_filepathW + wcslen(L"\\\\?\\") * sizeof(WCHAR),
             (wcslen(long_evaluated_filepathW) - wcslen(L"\\\\?\\")) * sizeof(WCHAR),
             CODEPAGE_UTF16_LE,
             &evaluated_filepath,

--- a/libclamav/others_common.c
+++ b/libclamav/others_common.c
@@ -61,6 +61,7 @@
 #include "matcher-ac.h"
 #include "str.h"
 #include "entconv.h"
+#include "clamav_rust.h"
 
 #define MSGBUFSIZ 8192
 
@@ -122,15 +123,15 @@ void cli_logg_unsetup(void)
 uint8_t cli_debug_flag              = 0;
 uint8_t cli_always_gen_section_hash = 0;
 
-static void fputs_callback(enum cl_msg severity, const char *fullmsg, const char *msg, void *context)
+static void clrs_eprint_callback(enum cl_msg severity, const char *fullmsg, const char *msg, void *context)
 {
     UNUSEDPARAM(severity);
     UNUSEDPARAM(msg);
     UNUSEDPARAM(context);
-    fputs(fullmsg, stderr);
+    clrs_eprint(fullmsg);
 }
 
-static clcb_msg msg_callback = fputs_callback;
+static clcb_msg msg_callback = clrs_eprint_callback;
 
 void cl_set_clcb_msg(clcb_msg callback)
 {
@@ -176,7 +177,7 @@ inline void cli_dbgmsg(const char *str, ...)
 {
     if (UNLIKELY(cli_get_debug_flag())) {
         MSGCODE(buff, len, "LibClamAV debug: ");
-        fputs(buff, stderr);
+        clrs_eprint(buff);
     }
 }
 

--- a/libclamav/others_common.c
+++ b/libclamav/others_common.c
@@ -145,7 +145,6 @@ void cl_set_clcb_msg(clcb_msg callback)
     strncpy(buff, x, len);                                \
     va_start(args, str);                                  \
     vsnprintf(buff + len, sizeof(buff) - len, str, args); \
-    buff[sizeof(buff) - 1] = '\0';                        \
     va_end(args)
 
 void cli_warnmsg(const char *str, ...)
@@ -191,15 +190,15 @@ void cli_dbgmsg_no_inline(const char *str, ...)
 
 size_t cli_eprintf(const char *str, ...)
 {
+    size_t bytes_written = 0;
     va_list args;
     char buff[MSGBUFSIZ];
     va_start(args, str);
-    vsnprintf(buff, sizeof(buff), str, args);
-    buff[sizeof(buff) - 1] = '\0';
+    bytes_written = vsnprintf(buff, sizeof(buff), str, args);
     va_end(args);
     clrs_eprint(buff);
 
-    return strlen(buff);
+    return bytes_written;
 }
 
 int cli_matchregex(const char *str, const char *regex)

--- a/libclamav/others_common.c
+++ b/libclamav/others_common.c
@@ -185,8 +185,21 @@ void cli_dbgmsg_no_inline(const char *str, ...)
 {
     if (UNLIKELY(cli_get_debug_flag())) {
         MSGCODE(buff, len, "LibClamAV debug: ");
-        fputs(buff, stderr);
+        clrs_eprint(buff);
     }
+}
+
+size_t cli_eprintf(const char *str, ...)
+{
+    va_list args;
+    char buff[MSGBUFSIZ];
+    va_start(args, str);
+    vsnprintf(buff, sizeof(buff), str, args);
+    buff[sizeof(buff) - 1] = '\0';
+    va_end(args);
+    clrs_eprint(buff);
+
+    return strlen(buff);
 }
 
 int cli_matchregex(const char *str, const char *regex)

--- a/libclamav/special.c
+++ b/libclamav/special.c
@@ -324,11 +324,11 @@ int cli_detect_swizz(struct swizz_stats *stats)
             uint32_t v = gn[i];
             gn[i]      = (v << 15) / all;
             if (cli_debug_flag)
-                fprintf(stderr, "%lu, ", (unsigned long)gn[i]);
+                cli_eprintf("%lu, ", (unsigned long)gn[i]);
         }
         global_swizz = swizz_j48_global(gn) ? CL_VIRUS : CL_CLEAN;
         if (cli_debug_flag) {
-            fprintf(stderr, "\n");
+            cli_eprintf("\n");
             cli_dbgmsg("cli_detect_swizz: global: %s\n", global_swizz ? "suspicious" : "clean");
         }
     }

--- a/libclamav_rust/cbindgen.toml
+++ b/libclamav_rust/cbindgen.toml
@@ -27,6 +27,7 @@ include = [
   "frs_error::FFIError",
   "frs_error::ffierror_fmt",
   "frs_error::ffierror_free",
+  "logging::clrs_eprint",
 ]
 
 # prefix = "CAPI_"

--- a/libclamav_rust/src/logging.rs
+++ b/libclamav_rust/src/logging.rs
@@ -20,7 +20,10 @@
  *  MA 02110-1301, USA.
  */
 
-use std::ffi::CString;
+use std::{
+    ffi::{CStr, CString},
+    os::raw::c_char,
+};
 
 use log::{set_max_level, Level, LevelFilter, Metadata, Record};
 
@@ -80,4 +83,10 @@ mod tests {
         warn!("my old");
         error!("friend.");
     }
+}
+
+#[no_mangle]
+pub extern "C" fn clrs_eprint(c_buf: *const c_char) -> () {
+    let msg = unsafe { CStr::from_ptr(c_buf) }.to_string_lossy();
+    eprint!("{}", msg);
 }

--- a/libclamav_rust/src/logging.rs
+++ b/libclamav_rust/src/logging.rs
@@ -85,8 +85,15 @@ mod tests {
     }
 }
 
+/// API exported for C code to log to standard error using Rust.
+/// This would be be an alternative to fputs, and reliably prints
+/// non-ASCII UTF8 characters on Windows, where fputs does not.
 #[no_mangle]
 pub extern "C" fn clrs_eprint(c_buf: *const c_char) -> () {
+    if c_buf.is_null() {
+        return;
+    }
+
     let msg = unsafe { CStr::from_ptr(c_buf) }.to_string_lossy();
     eprint!("{}", msg);
 }


### PR DESCRIPTION
- Win32: Fix utf8 filename support issue

The function used to verify the real path for the file being
scanned fails on some utf8 filenames, like:
    file_with_ümlaut.eicar.com

The scan continues despite the failure, but the error reported from
clamd and warnings from clamscan are confusing because it looks like
the scan failed even if a verdict shows up later.

The fix here is to convert the path from utf8 to utf16 and then use
the CreateFileW() API to grab the file handle for the real path check.

Resolves: https://github.com/Cisco-Talos/clamav/issues/418

- libclamav: fix utf8 logging issues on Windows

Print to the log using rust eprint() instead of fputs()

Rust's eprint() function supports full utf8, while fputs() gets
confused and prints stuff like:
    file_with_├╝mlaut.eicar.com
instead of:
    file_with_ümlaut.eicar.com
