### PR TITLE
Persist ClamAV Headers - Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,6 @@ RUN apk add --no-cache \
           -DENABLE_STATIC_LIB=OFF && \
     make DESTDIR="/clamav" -j$(($(nproc) - 1)) install && \
     rm -r \
-       "/clamav/usr/include" \
        "/clamav/usr/lib/pkgconfig/" \
     && \
     sed -e "s|^\(Example\)|\# \1|" \


### PR DESCRIPTION
Persist the ClamAV header files for more complex integrations / use cases