### PR TITLE
Silence error message when logical sig max flevel is low (0.105.1)

### DIFF
--- a/libclamav/readdb.c
+++ b/libclamav/readdb.c
@@ -2110,7 +2110,11 @@ static cl_error_t load_oneldb(char *buffer, int chkpua, struct cl_engine *engine
     /* Initialize Target Description Block (TDB) */
     memset(&tdb, 0, sizeof(tdb));
     if (CL_SUCCESS != (ret = init_tdb(&tdb, engine, tokens[1], virname))) {
-        cli_errmsg("cli_loadldb: Failed to initialize target description block\n");
+        if (CL_BREAK == ret) {
+            status = CL_SUCCESS;
+        } else {
+            cli_errmsg("cli_loadldb: Failed to initialize target description block\n");
+        }
         status = ret;
         goto done;
     }


### PR DESCRIPTION
backported copy of https://github.com/Cisco-Talos/clamav/pull/619

---

libclamav will print this error message if you load a logical sig where
the max FLEVEL is less than the current flevel:

    LibClamAV Error: cli_loadldb: Failed to initialize target description block

This bug was introduced with this change:
https://github.com/Cisco-Talos/clamav/commit/fd587c741c0ca88d2a6493e9e85a2bf2453687ee#diff-1b118ae1a67627d562f94eacd4a44abe3a013db75e98405463ada73f65e65e41R2012-R2016