### PR TITLE
ClamAV Docker Container running as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -117,4 +117,4 @@ HEALTHCHECK --start-period=6m CMD "clamdcheck.sh"
 
 ENTRYPOINT [ "/init" ]
 
-USER clamav
+USER 100


### PR DESCRIPTION
#478 

Moved the PID and socket file location to /tmp so the container can run as clamav user instead of root.

Updated docker-entrypoint.sh script to look for the PID files in /tmp.