### PR TITLE
Changed freshclam warning threshold

### DIFF
--- a/libfreshclam/libfreshclam.c
+++ b/libfreshclam/libfreshclam.c
@@ -513,8 +513,8 @@ fc_error_t fc_dns_query_update_info(
     reply_token = NULL;
 
     time(&currentTime);
-    if ((int)currentTime - recordTime > 10800) {
-        logg(LOGG_WARNING, "DNS record is older than 3 hours.\n");
+    if ((int)currentTime - recordTime > DNS_WARNING_THRESHOLD_SECONDS) {
+        logg(LOGG_WARNING, "DNS record is older than %d hours.\n", DNS_WARNING_THRESHOLD_HOURS);
         goto done;
     }
 

--- a/libfreshclam/libfreshclam_internal.c
+++ b/libfreshclam/libfreshclam_internal.c
@@ -1958,8 +1958,8 @@ static fc_error_t query_remote_database_version(
                     recordTime = atoi(recordTimeStr);
                     free(recordTimeStr);
                     time(&currentTime);
-                    if ((int)currentTime - recordTime > 10800) {
-                        logg(LOGG_WARNING, "DNS record is older than 3 hours.\n");
+                    if ((int)currentTime - recordTime > DNS_WARNING_THRESHOLD_SECONDS) {
+                        logg(LOGG_WARNING, "DNS record is older than %d hours.\n", DNS_WARNING_THRESHOLD_HOURS);
                     } else if (NULL != (verStrDnsExtra = cli_strtok(extradnsreply, 0, ":"))) {
                         if (!cli_isnumber(verStrDnsExtra)) {
                             logg(LOGG_WARNING, "Broken database version in TXT record for %s\n", cvdfile);

--- a/libfreshclam/libfreshclam_internal.h
+++ b/libfreshclam/libfreshclam_internal.h
@@ -89,4 +89,8 @@ fc_error_t updatecustomdb(
     char **dbFilename,
     int *bUpdated);
 
+
+#define DNS_WARNING_THRESHOLD_HOURS 12
+#define DNS_WARNING_THRESHOLD_SECONDS (DNS_WARNING_THRESHOLD_HOURS * 60 * 60)
+
 #endif // __LIBFRESHCLAM_INTERNAL_H


### PR DESCRIPTION
Changed freshclam warning threshold from 3 hours to 12 hours before
warning that the DNS entry is too old.