### PR TITLE
Add missing MaxScanTime heuristic alert, when enabled

### DIFF
--- a/libclamav/others.c
+++ b/libclamav/others.c
@@ -1124,6 +1124,8 @@ cl_error_t cli_checklimits(const char *who, cli_ctx *ctx, unsigned long need1, u
     if (CL_ETIMEOUT == (ret = cli_checktimelimit(ctx))) {
         /* Abort the scan ... */
         ret = CL_ETIMEOUT;
+        cli_append_virus_if_heur_exceedsmax(ctx, "Heuristics.Limits.Exceeded.MaxScanTime");
+        ctx->abort_scan = true;
     }
 
     /* Enforce global scan-size limit */


### PR DESCRIPTION
It appears that exceeding the max scan time may not trigger an
heuristic allert when AlertExceedsMax is enabled. This Adds that, and
sets the flag that should ensure we fully abort the scan, like we
have with MaxScanFiles.