### PR TITLE
fix: Update bytecode timeout value in man pages

### DIFF
--- a/docs/man/clamd.conf.5.in
+++ b/docs/man/clamd.conf.5.in
@@ -312,7 +312,7 @@ Default: TrustSigned
 \fBBytecodeTimeout NUMBER\fR
 Set bytecode timeout in milliseconds.
 .br
-Default: 5000
+Default: 10000
 .TP
 \fBBytecodeUnsigned BOOL\fR
 Allow loading bytecode from outside digitally signed .c[lv]d files.

--- a/docs/man/clamscan.1.in
+++ b/docs/man/clamscan.1.in
@@ -103,7 +103,7 @@ With this option enabled ClamAV will load bytecode from the database. It is high
 Allow loading bytecode from outside digitally signed .c[lv]d files. **Caution**: You should NEVER run bytecode signatures from untrusted sources. Doing so may result in arbitrary code execution.
 .TP
 \fB\-\-bytecode\-timeout=N\fR
-Set bytecode timeout in milliseconds (default: 5000 = 5s)
+Set bytecode timeout in milliseconds (default: 10000 = 10s)
 .TP
 \fB\-\-statistics[=none(*)/bytecode/pcre]\fR
 Collect and print execution statistics.


### PR DESCRIPTION
Noticed that the man pages haven't been updated to include the new default bytecode timeout value 👍 .

- Update bytecode timeout values in the man pages

Signed-off-by: Liam Jarvis <jarviliam@gmail.com>