### PR TITLE
Remove Docker registry URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # Copyright (C) 2021-2022 Cisco Systems, Inc. and/or its affiliates. All rights reserved.
 
 # hadolint ignore=DL3007  latest is the latest stable for alpine
-FROM index.docker.io/library/alpine:latest AS builder
+FROM alpine:latest AS builder
 
 WORKDIR /src
 
@@ -80,7 +80,7 @@ RUN apk add --no-cache \
     exit 1 && \
     ctest -V
 
-FROM index.docker.io/library/alpine:latest
+FROM alpine:latest
 
 LABEL maintainer="ClamAV bugs <clamav-bugs@external.cisco.com>"
 


### PR DESCRIPTION
The index.docker.io/library/ URL is not needed anymore. Now we can use the FROM alpine:latest and the result will be something like below:
```
latest: Pulling from library/alpine
Digest: sha256:bc41182d7ef5ffc53a40b044e725193bc10142a1243f395ee852a8d9730fc2ad
Status: Image is up to date for alpine:latest
docker.io/library/alpine:latest
```