### PR TITLE
Clam 2014 fix intermediates 0.103.7

### DIFF
--- a/libclamav/matcher.c
+++ b/libclamav/matcher.c
@@ -791,7 +791,9 @@ done:
 static int intermediates_eval(cli_ctx *ctx, struct cli_ac_lsig *ac_lsig)
 {
     uint32_t i, icnt = ac_lsig->tdb.intermediates[0];
-    int32_t j = -1;
+
+    // -1 is the deepest layer (the current layer), so we start at -2, which is the first ancestor
+    int32_t j = -2;
 
     if (ctx->recursion_level < icnt)
         return 0;


### PR DESCRIPTION
backport of https://github.com/Cisco-Talos/clamav/pull/628

---

The file type check for the logical signature Intermediates feature is
off-by-one and so the first layer checked is supposed to be the first
parent of the current layer, but is in fact the current layer.

This commit fixes the issue by correctly checking starting at -2 instead
of -1. (-1 is the current layer, 0 is the outermost layer).