### PR TITLE
ccmake: make the values of BYTECODE_RUNTIME enumeratable by ENTER

### DIFF
--- a/CMakeOptions.cmake
+++ b/CMakeOptions.cmake
@@ -29,6 +29,7 @@ set(DISABLE_MPOOL
 set(BYTECODE_RUNTIME
     "interpreter" CACHE STRING
     "Bytecode Runtime, may be: 'llvm', 'interpreter', 'none'.")
+set_property(CACHE BYTECODE_RUNTIME PROPERTY STRINGS llvm interpreter none)
 
 option(OPTIMIZE
     "Allow compiler optimizations.  Set to OFF to disable (i.e. to set -O0)."


### PR DESCRIPTION
When clamav is configured with `ccmake`, after this change at the line with BYTECODE_RUNTIME the user can just press the ENTER key to toggle the available values.