### PR TITLE
Clam 1643 cli_ac_addsig 2 byte over-read

### DIFF
--- a/libclamav/matcher-ac.c
+++ b/libclamav/matcher-ac.c
@@ -769,6 +769,7 @@ int cli_ac_chklsig(const char *expr, const char *end, uint32_t *lsigcnt, unsigne
                     return -1;
                 }
                 pth--;
+                /* fall-through */
 
             case '>':
             case '<':
@@ -1102,9 +1103,9 @@ inline static int ac_findmatch_special(const unsigned char *buffer, uint32_t off
                     break;
                 subbp = bp;
             } else {
-                if (bp < (special->len[0] - 1))
+                if (bp < (uint32_t)(special->len[0] - 1))
                     break;
-                subbp = bp - (special->len[0] - 1);
+                subbp = bp - (uint32_t)(special->len[0] - 1);
             }
 
             match *= special->len[0];
@@ -1128,11 +1129,11 @@ inline static int ac_findmatch_special(const unsigned char *buffer, uint32_t off
                     }
                     subbp = bp;
                 } else {
-                    if (bp < (alt->len - 1)) {
+                    if (bp < (uint32_t)(alt->len - 1)) {
                         alt = alt->next;
                         continue;
                     }
-                    subbp = bp - (alt->len - 1);
+                    subbp = bp - (uint32_t)(alt->len - 1);
                 }
 
                 /* note that generic alternates CANNOT be negated */
@@ -1894,7 +1895,7 @@ cl_error_t cli_ac_scanbuff(
                                 continue;
                             }
 
-                            if (pt->partno + 1 > mdata->min_partno)
+                            if ((uint32_t)(pt->partno + 1) > mdata->min_partno)
                                 mdata->min_partno = pt->partno + 1;
 
                             /* sparsely populated matrix, so allocate and initialize if NULL */
@@ -2872,6 +2873,17 @@ cl_error_t cli_ac_addsig(struct cli_matcher *root, const char *virname, const ch
     }
 
     new->length[0] = (uint16_t)strlen(hex ? hex : hexsig) / 2;
+    if (new->length[0] < root->ac_mindepth) {
+        cli_errmsg("cli_ac_addsig: Subpattern in signature is shorter than the minimum depth of the AC trie. (%u < %u)\n", new->length[0], root->ac_mindepth);
+        if (new->special)
+            mpool_ac_free_special(root->mempool, new);
+
+        MPOOL_FREE(root->mempool, new->pattern);
+        MPOOL_FREE(root->mempool, new);
+        free(hex);
+        return CL_EMALFDB;
+    }
+
     for (i = 0, j = 0; i < new->length[0]; i++) {
         if ((new->pattern[i] & CLI_MATCH_METADATA) == CLI_MATCH_SPECIAL) {
             new->length[1] += new->special_table[j]->len[0];
@@ -2914,8 +2926,9 @@ cl_error_t cli_ac_addsig(struct cli_matcher *root, const char *virname, const ch
             break;
         }
 
-        if (zprefix && new->pattern[i])
+        if (zprefix && 0 != new->pattern[i]) {
             zprefix = 0;
+        }
     }
 
     if (wprefix || zprefix) {
@@ -2924,28 +2937,36 @@ cl_error_t cli_ac_addsig(struct cli_matcher *root, const char *virname, const ch
             for (j = i; j < i + root->ac_maxdepth && j < new->length[0]; j++) {
                 if (new->pattern[j] & CLI_MATCH_WILDCARD) {
                     break;
-                } else {
-                    if (j - i + 1 >= plen) {
-                        plen = j - i + 1;
-                        ppos = i;
-                    }
                 }
 
-                if (new->pattern[ppos] || new->pattern[ppos + 1]) {
+                if (j - i + 1 >= plen) {
+                    plen = j - i + 1;
+                    ppos = i;
+                }
+
+                if ((0 != new->pattern[ppos]) ||
+                    ((new->length[0] > ppos + 1) && (0 != new->pattern[ppos + 1]))) {
+
                     if (plen >= root->ac_maxdepth) {
                         break;
-                    } else if (plen >= root->ac_mindepth && plen > nzplen) {
+                    }
+
+                    if (plen >= root->ac_mindepth && plen > nzplen) {
                         nzplen = plen;
                         nzpos  = ppos;
                     }
                 }
             }
 
-            if (plen >= root->ac_maxdepth && (new->pattern[ppos] || new->pattern[ppos + 1]))
+            if (plen >= root->ac_maxdepth && (0 != new->pattern[ppos] || 0 != new->pattern[ppos + 1])) {
                 break;
+            }
         }
 
-        if (!new->pattern[ppos] && !new->pattern[ppos + 1] && nzplen) {
+        if ((0 != nzplen) &&
+            (new->length[0] > ppos + 1) &&
+            (0 == new->pattern[ppos]) &&
+            (0 == new->pattern[ppos + 1])) {
             plen = nzplen;
             ppos = nzpos;
         }
@@ -2980,8 +3001,9 @@ cl_error_t cli_ac_addsig(struct cli_matcher *root, const char *virname, const ch
         new->length[2] -= new->prefix_length[2];
     }
 
-    if (new->length[2] + new->prefix_length[2] > root->maxpatlen)
+    if (new->length[2] + new->prefix_length[2] > root->maxpatlen) {
         root->maxpatlen = new->length[2] + new->prefix_length[2];
+    }
 
     if (0 == new->lsigid[0]) {
         /* For logical signatures, we already recorded the virname in the lsig table entry.


### PR DESCRIPTION
- Fix possible 2-byte overread when adding sig pattern

  It is possible to create a signature pattern that tries to add a
  zero-byte matching pattern to the A-C trie. A missing check at this
  stage can end up with a 2-byte overread when indexing the (empty)
  pattern to make sure the bytes added to the A-C trie are static and
  not both zero.

  This over read issue is not a vulnerability.

  This commit fixes the issue by adding a check for the pattern length.

  Resolves: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=43832

  Also added:
  - type casts and a "fall-through" comment to silence compile warnings.
  - a few additional length checks to protect against an additional 1-byte
  over read.

- Add code comments to explain AC pattern prefix process

  When adding a pattern to the AC trie, checks are done to make sure the
  bytes that go in the AC trie don't have any `?` wildcards and
  additionally that the first two bytes are not "\x00\x00".
  If they are, the position of the pattern that goes in the AC trie can be
  shifted right until a static pattern is identified that can go in the
  AC trie. Any bytes to the left of the new start of the pattern become a
  "prefix".

  During matching, once the AC trie match occurs and the bytes to the
  right of that pattern are matched, then the bytes from the prefix are
  matched.

  The reason that we don't want the bytes that go in the AC trie to start
  with "\x00\x00" is that it is such a common pattern in files that it
  would match constantly, and the scan process would spend a lot of time
  just checking through the list of patterns associated with a "\x00\x00"
  AC match, and that'd be crazy slow.
  But it is important to note that when shifting right, if there aren't
  enough nonzero, non-wildcard bytes to form a good prefix for the AC
  trie, that it is tolerable to bend the rule and let some patterns start
  with "\x00\x00". In that way, a small pattern like "0000ab" is still
  valid, and can be matched.