### PR TITLE
CMake Windows: Install debug symbol files for debug builds

### DIFF
--- a/clambc/CMakeLists.txt
+++ b/clambc/CMakeLists.txt
@@ -36,6 +36,7 @@ target_link_libraries( clambc
         ClamAV::common )
 if(WIN32)
     install(TARGETS clambc DESTINATION . COMPONENT programs)
+    install(FILES $<TARGET_PDB_FILE:clambc> DESTINATION . OPTIONAL COMPONENT programs)
 else()
     install(TARGETS clambc DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT programs)
 endif()

--- a/clamconf/CMakeLists.txt
+++ b/clamconf/CMakeLists.txt
@@ -36,6 +36,7 @@ target_link_libraries( clamconf
         ClamAV::common )
 if(WIN32)
     install(TARGETS clamconf DESTINATION . COMPONENT programs)
+    install(FILES $<TARGET_PDB_FILE:clamconf> DESTINATION . OPTIONAL COMPONENT programs)
 else()
     install(TARGETS clamconf DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT programs)
 endif()

--- a/clamd/CMakeLists.txt
+++ b/clamd/CMakeLists.txt
@@ -54,6 +54,7 @@ target_link_libraries( clamd
         ClamAV::common )
 if(WIN32)
     install(TARGETS clamd DESTINATION . COMPONENT programs)
+    install(FILES $<TARGET_PDB_FILE:clamd> DESTINATION . OPTIONAL COMPONENT programs)
 else()
     install(TARGETS clamd DESTINATION ${CMAKE_INSTALL_SBINDIR} COMPONENT programs)
 endif()

--- a/clamdscan/CMakeLists.txt
+++ b/clamdscan/CMakeLists.txt
@@ -43,6 +43,7 @@ target_link_libraries( clamdscan
         ClamAV::common )
 if(WIN32)
     install(TARGETS clamdscan DESTINATION . COMPONENT programs)
+    install(FILES $<TARGET_PDB_FILE:clamdscan> DESTINATION . OPTIONAL COMPONENT programs)
 else()
     install(TARGETS clamdscan DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT programs)
 endif()

--- a/clamdtop/CMakeLists.txt
+++ b/clamdtop/CMakeLists.txt
@@ -37,6 +37,7 @@ target_link_libraries( clamdtop
         Curses::curses )
 if(WIN32)
     install(TARGETS clamdtop DESTINATION . COMPONENT programs)
+    install(FILES $<TARGET_PDB_FILE:clamdtop> DESTINATION . OPTIONAL COMPONENT programs)
     # Also install shared library (DLL) dependencies
     install(CODE [[
         file(GET_RUNTIME_DEPENDENCIES

--- a/clamscan/CMakeLists.txt
+++ b/clamscan/CMakeLists.txt
@@ -42,6 +42,7 @@ target_link_libraries( clamscan
         ClamAV::common )
 if(WIN32)
     install(TARGETS clamscan DESTINATION . COMPONENT programs)
+    install(FILES $<TARGET_PDB_FILE:clamscan> DESTINATION . OPTIONAL COMPONENT programs)
 else()
     install(TARGETS clamscan DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT programs)
 endif()

--- a/clamsubmit/CMakeLists.txt
+++ b/clamsubmit/CMakeLists.txt
@@ -44,6 +44,7 @@ if(APPLE)
 endif()
 if(WIN32)
     install(TARGETS clamsubmit DESTINATION . COMPONENT programs)
+    install(FILES $<TARGET_PDB_FILE:clamsubmit> DESTINATION . OPTIONAL COMPONENT programs)
     # Also install shared library (DLL) dependencies
     install(CODE [[
         file(GET_RUNTIME_DEPENDENCIES

--- a/freshclam/CMakeLists.txt
+++ b/freshclam/CMakeLists.txt
@@ -41,6 +41,7 @@ target_link_libraries(freshclam-bin
         ClamAV::common )
 if(WIN32)
     install(TARGETS freshclam-bin DESTINATION . COMPONENT programs)
+    install(FILES $<TARGET_PDB_FILE:freshclam-bin> DESTINATION . OPTIONAL COMPONENT programs)
 else()
     install(TARGETS freshclam-bin DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT programs)
 endif()

--- a/libclamav/CMakeLists.txt
+++ b/libclamav/CMakeLists.txt
@@ -572,7 +572,7 @@ if(ENABLE_SHARED_LIB)
     endif()
     if(WIN32)
         install( TARGETS clamav DESTINATION . COMPONENT libraries )
-
+        install( FILES $<TARGET_PDB_FILE:clamav> DESTINATION . OPTIONAL COMPONENT libraries )
         # Also install shared library (DLL) dependencies
         install( CODE [[
             file(GET_RUNTIME_DEPENDENCIES

--- a/libclammspack/CMakeLists.txt
+++ b/libclammspack/CMakeLists.txt
@@ -81,6 +81,7 @@ if(ENABLE_SHARED_LIB)
 
     if(WIN32)
         install(TARGETS clammspack DESTINATION . COMPONENT libraries)
+        install(FILES $<TARGET_PDB_FILE:clammspack> DESTINATION . OPTIONAL COMPONENT libraries)
     else()
         install(TARGETS clammspack DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT libraries)
     endif()

--- a/libclamunrar/CMakeLists.txt
+++ b/libclamunrar/CMakeLists.txt
@@ -99,6 +99,7 @@ if(ENABLE_SHARED_LIB)
 
     if(WIN32)
         install(TARGETS clamunrar DESTINATION . COMPONENT libraries)
+        install(FILES $<TARGET_PDB_FILE:clamunrar> DESTINATION . OPTIONAL COMPONENT libraries)
     else()
         install(TARGETS clamunrar DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT libraries)
     endif()

--- a/libclamunrar_iface/CMakeLists.txt
+++ b/libclamunrar_iface/CMakeLists.txt
@@ -73,6 +73,7 @@ if(ENABLE_UNRAR)
 
         if(WIN32)
             install(TARGETS clamunrar_iface DESTINATION . COMPONENT libraries)
+            install( FILES $<TARGET_PDB_FILE:clamunrar_iface> DESTINATION . OPTIONAL COMPONENT libraries )
         else()
             install(TARGETS clamunrar_iface DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT libraries)
         endif()

--- a/libfreshclam/CMakeLists.txt
+++ b/libfreshclam/CMakeLists.txt
@@ -64,6 +64,7 @@ if(ENABLE_SHARED_LIB)
         VERSION ${LIBFRESHCLAM_VERSION} SOVERSION ${LIBFRESHCLAM_SOVERSION})
     if(WIN32)
         install(TARGETS freshclam DESTINATION . COMPONENT libraries)
+        install(FILES $<TARGET_PDB_FILE:freshclam> DESTINATION . OPTIONAL COMPONENT libraries)
         # Also install shared library (DLL) dependencies
         install(CODE [[
             file(GET_RUNTIME_DEPENDENCIES

--- a/sigtool/CMakeLists.txt
+++ b/sigtool/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries( sigtool
         ClamAV::common )
 if(WIN32)
     install(TARGETS sigtool DESTINATION . COMPONENT programs)
+    install(FILES $<TARGET_PDB_FILE:sigtool> DESTINATION . OPTIONAL COMPONENT programs)
 else()
     install(TARGETS sigtool DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT programs)
 endif()


### PR DESCRIPTION
CMake does not install the PDB debugging symbol files automatically.
These are useful for testing programs built using libclamav.dll.