### PR TITLE
Fix scan error when image fuzzy hash fails (0.105.1)

### DIFF
--- a/libclamav/matcher.c
+++ b/libclamav/matcher.c
@@ -200,7 +200,8 @@ static inline cl_error_t matcher_run(const struct cli_matcher *root,
         case CL_TYPE_JPEG:
         case CL_TYPE_PNG:
         case CL_TYPE_GRAPHICS: {
-            if (!fuzzy_hash_check(root->fuzzy_hashmap, mdata, ctx->recursion_stack[ctx->recursion_level].image_fuzzy_hash)) {
+            if (ctx->recursion_stack[ctx->recursion_level].calculated_image_fuzzy_hash &&
+                !fuzzy_hash_check(root->fuzzy_hashmap, mdata, ctx->recursion_stack[ctx->recursion_level].image_fuzzy_hash)) {
                 cli_errmsg("Unexpected error when checking for fuzzy hash matches.\n");
                 return CL_ERROR;
             }

--- a/libclamav/others.h
+++ b/libclamav/others.h
@@ -187,6 +187,7 @@ typedef struct recursion_level_tag {
     uint32_t recursion_level_buffer_fmap; /* Which fmap layer in this buffer. */
     bool is_normalized_layer;             /* Indicates that the layer should be skipped when checking container and intermediate types. */
     image_fuzzy_hash_t image_fuzzy_hash;  /* Used for image/graphics files to store a fuzzy hash. */
+    bool calculated_image_fuzzy_hash;     /* Used for image/graphics files to store a fuzzy hash. */
 } recursion_level_t;
 
 /* internal clamav context */


### PR DESCRIPTION
This is a backport of https://github.com/Cisco-Talos/clamav/pull/618

---

Scanning a file containing an image where it fails to calculate the
image fuzzy hash may cause the entire scan to end with an error.

This commit fixes that by ignoring any image fuzzy hash failure.
If calculating the hash fails, the hash is left uninitialized (all
zeroes). To prevent doing image fuzzy hash lookups when it failed,
I added a boolean that is set to true only after creating the hash.

Fixes: https://github.com/Cisco-Talos/clamav/issues/600
Fixes: https://github.com/Cisco-Talos/clamav/issues/593