### PR TITLE
330 - clamd becomes zombie process after some time

### DIFF
--- a/dockerfiles/docker-entrypoint.sh
+++ b/dockerfiles/docker-entrypoint.sh
@@ -41,6 +41,19 @@ else
 		freshclam --foreground --stdout
 	fi
 
+	if [ "${CLAMAV_NO_FRESHCLAMD:-false}" != "true" ]; then
+		echo "Starting Freshclamd"
+		freshclam \
+		          --checks="${FRESHCLAM_CHECKS:-1}" \
+		          --daemon \
+		          --foreground \
+		          --stdout \
+		          --user="clamav" \
+			  &
+	fi
+
+	sleep "${CLAMD_STARTUP_DELAY:-60}"
+
 	if [ "${CLAMAV_NO_CLAMD:-false}" != "true" ]; then
 		echo "Starting ClamAV"
 		if [ -S "/run/clamav/clamd.sock" ]; then
@@ -58,17 +71,6 @@ else
 			_timeout="$((_timeout + 1))"
 		done
 		echo "socket found, clamd started."
-	fi
-
-	if [ "${CLAMAV_NO_FRESHCLAMD:-false}" != "true" ]; then
-		echo "Starting Freshclamd"
-		freshclam \
-		          --checks="${FRESHCLAM_CHECKS:-1}" \
-		          --daemon \
-		          --foreground \
-		          --stdout \
-		          --user="clamav" \
-			  &
 	fi
 
 	if [ "${CLAMAV_NO_MILTERD:-true}" != "true" ]; then

--- a/dockerfiles/docker-entrypoint.sh
+++ b/dockerfiles/docker-entrypoint.sh
@@ -50,9 +50,9 @@ else
 		          --stdout \
 		          --user="clamav" \
 			  &
+		sleep "${CLAMD_STARTUP_DELAY:-60}"
 	fi
 
-	sleep "${CLAMD_STARTUP_DELAY:-60}"
 
 	if [ "${CLAMAV_NO_CLAMD:-false}" != "true" ]; then
 		echo "Starting ClamAV"


### PR DESCRIPTION
Issue happens when new container starts and databases are out of date.
The most likely reason is changes in database during clamd first initialization. 

This change would allow freshclam to finish updating the database, by moving its startup before clamd and introducing a delay after.

Defaulted to 60 seconds, controlled via CLAMD_STARTUP_DELAY variable.