### PR TITLE
Fix BytecodeTimeout value in conf.sample

### DIFF
--- a/etc/clamd.conf.sample
+++ b/etc/clamd.conf.sample
@@ -797,5 +797,5 @@ Example
 
 # Set bytecode timeout in milliseconds.
 #
-# Default: 5000
+# Default: 10000
 # BytecodeTimeout 1000

--- a/win32/conf_examples/clamd.conf.sample
+++ b/win32/conf_examples/clamd.conf.sample
@@ -662,5 +662,5 @@ TCPAddr localhost
 
 # Set bytecode timeout in milliseconds.
 #
-# Default: 5000
+# Default: 10000
 # BytecodeTimeout 1000


### PR DESCRIPTION
Match code: https://github.com/Cisco-Talos/clamav/blob/cdbb4b8a4853e7431f527a613a79b04ac00acf01/common/optparser.c#L358-L359