### PR TITLE
Clam 2102 cl cvd unpack

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -28,3 +28,29 @@ if(ENABLE_STATIC_LIB)
         target_link_libraries( ex1_static PUBLIC ${LLVM_LIBRARIES} )
     endif()
 endif()
+
+add_executable(ex_cl_cvdunpack)
+target_sources(ex_cl_cvdunpack
+    PRIVATE   ex_cl_cvdunpack.c)
+set_target_properties( ex_cl_cvdunpack PROPERTIES COMPILE_FLAGS "${WARNCFLAGS}" )
+target_link_libraries(ex_cl_cvdunpack
+    PRIVATE
+        ClamAV::libclamav)
+if(LLVM_FOUND)
+    target_link_directories( ex_cl_cvdunpack PUBLIC ${LLVM_LIBRARY_DIRS} )
+    target_link_libraries( ex_cl_cvdunpack PUBLIC ${LLVM_LIBRARIES} )
+endif()
+
+if(ENABLE_STATIC_LIB)
+    add_executable(ex_cl_cvdunpack_static)
+    set_target_properties( ex_cl_cvdunpack_static PROPERTIES COMPILE_FLAGS "${WARNCFLAGS}" )
+    target_sources(ex_cl_cvdunpack_static
+        PRIVATE   ex_cl_cvdunpack.c)
+    target_link_libraries(ex_cl_cvdunpack_static
+        PRIVATE
+            ClamAV::libclamav_static)
+    if(LLVM_FOUND)
+        target_link_directories( ex_cl_cvdunpack_static PUBLIC ${LLVM_LIBRARY_DIRS} )
+        target_link_libraries( ex_cl_cvdunpack_static PUBLIC ${LLVM_LIBRARIES} )
+    endif()
+endif()

--- a/examples/ex_cl_cvdunpack.c
+++ b/examples/ex_cl_cvdunpack.c
@@ -1,0 +1,90 @@
+/*
+ *  Compilation: gcc -Wall ex1.c -o ex1 -lclamav
+ *
+ *  Copyright (C) 2013-2022 Cisco Systems, Inc. and/or its affiliates. All rights reserved.
+ *  Copyright (C) 2007-2013 Sourcefire, Inc.
+ *  Author: Tomasz Kojm <tkojm@clamav.net>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ *  MA 02110-1301, USA.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#ifndef _WIN32
+#include <unistd.h>
+#endif
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <clamav.h>
+
+#ifndef O_BINARY
+#define O_BINARY 0
+#endif
+
+/*
+ * Exit codes: 0 is success. See `cl_error_t` enum from clamav.h.
+ */
+int main(int argc, char **argv)
+{
+    int fd;
+    cl_error_t ret;
+
+    const char *filename;
+    const char *destination_directory;
+    bool dont_verify = false;
+
+    char dest_buff[1024];
+
+    unsigned long int size = 0;
+    unsigned int sigs      = 0;
+    long double mb;
+    const char *virname;
+    struct cl_engine *engine;
+    struct cl_scan_options options;
+
+    switch (argc) {
+        case 2:
+            filename              = argv[1];
+            destination_directory = ".";
+            break;
+        case 3:
+            filename              = argv[1];
+            destination_directory = argv[2];
+            break;
+        case 4:
+            if (strcmp(argv[1], "--no-verify") == 0) {
+                filename              = argv[2];
+                destination_directory = argv[3];
+                dont_verify           = true;
+            } else {
+                printf("Usage: %s [--no-verify] file [destination_directory]\n", argv[0]);
+                return CL_EARG;
+            }
+            break;
+        default:
+            printf("Usage: %s [--no-verify] file [destination_directory]\n", argv[0]);
+            return CL_EARG;
+    }
+
+    ret = cl_cvdunpack(filename, destination_directory, dont_verify);
+    if (ret != CL_SUCCESS) {
+        printf("ERROR: %s\n", cl_strerror(ret));
+    }
+
+    return (int)ret;
+}

--- a/libclamav/clamav.h
+++ b/libclamav/clamav.h
@@ -65,6 +65,7 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <stdbool.h>
 
 #include "clamav-types.h"
 #include "clamav-version.h"
@@ -1072,6 +1073,18 @@ extern cl_error_t cl_cvdverify(const char *file);
  * @param cvd   Pointer to a CVD header struct.
  */
 extern void cl_cvdfree(struct cl_cvd *cvd);
+
+/**
+ * @brief Unpack a CVD file.
+ *
+ * Will verify the CVD is correctly signed unless the `dont_verify` parameter is true.
+ *
+ * @param file          Filepath of CVD file.
+ * @param dir           Destination directory.
+ * @param dont_verify   If true, don't verify the CVD.
+ * @return cl_error_t   CL_SUCCESS if success, else a CL_E* error code.
+ */
+extern cl_error_t cl_cvdunpack(const char *file, const char *dir, bool dont_verify);
 
 /* ----------------------------------------------------------------------------
  * DB directory stat functions.

--- a/libclamav/cvd.c
+++ b/libclamav/cvd.c
@@ -723,7 +723,7 @@ int cli_cvdload(FILE *fs, struct cl_engine *engine, unsigned int *signo, unsigne
     return ret;
 }
 
-int cli_cvdunpack(const char *file, const char *dir)
+static cl_error_t cli_cvdunpack(const char *file, const char *dir)
 {
     int fd, ret;
 

--- a/libclamav/cvd.c
+++ b/libclamav/cvd.c
@@ -611,11 +611,11 @@ cl_error_t cl_cvdverify(const char *file)
     return ret;
 }
 
-int cli_cvdload(FILE *fs, struct cl_engine *engine, unsigned int *signo, unsigned int options, unsigned int dbtype, const char *filename, unsigned int chkonly)
+cl_error_t cli_cvdload(FILE *fs, struct cl_engine *engine, unsigned int *signo, unsigned int options, unsigned int dbtype, const char *filename, unsigned int chkonly)
 {
     struct cl_cvd cvd, dupcvd;
     FILE *dupfs;
-    int ret;
+    cl_error_t ret;
     time_t s_time;
     int cfd;
     struct cli_dbio dbio;

--- a/libclamav/cvd.h
+++ b/libclamav/cvd.h
@@ -41,6 +41,6 @@ struct cli_dbio {
     void *hashctx;
 };
 
-int cli_cvdload(FILE *fs, struct cl_engine *engine, unsigned int *signo, unsigned int options, unsigned int dbtype, const char *filename, unsigned int chkonly);
+cl_error_t cli_cvdload(FILE *fs, struct cl_engine *engine, unsigned int *signo, unsigned int options, unsigned int dbtype, const char *filename, unsigned int chkonly);
 
 #endif

--- a/libclamav/cvd.h
+++ b/libclamav/cvd.h
@@ -42,6 +42,5 @@ struct cli_dbio {
 };
 
 int cli_cvdload(FILE *fs, struct cl_engine *engine, unsigned int *signo, unsigned int options, unsigned int dbtype, const char *filename, unsigned int chkonly);
-int cli_cvdunpack(const char *file, const char *dir);
 
 #endif

--- a/libfreshclam/libfreshclam_internal.c
+++ b/libfreshclam/libfreshclam_internal.c
@@ -1498,9 +1498,12 @@ done:
 }
 
 /**
- * @brief Change to the temp dir for storing CDIFFs for incremental database update.
+ * @brief Create a temp dir for storing CDIFFs for incremental database update.
  *
- * Will create the temp dir if it does not already exist.
+ * Will create the temp dir if it does not already exist and populate it with the
+ * unpacked CVD. Then it will chdir to that directory.
+ *
+ * But if that directory already exists, it will simply chdir to it.
  *
  * @param database      The database we're updating.
  * @param[out] tmpdir   The name of the temp dir to use.
@@ -1555,7 +1558,10 @@ static fc_error_t mkdir_and_chdir_for_cdiff_tmp(const char *database, const char
             goto done;
         }
 
-        if (-1 == cli_cvdunpack(cvdfile, tmpdir)) {
+        /*
+         * 3) Unpack the existing CVD/CLD database to this directory.
+         */
+        if (CL_SUCCESS != cl_cvdunpack(cvdfile, tmpdir, false)) {
             logg(LOGG_ERROR, "mkdir_and_chdir_for_cdiff_tmp: Can't unpack %s into %s\n", cvdfile, tmpdir);
             cli_rmdirs(tmpdir);
             goto done;

--- a/sigtool/sigtool.c
+++ b/sigtool/sigtool.c
@@ -1094,7 +1094,7 @@ static int build(const struct optstruct *opts)
         return -1;
     }
 
-    if (cli_cvdunpack(olddb, pt) == -1) {
+    if (CL_SUCCESS != cl_cvdunpack(olddb, pt, false)) {
         mprintf(LOGG_ERROR, "build: Can't unpack CVD file %s\n", olddb);
         cli_rmdirs(pt);
         free(pt);
@@ -1120,7 +1120,7 @@ static int build(const struct optstruct *opts)
         return -1;
     }
 
-    if (cli_cvdunpack(newcvd, pt) == -1) {
+    if (CL_SUCCESS != cl_cvdunpack(newcvd, pt, false)) {
         mprintf(LOGG_ERROR, "build: Can't unpack CVD file %s\n", newcvd);
         cli_rmdirs(pt);
         free(pt);
@@ -1194,7 +1194,7 @@ static int unpack(const struct optstruct *opts)
         return -1;
     }
 
-    if (cli_cvdunpack(name, ".") == -1) {
+    if (CL_SUCCESS != cl_cvdunpack(name, ".", false)) {
         mprintf(LOGG_ERROR, "unpack: Can't unpack file %s\n", name);
         return -1;
     }
@@ -1348,7 +1348,7 @@ static int listdb(const char *filename, const regex_t *regex)
             return -1;
         }
 
-        if (cli_cvdunpack(filename, dir) == -1) {
+        if (CL_SUCCESS != cl_cvdunpack(filename, dir, false)) {
             mprintf(LOGG_ERROR, "listdb: Can't unpack CVD file %s\n", filename);
             cli_rmdirs(dir);
             free(dir);
@@ -1981,7 +1981,7 @@ static int verifydiff(const char *diff, const char *cvd, const char *incdir)
     }
 
     if (cvd) {
-        if (cli_cvdunpack(cvd, tempdir) == -1) {
+        if (CL_SUCCESS != cl_cvdunpack(cvd, tempdir, false)) {
             mprintf(LOGG_ERROR, "verifydiff: Can't unpack CVD file %s\n", cvd);
             cli_rmdirs(tempdir);
             free(tempdir);
@@ -3196,7 +3196,7 @@ static int makediff(const struct optstruct *opts)
         return -1;
     }
 
-    if (cli_cvdunpack(optget(opts, "diff")->strarg, odir) == -1) {
+    if (CL_SUCCESS != cl_cvdunpack(optget(opts, "diff")->strarg, odir, false)) {
         mprintf(LOGG_ERROR, "makediff: Can't unpack CVD file %s\n", optget(opts, "diff")->strarg);
         cli_rmdirs(odir);
         free(odir);
@@ -3219,7 +3219,7 @@ static int makediff(const struct optstruct *opts)
         return -1;
     }
 
-    if (cli_cvdunpack(opts->filename[0], ndir) == -1) {
+    if (CL_SUCCESS != cl_cvdunpack(opts->filename[0], ndir, false)) {
         mprintf(LOGG_ERROR, "makediff: Can't unpack CVD file %s\n", opts->filename[0]);
         cli_rmdirs(odir);
         cli_rmdirs(ndir);

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -391,6 +391,17 @@ if(ENABLE_APP)
     endif()
 endif()
 
+if(ENABLE_EXAMPLES)
+    add_test(NAME examples COMMAND ${PythonTest_COMMAND};examples
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+    set_property(TEST examples PROPERTY ENVIRONMENT ${ENVIRONMENT})
+    if(Valgrind_FOUND)
+        add_test(NAME examples_valgrind COMMAND ${PythonTest_COMMAND};examples
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+        set_property(TEST examples_valgrind PROPERTY ENVIRONMENT ${ENVIRONMENT} VALGRIND=${Valgrind_EXECUTABLE})
+    endif()
+endif()
+
 if(WIN32)
     #
     # Prepare a test install, with all our DLL dependencies co-located with our EXEs and DLLs

--- a/unit_tests/examples/ex_cl_cvdunpack_test.py
+++ b/unit_tests/examples/ex_cl_cvdunpack_test.py
@@ -1,0 +1,139 @@
+# Copyright (C) 2020-2022 Cisco Systems, Inc. and/or its affiliates. All rights reserved.
+
+"""
+Run sigtool tests.
+"""
+
+import os
+import platform
+import shutil
+import sys
+
+sys.path.append('../unit_tests')
+import testcase
+
+
+os_platform = platform.platform()
+operating_system = os_platform.split('-')[0].lower()
+
+program_name = 'ex_cl_cvdunpack'
+
+class TC(testcase.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super(TC, cls).setUpClass()
+
+        # Find the example program
+        if operating_system == 'windows':
+            # Windows needs the example program to be in the same directory as libclamav and the rest.
+            shutil.copy(
+                str(TC.path_build / 'examples' / program_name + '.exe'),
+                str(TC.path_build / 'unit_tests' / program_name + '.exe'),
+            )
+
+            TC.example_program = TC.path_build / 'unit_tests' / program_name + '.exe'
+            if not TC.example_program.exists():
+                # Try the static version.
+                TC.example_program = TC.path_build / 'unit_tests' / program_name + '_static.exe'
+                if not TC.example_program.exists():
+                    raise Exception('Could not find the example program.')
+        else:
+            # Linux and macOS can use the LD_LIBRARY_PATH environment variable to find libclamav
+            TC.example_program = TC.path_build / 'examples' / program_name
+            if not TC.example_program.exists():
+                # Try the static version.
+                TC.example_program = TC.path_build / 'examples' / program_name + '_static'
+                if not TC.example_program.exists():
+                    raise Exception('Could not find the example program.')
+
+        # Copy the test cvd to the temp directory
+        shutil.copyfile(
+            str(TC.path_source / 'unit_tests' / 'input' / 'freshclam_testfiles' / 'test-2.cvd'),
+            str(TC.path_tmp / 'verify_good.cvd')
+        )
+
+        # Also get a corrupted version of the cvd
+        shutil.copyfile(
+            str(TC.path_source / 'unit_tests' / 'input' / 'freshclam_testfiles' / 'test-2.cvd'),
+            str(TC.path_tmp / 'verify_bad.cvd')
+        )
+        with open(str(TC.path_tmp / 'verify_bad.cvd'), 'r+b') as f:
+            f.seek(0, os.SEEK_END)
+            f.write(b'egad bad cvd')
+
+    @classmethod
+    def tearDownClass(cls):
+        super(TC, cls).tearDownClass()
+
+    def setUp(self):
+        super(TC, self).setUp()
+
+    def tearDown(self):
+        super(TC, self).tearDown()
+        self.verify_valgrind_log()
+
+    def test_cl_cvdunpack_verify_success(self):
+        self.step_name('test with good cvd, verify extraction')
+
+        # Make temp directory to store extracted stuffs
+        (TC.path_tmp / 'verify_good').mkdir(parents=True)
+
+        command = '{valgrind} {valgrind_args} {example} {database} {tmp}'.format(
+            valgrind=TC.valgrind, valgrind_args=TC.valgrind_args, example=TC.example_program,
+            database=TC.path_tmp / 'verify_good.cvd',
+            tmp=TC.path_tmp / 'verify_good'
+        )
+        output = self.execute_command(command)
+
+        assert output.ec == 0  # success
+        for each in (TC.path_tmp / 'verify_good').iterdir():
+            if each.name == 'test.info':
+                return
+        # could not find test.info
+        assert False
+
+    def test_cl_cvdunpack_verify_failure(self):
+        self.step_name('test with bad cvd, verify failure')
+
+        # Make temp directory to store extracted stuffs
+        (TC.path_tmp / 'verify_bad').mkdir(parents=True)
+
+        command = '{valgrind} {valgrind_args} {example} {database} {tmp}'.format(
+            valgrind=TC.valgrind, valgrind_args=TC.valgrind_args, example=TC.example_program,
+            database=TC.path_tmp / 'verify_bad.cvd',
+            tmp=TC.path_tmp / 'verify_bad'
+        )
+        output = self.execute_command(command)
+
+        assert output.ec != 0  # success
+        for each in (TC.path_tmp / 'verify_bad').iterdir():
+            if each.name == 'test.info':
+                # found test.info
+                assert False
+
+        expected_results = [
+            'ERROR: Can\'t verify database integrity',
+        ]
+        self.verify_output(output.out, expected=expected_results)
+
+    def test_cl_cvdunpack_noverify(self):
+        self.step_name('test with bad cvd, use --no-verify')
+
+        # Make temp directory to store extracted stuffs
+        (TC.path_tmp / 'no_verify_bad').mkdir(parents=True)
+
+        command = '{valgrind} {valgrind_args} {example} --no-verify {database} {tmp}'.format(
+            valgrind=TC.valgrind, valgrind_args=TC.valgrind_args, example=TC.example_program,
+            database=TC.path_tmp / 'verify_bad.cvd',
+            tmp=TC.path_tmp / 'no_verify_bad'
+        )
+        output = self.execute_command(command)
+
+        # In this case, because we just tacked on bytes at the end, it will
+        # probably still extract at least some stuff.
+        assert output.ec == 0  # success
+        for each in (TC.path_tmp / 'no_verify_bad').iterdir():
+            if each.name == 'test.info':
+                return
+        # could not find test.info
+        assert False


### PR DESCRIPTION
- libclamav API: Add cl_cvdunpack() function

  Add `cl_cvdunpack()` function to the public API.
  
  This new API has an option to disable verification, but otherwise it
  will attempt to verify that the CVD is correctly signed.

- Freshclam, Sigtool: use public CVD unpack API

  In the interest of using the public API's as much as possible for our
  own applications (dog-fooding the API), this commit swaps sigtool and
  freshclam `cli_cvdunpack()` calls to `cl_cvdunpack()`.

- Tests: unit tests for cl_load(), cl_cvdverify(), cl_cvdunpack()

  Some basic testing is needed for the new cl_cvdunpack() API, so this
  commit adds basic unit tests for that.
  
  For reasons unknown, a number of cl_* API's have stubs for unit tests
  that weren't filled out.  The CVD load/verify ones in particular
  required access to a signed CVD.  We actually ship a very basic signed
  CVD with the databases now, so I added tests for those while I was at it.