### PR TITLE
CLAM-1775: increase max allocation size

### DIFF
--- a/libclamav/bytecode_api.c
+++ b/libclamav/bytecode_api.c
@@ -99,7 +99,7 @@ int32_t cli_bcapi_read(struct cli_bc_ctx *ctx, uint8_t *data, int32_t size)
         API_MISUSE();
         return -1;
     }
-    if (size < 0 || size > CLI_MAX_ALLOCATION) {
+    if (size < 0) {
         cli_warnmsg("bytecode: negative read size: %d\n", size);
         API_MISUSE();
         return -1;

--- a/libclamav/others.h
+++ b/libclamav/others.h
@@ -146,7 +146,7 @@ extern uint8_t cli_always_gen_section_hash;
      (size_t)(sb) + (size_t)(sb_size) <= (size_t)(bb_size) && \
      (size_t)(sb) <= (size_t)(bb_size))
 
-#define CLI_MAX_ALLOCATION (182 * 1024 * 1024)
+#define CLI_MAX_ALLOCATION (1024 * 1024 * 1024 * 3)
 
 #ifdef HAVE_SYS_PARAM_H
 #include <sys/param.h> /* for NAME_MAX */

--- a/libclamav/others_common.c
+++ b/libclamav/others_common.c
@@ -221,7 +221,9 @@ void *cli_malloc(size_t size)
     void *alloc;
 
     if (!size || size > CLI_MAX_ALLOCATION) {
-        cli_errmsg("cli_malloc(): Attempt to allocate %lu bytes. Please report to https://github.com/Cisco-Talos/clamav/issues\n", (unsigned long int)size);
+        cli_warnmsg("cli_malloc(): File or section is too large to scan (%zu bytes). \
+                     For your safety, ClamAV limits how much memory an operation can allocate to %zu bytes\n",
+                     size, CLI_MAX_ALLOCATION);
         return NULL;
     }
 
@@ -229,7 +231,7 @@ void *cli_malloc(size_t size)
 
     if (!alloc) {
         perror("malloc_problem");
-        cli_errmsg("cli_malloc(): Can't allocate memory (%lu bytes).\n", (unsigned long int)size);
+        cli_errmsg("cli_malloc(): Can't allocate memory (%zu bytes).\n", size);
         return NULL;
     } else
         return alloc;
@@ -240,7 +242,9 @@ void *cli_calloc(size_t nmemb, size_t size)
     void *alloc;
 
     if (!nmemb || !size || size > CLI_MAX_ALLOCATION || nmemb > CLI_MAX_ALLOCATION || (nmemb * size > CLI_MAX_ALLOCATION)) {
-        cli_errmsg("cli_calloc(): Attempt to allocate %lu bytes. Please report to https://github.com/Cisco-Talos/clamav/issues\n", (unsigned long int)nmemb * size);
+        cli_warnmsg("cli_calloc2(): File or section is too large to scan (%zu bytes). \
+                     For your safety, ClamAV limits how much memory an operation can allocate to %zu bytes\n",
+                     size, CLI_MAX_ALLOCATION);
         return NULL;
     }
 
@@ -248,7 +252,7 @@ void *cli_calloc(size_t nmemb, size_t size)
 
     if (!alloc) {
         perror("calloc_problem");
-        cli_errmsg("cli_calloc(): Can't allocate memory (%lu bytes).\n", (unsigned long int)(nmemb * size));
+        cli_errmsg("cli_calloc(): Can't allocate memory (%zu bytes).\n", (nmemb * size));
         return NULL;
     } else
         return alloc;
@@ -259,7 +263,9 @@ void *cli_realloc(void *ptr, size_t size)
     void *alloc;
 
     if (!size || size > CLI_MAX_ALLOCATION) {
-        cli_errmsg("cli_realloc(): Attempt to allocate %lu bytes. Please report to https://github.com/Cisco-Talos/clamav/issues\n", (unsigned long int)size);
+        cli_warnmsg("cli_realloc(): File or section is too large to scan (%zu bytes). \
+                     For your safety, ClamAV limits how much memory an operation can allocate to %zu bytes\n",
+                     size, CLI_MAX_ALLOCATION);
         return NULL;
     }
 
@@ -267,7 +273,7 @@ void *cli_realloc(void *ptr, size_t size)
 
     if (!alloc) {
         perror("realloc_problem");
-        cli_errmsg("cli_realloc(): Can't re-allocate memory to %lu bytes.\n", (unsigned long int)size);
+        cli_errmsg("cli_realloc(): Can't re-allocate memory to %zu bytes.\n", size);
         return NULL;
     } else
         return alloc;
@@ -278,7 +284,9 @@ void *cli_realloc2(void *ptr, size_t size)
     void *alloc;
 
     if (!size || size > CLI_MAX_ALLOCATION) {
-        cli_errmsg("cli_realloc2(): Attempt to allocate %lu bytes. Please report to https://github.com/Cisco-Talos/clamav/issues\n", (unsigned long int)size);
+        cli_warnmsg("cli_realloc2(): File or section is too large to scan (%zu bytes). \
+                     For your safety, ClamAV limits how much memory an operation can allocate to %zu bytes\n",
+                     size, CLI_MAX_ALLOCATION);
         return NULL;
     }
 
@@ -286,7 +294,7 @@ void *cli_realloc2(void *ptr, size_t size)
 
     if (!alloc) {
         perror("realloc_problem");
-        cli_errmsg("cli_realloc2(): Can't re-allocate memory to %lu bytes.\n", (unsigned long int)size);
+        cli_errmsg("cli_realloc2(): Can't re-allocate memory to %zu bytes.\n", size);
         if (ptr)
             free(ptr);
         return NULL;
@@ -299,7 +307,7 @@ char *cli_strdup(const char *s)
     char *alloc;
 
     if (s == NULL) {
-        cli_errmsg("cli_strdup(): s == NULL. Please report to https://github.com/Cisco-Talos/clamav/issues\n");
+        cli_errmsg("cli_strdup(): passed reference is NULL, nothing to duplicate\n");
         return NULL;
     }
 


### PR DESCRIPTION
Increases internal max allocation size to allow support for
files up to 3GB.

Provides a more helpful, less dramatic warning message if this
limit is exceeded.