### PR TITLE
Clam 2001 regex slash colon

### DIFF
--- a/libclamav/str.c
+++ b/libclamav/str.c
@@ -858,19 +858,19 @@ size_t cli_ldbtokenize(char *buffer, const char delim, const size_t token_count,
                        const char **tokens, size_t token_skip)
 {
     size_t tokens_found, i;
-    int within_pcre = 0;
-    char *start     = buffer;
+    char *start = buffer;
 
     for (tokens_found = 0; tokens_found < token_count;) {
         tokens[tokens_found++] = buffer;
 
         while (*buffer != '\0') {
-            if (!within_pcre && (*buffer == delim))
+            if (*buffer == delim) {
                 break;
-            else if ((tokens_found > token_skip) &&
-                     ((buffer > start) && (*(buffer - 1) != '\\')) &&
-                     (*buffer == '/'))
-                within_pcre = !within_pcre;
+            } else if ((tokens_found > token_skip) &&
+                       ((buffer > start) && (*(buffer - 1) != '\\')) &&
+                       (*buffer == '/')) {
+                return tokens_found;
+            }
             buffer++;
         }
 
@@ -878,8 +878,9 @@ size_t cli_ldbtokenize(char *buffer, const char delim, const size_t token_count,
             *buffer++ = '\0';
         } else {
             i = tokens_found;
-            while (i < token_count)
+            while (i < token_count) {
                 tokens[i++] = NULL;
+            }
             return tokens_found;
         }
     }

--- a/libclamav_rust/src/sys.rs
+++ b/libclamav_rust/src/sys.rs
@@ -743,6 +743,7 @@ pub struct recursion_level_tag {
     pub recursion_level_buffer_fmap: u32,
     pub is_normalized_layer: bool,
     pub image_fuzzy_hash: image_fuzzy_hash_t,
+    pub calculated_image_fuzzy_hash: bool,
 }
 pub type recursion_level_t = recursion_level_tag;
 #[repr(C)]


### PR DESCRIPTION
- Fix issue loading regex sigs containing '/' and ':'

  There is an issue parsing PCRE patterns if the pattern contains a '/' in
  the middle, followed by a ':'.  When splitting the subsignature (or yara
  regex string) by ':' delimiters to identify the offset, it will
  inadvertently think that the '/' in the middle of the sig is the end of
  the PCRE string and will therefore consider the ':' in the string as
  valid delimiter instead of ignoring it for being inside of the regex
  string.
  
  The solution I came up with is to ignore all content after a '/' when
  tokenizing rather than ignoring content between a matching pair of /'s.
  This works for LDB signatures because PCRE subsignatures are always
  the last subsignature and because a ':' never comes *after* the PCRE
  string.
  It works for YARA rules because the `cli_tokenize()` function is only
  ever used on the regex strings, never on the whole rule.

  Fixes: https://github.com/Cisco-Talos/clamav/issues/594

- Test: Add test for LDB & Yara regex rules with : + /

- Also update generated sys.rs file (unrelated, just neglected in previous change)
