### PR TITLE
Clam 1619 cmake rust improvements

### DIFF
--- a/cmake/FindRust.cmake
+++ b/cmake/FindRust.cmake
@@ -7,68 +7,68 @@
 # To see this in a sample project, visit: https://github.com/micahsnyder/cmake-rust-demo
 #
 # Code to set the Cargo arguments was lifted from:
-#   https://github.com/Devolutions/CMakeRust
+# https://github.com/Devolutions/CMakeRust
 #
 # This Module defines the following variables:
-#  - <program>_FOUND      - True if the program was found
-#  - <program>_EXECUTABLE - path of the program
-#  - <program>_VERSION    - version number of the program
+# - <program>_FOUND      - True if the program was found
+# - <program>_EXECUTABLE - path of the program
+# - <program>_VERSION    - version number of the program
 #
 # ... for the following Rust toolchain programs:
-#  - cargo
-#  - rustc
-#  - rustup
-#  - rust-gdb
-#  - rust-lldb
-#  - rustdoc
-#  - rustfmt
-#  - bindgen
+# - cargo
+# - rustc
+# - rustup
+# - rust-gdb
+# - rust-lldb
+# - rustdoc
+# - rustfmt
+# - bindgen
 #
 # Callers can make any program mandatory by setting `<program>_REQUIRED` before
 # the call to `find_package(Rust)`
 #
 # Eg:
-#    find_package(Rust REQUIRED)
+# find_package(Rust REQUIRED)
 #
 # This module also provides:
 #
-#  - `add_rust_library()` - This allows a caller to create a Rust static library
-#   target which you can link to with `target_link_libraries()`.
+# - `add_rust_library()` - This allows a caller to create a Rust static library
+# target which you can link to with `target_link_libraries()`.
 #
-#   Your Rust static library target will itself depend on the native static libs
-#   you get from `rustc --crate-type staticlib --print=native-static-libs /dev/null`
+# Your Rust static library target will itself depend on the native static libs
+# you get from `rustc --crate-type staticlib --print=native-static-libs /dev/null`
 #
-#   The CARGO_CMD environment variable will be set to "BUILD" so you can tell
-#   it's not building the unit tests inside your (optional) `build.rs` file.
+# The CARGO_CMD environment variable will be set to "BUILD" so you can tell
+# it's not building the unit tests inside your (optional) `build.rs` file.
 #
-#   Example `add_rust_library()` usage:
+# Example `add_rust_library()` usage:
 #
-#       add_rust_library(TARGET yourlib WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
-#       add_library(YourProject::yourlib ALIAS yourlib)
+# add_rust_library(TARGET yourlib WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
+# add_library(YourProject::yourlib ALIAS yourlib)
 #
-#       add_executable(yourexe)
-#       target_link_libraries(yourexe YourProject::yourlib)
+# add_executable(yourexe)
+# target_link_libraries(yourexe YourProject::yourlib)
 #
-#  - `add_rust_test()` - This allows a caller to run `cargo test` for a specific
-#    Rust target as a CTest test.
+# - `add_rust_test()` - This allows a caller to run `cargo test` for a specific
+# Rust target as a CTest test.
 #
-#   The CARGO_CMD environment variable will be set to "TEST" so you can tell
-#   it's not building the unit tests inside your (optional) `build.rs` file.
+# The CARGO_CMD environment variable will be set to "TEST" so you can tell
+# it's not building the unit tests inside your (optional) `build.rs` file.
 #
-#   Example `add_rust_test()` usage:
+# Example `add_rust_test()` usage:
 #
-#       add_rust_test(NAME yourlib WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/yourlib")
-#       set_property(TEST yourlib PROPERTY ENVIRONMENT ${ENVIRONMENT})
+# add_rust_test(NAME yourlib WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/yourlib")
+# set_property(TEST yourlib PROPERTY ENVIRONMENT ${ENVIRONMENT})
 #
-#  - `add_rust_executable()` - This allows a caller to create a Rust executable target.
+# - `add_rust_executable()` - This allows a caller to create a Rust executable target.
 #
-#   Example `add_rust_executable()` usage:
+# Example `add_rust_executable()` usage:
 #
-#       add_rust_executable(TARGET yourapp WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
-#       add_executable(YourProject::yourapp ALIAS yourapp)
+# add_rust_executable(TARGET yourapp WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
+# add_executable(YourProject::yourapp ALIAS yourapp)
 #
-#       add_executable(yourexe)
-#       target_link_libraries(yourexe YourProject::yourlib)
+# add_executable(yourexe)
+# target_link_libraries(yourexe YourProject::yourlib)
 #
 
 if(NOT DEFINED CARGO_HOME)
@@ -90,9 +90,10 @@ function(find_rust_program RUST_PROGRAM)
     if(${RUST_PROGRAM}_EXECUTABLE)
         execute_process(COMMAND "${${RUST_PROGRAM}_EXECUTABLE}" --version
             OUTPUT_VARIABLE ${RUST_PROGRAM}_VERSION_OUTPUT
-            ERROR_VARIABLE  ${RUST_PROGRAM}_VERSION_ERROR
+            ERROR_VARIABLE ${RUST_PROGRAM}_VERSION_ERROR
             RESULT_VARIABLE ${RUST_PROGRAM}_VERSION_RESULT
         )
+
         if(NOT ${${RUST_PROGRAM}_VERSION_RESULT} EQUAL 0)
             message(STATUS "Rust tool `${RUST_PROGRAM}` not found: Failed to determine version.")
             unset(${RUST_PROGRAM}_EXECUTABLE)
@@ -131,14 +132,16 @@ function(cargo_vendor)
             COMMAND ${CMAKE_COMMAND} -E env "CARGO_TARGET_DIR=${CMAKE_CURRENT_BINARY_DIR}" ${cargo_EXECUTABLE} vendor ".cargo/vendor"
             WORKING_DIRECTORY "${ARGS_WORKING_DIRECTORY}"
             OUTPUT_VARIABLE CARGO_VENDOR_OUTPUT
-            ERROR_VARIABLE  CARGO_VENDOR_ERROR
+            ERROR_VARIABLE CARGO_VENDOR_ERROR
             RESULT_VARIABLE CARGO_VENDOR_RESULT
         )
+
         if(NOT ${CARGO_VENDOR_RESULT} EQUAL 0)
             message(FATAL_ERROR "Failed!\n${CARGO_VENDOR_ERROR}")
         else()
             message("Success!")
         endif()
+
         write_file(${ARGS_WORKING_DIRECTORY}/.cargo/config.toml "
 [source.crates-io]
 replace-with = \"vendored-sources\"
@@ -185,7 +188,7 @@ function(add_rust_executable)
     # Specify where the executable is
     set_target_properties(${ARGS_TARGET}
         PROPERTIES
-            IMPORTED_LOCATION "${OUTPUT}"
+        IMPORTED_LOCATION "${OUTPUT}"
     )
 
     # Vendor the dependencies, if desired
@@ -243,8 +246,8 @@ function(add_rust_library)
     # Specify where the library is and where to find the headers
     set_target_properties(${ARGS_TARGET}
         PROPERTIES
-            IMPORTED_LOCATION "${OUTPUT}"
-            INTERFACE_INCLUDE_DIRECTORIES "${ARGS_WORKING_DIRECTORY};${CMAKE_CURRENT_BINARY_DIR}"
+        IMPORTED_LOCATION "${OUTPUT}"
+        INTERFACE_INCLUDE_DIRECTORIES "${ARGS_WORKING_DIRECTORY};${CMAKE_CURRENT_BINARY_DIR}"
     )
 
     # Vendor the dependencies, if desired
@@ -259,7 +262,8 @@ function(add_rust_test)
     cmake_parse_arguments(ARGS "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
     set(MY_CARGO_ARGS "test")
-    if(NOT "${CMAKE_OSX_ARCHITECTURES}" MATCHES "^(arm64;x86_64|x86_64;arm64)$") #  Don't specify the target for universal, we'll do that manually for each build.
+
+    if(NOT "${CMAKE_OSX_ARCHITECTURES}" MATCHES "^(arm64;x86_64|x86_64;arm64)$") # Don't specify the target for universal, we'll do that manually for each build.
         list(APPEND MY_CARGO_ARGS "--target" ${RUST_COMPILER_TARGET})
     endif()
 
@@ -302,19 +306,23 @@ endif()
 execute_process(
     COMMAND ${CMAKE_COMMAND} -E env "CARGO_TARGET_DIR=${CMAKE_CURRENT_BINARY_DIR}" ${rustc_EXECUTABLE} --crate-type staticlib --print=native-static-libs /dev/null
     OUTPUT_VARIABLE RUST_NATIVE_STATIC_LIBS_OUTPUT
-    ERROR_VARIABLE  RUST_NATIVE_STATIC_LIBS_ERROR
+    ERROR_VARIABLE RUST_NATIVE_STATIC_LIBS_ERROR
     RESULT_VARIABLE RUST_NATIVE_STATIC_LIBS_RESULT
 )
 string(REGEX REPLACE "\r?\n" ";" LINE_LIST "${RUST_NATIVE_STATIC_LIBS_ERROR}")
+
 foreach(LINE ${LINE_LIST})
     # do the match on each line
     string(REGEX MATCH "native-static-libs: .*" LINE "${LINE}")
+
     if(NOT LINE)
         continue()
     endif()
+
     string(REPLACE "native-static-libs: " "" LINE "${LINE}")
     string(REGEX REPLACE "  " "" LINE "${LINE}")
     string(REGEX REPLACE " " ";" LINE "${LINE}")
+
     if(LINE)
         message(STATUS "Rust's native static libs: ${LINE}")
         set(RUST_NATIVE_STATIC_LIBS "${LINE}")
@@ -325,7 +333,7 @@ endforeach()
 if(NOT RUST_COMPILER_TARGET)
     # Automatically determine the Rust Target Triple.
     # Note: Users may override automatic target detection by specifying their own. Most likely needed for cross-compiling.
-    #       For reference determining target platform: https://doc.rust-lang.org/nightly/rustc/platform-support.html
+    # For reference determining target platform: https://doc.rust-lang.org/nightly/rustc/platform-support.html
     if(WIN32)
         # For windows x86/x64, it's easy enough to guess the target.
         if(CMAKE_SIZEOF_VOID_P EQUAL 8)
@@ -348,12 +356,14 @@ if(NOT RUST_COMPILER_TARGET)
 endif()
 
 set(CARGO_ARGS "build")
+
 if(NOT "${RUST_COMPILER_TARGET}" MATCHES "^universal-apple-darwin$")
     # Don't specify the target for macOS universal builds, we'll do that manually for each build.
     list(APPEND CARGO_ARGS "--target" ${RUST_COMPILER_TARGET})
 endif()
 
 set(RUSTFLAGS "")
+
 if(NOT CMAKE_BUILD_TYPE)
     set(CARGO_BUILD_TYPE "debug")
 elseif(${CMAKE_BUILD_TYPE} STREQUAL "Release" OR ${CMAKE_BUILD_TYPE} STREQUAL "MinSizeRel")

--- a/cmake/FindRust.cmake
+++ b/cmake/FindRust.cmake
@@ -28,10 +28,6 @@
 # the call to `find_package(Rust)`
 #
 # Eg:
-#
-#    if(MAINTAINER_MODE)
-#        set(bindgen_REQUIRED 1)
-#    endif()
 #    find_package(Rust REQUIRED)
 #
 # This module also provides:
@@ -59,10 +55,20 @@
 #   The CARGO_CMD environment variable will be set to "TEST" so you can tell
 #   it's not building the unit tests inside your (optional) `build.rs` file.
 #
-#   Example `add_rust_library()` usage:
+#   Example `add_rust_test()` usage:
 #
 #       add_rust_test(NAME yourlib WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/yourlib")
 #       set_property(TEST yourlib PROPERTY ENVIRONMENT ${ENVIRONMENT})
+#
+#  - `add_rust_executable()` - This allows a caller to create a Rust executable target.
+#
+#   Example `add_rust_executable()` usage:
+#
+#       add_rust_executable(TARGET yourapp WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
+#       add_executable(YourProject::yourapp ALIAS yourapp)
+#
+#       add_executable(yourexe)
+#       target_link_libraries(yourexe YourProject::yourlib)
 #
 
 if(NOT DEFINED CARGO_HOME)
@@ -144,15 +150,59 @@ directory = \".cargo/vendor\"
     endif()
 endfunction()
 
+function(add_rust_executable)
+    set(options)
+    set(oneValueArgs TARGET WORKING_DIRECTORY)
+    cmake_parse_arguments(ARGS "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    if(WIN32)
+        set(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${RUST_COMPILER_TARGET}/${CARGO_BUILD_TYPE}/${ARGS_TARGET}.exe")
+    else()
+        set(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${RUST_COMPILER_TARGET}/${CARGO_BUILD_TYPE}/${ARGS_TARGET}")
+    endif()
+
+    file(GLOB_RECURSE EXE_SOURCES "${ARGS_WORKING_DIRECTORY}/*.rs")
+
+    set(MY_CARGO_ARGS ${CARGO_ARGS})
+    list(APPEND MY_CARGO_ARGS "--target-dir" ${CMAKE_CURRENT_BINARY_DIR})
+    list(JOIN MY_CARGO_ARGS " " MY_CARGO_ARGS_STRING)
+
+    # Build the executable.
+    add_custom_command(
+        OUTPUT "${OUTPUT}"
+        COMMAND ${CMAKE_COMMAND} -E env "CARGO_TARGET_DIR=${CMAKE_CURRENT_BINARY_DIR}" ${cargo_EXECUTABLE} ARGS ${MY_CARGO_ARGS}
+        WORKING_DIRECTORY "${ARGS_WORKING_DIRECTORY}"
+        DEPENDS ${EXE_SOURCES}
+        COMMENT "Building ${ARGS_TARGET} in ${ARGS_WORKING_DIRECTORY} with:\n\t ${cargo_EXECUTABLE} ${MY_CARGO_ARGS_STRING}")
+
+    # Create a target from the build output
+    add_custom_target(${ARGS_TARGET}_target
+        DEPENDS ${OUTPUT})
+
+    # Create an executable target from custom target
+    add_custom_target(${ARGS_TARGET} ALL DEPENDS ${ARGS_TARGET}_target)
+
+    # Specify where the executable is
+    set_target_properties(${ARGS_TARGET}
+        PROPERTIES
+            IMPORTED_LOCATION "${OUTPUT}"
+    )
+
+    # Vendor the dependencies, if desired
+    if(VENDOR_DEPENDENCIES)
+        cargo_vendor(TARGET "${ARGS_TARGET}" WORKING_DIRECTORY "${ARGS_WORKING_DIRECTORY}")
+    endif()
+endfunction()
+
 function(add_rust_library)
     set(options)
     set(oneValueArgs TARGET WORKING_DIRECTORY)
     cmake_parse_arguments(ARGS "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
     if(WIN32)
-        set(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${RUST_COMPILER_TARGET}/${LIB_BUILD_TYPE}/${ARGS_TARGET}.lib")
+        set(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${RUST_COMPILER_TARGET}/${CARGO_BUILD_TYPE}/${ARGS_TARGET}.lib")
     else()
-        set(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${RUST_COMPILER_TARGET}/${LIB_BUILD_TYPE}/lib${ARGS_TARGET}.a")
+        set(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${RUST_COMPILER_TARGET}/${CARGO_BUILD_TYPE}/lib${ARGS_TARGET}.a")
     endif()
 
     file(GLOB_RECURSE LIB_SOURCES "${ARGS_WORKING_DIRECTORY}/*.rs")
@@ -162,13 +212,13 @@ function(add_rust_library)
     list(JOIN MY_CARGO_ARGS " " MY_CARGO_ARGS_STRING)
 
     # Build the library and generate the c-binding
-    if ("${CMAKE_OSX_ARCHITECTURES}" MATCHES "^(arm64;x86_64|x86_64;arm64)$")
+    if("${CMAKE_OSX_ARCHITECTURES}" MATCHES "^(arm64;x86_64|x86_64;arm64)$")
         add_custom_command(
             OUTPUT "${OUTPUT}"
             COMMAND ${CMAKE_COMMAND} -E env "CARGO_CMD=build" "CARGO_TARGET_DIR=${CMAKE_CURRENT_BINARY_DIR}" "MAINTAINER_MODE=${MAINTAINER_MODE}" "RUSTFLAGS=\"${RUSTFLAGS}\"" ${cargo_EXECUTABLE} ARGS ${MY_CARGO_ARGS} --target=x86_64-apple-darwin
             COMMAND ${CMAKE_COMMAND} -E env "CARGO_CMD=build" "CARGO_TARGET_DIR=${CMAKE_CURRENT_BINARY_DIR}" "MAINTAINER_MODE=${MAINTAINER_MODE}" "RUSTFLAGS=\"${RUSTFLAGS}\"" ${cargo_EXECUTABLE} ARGS ${MY_CARGO_ARGS} --target=aarch64-apple-darwin
-            COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_CURRENT_BINARY_DIR}/${RUST_COMPILER_TARGET}/${LIB_BUILD_TYPE}"
-            COMMAND lipo ARGS -create ${CMAKE_CURRENT_BINARY_DIR}/x86_64-apple-darwin/${LIB_BUILD_TYPE}/lib${ARGS_TARGET}.a ${CMAKE_CURRENT_BINARY_DIR}/aarch64-apple-darwin/${LIB_BUILD_TYPE}/lib${ARGS_TARGET}.a -output "${OUTPUT}"
+            COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_CURRENT_BINARY_DIR}/${RUST_COMPILER_TARGET}/${CARGO_BUILD_TYPE}"
+            COMMAND lipo ARGS -create ${CMAKE_CURRENT_BINARY_DIR}/x86_64-apple-darwin/${CARGO_BUILD_TYPE}/lib${ARGS_TARGET}.a ${CMAKE_CURRENT_BINARY_DIR}/aarch64-apple-darwin/${CARGO_BUILD_TYPE}/lib${ARGS_TARGET}.a -output "${OUTPUT}"
             WORKING_DIRECTORY "${ARGS_WORKING_DIRECTORY}"
             DEPENDS ${LIB_SOURCES}
             COMMENT "Building ${ARGS_TARGET} in ${ARGS_WORKING_DIRECTORY} with:  ${cargo_EXECUTABLE} ${MY_CARGO_ARGS_STRING}")
@@ -185,7 +235,7 @@ function(add_rust_library)
     add_custom_target(${ARGS_TARGET}_target
         DEPENDS ${OUTPUT})
 
-    # Create a static imported library target from library target
+    # Create a static imported library target from custom target
     add_library(${ARGS_TARGET} STATIC IMPORTED GLOBAL)
     add_dependencies(${ARGS_TARGET} ${ARGS_TARGET}_target)
     target_link_libraries(${ARGS_TARGET} INTERFACE ${RUST_NATIVE_STATIC_LIBS})
@@ -209,7 +259,7 @@ function(add_rust_test)
     cmake_parse_arguments(ARGS "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
     set(MY_CARGO_ARGS "test")
-    if (NOT "${CMAKE_OSX_ARCHITECTURES}" MATCHES "^(arm64;x86_64|x86_64;arm64)$") #  Don't specify the target for universal, we'll do that manually for each build.
+    if(NOT "${CMAKE_OSX_ARCHITECTURES}" MATCHES "^(arm64;x86_64|x86_64;arm64)$") #  Don't specify the target for universal, we'll do that manually for each build.
         list(APPEND MY_CARGO_ARGS "--target" ${RUST_COMPILER_TARGET})
     endif()
 
@@ -241,6 +291,11 @@ find_rust_program(rust-lldb)
 find_rust_program(rustdoc)
 find_rust_program(rustfmt)
 find_rust_program(bindgen)
+
+if(RUSTC_MINIMUM_REQUIRED AND rustc_VERSION VERSION_LESS RUSTC_MINIMUM_REQUIRED)
+    message(FATAL_ERROR "Your Rust toolchain is to old to build this project:
+    ${rustc_VERSION} < ${RUSTC_MINIMUM_REQUIRED}")
+endif()
 
 # Determine the native libs required to link w/ rust static libs
 # message(STATUS "Detecting native static libs for rust: ${rustc_EXECUTABLE} --crate-type staticlib --print=native-static-libs /dev/null")
@@ -293,26 +348,26 @@ if(NOT RUST_COMPILER_TARGET)
 endif()
 
 set(CARGO_ARGS "build")
-if (NOT "${RUST_COMPILER_TARGET}" MATCHES "^universal-apple-darwin$")
+if(NOT "${RUST_COMPILER_TARGET}" MATCHES "^universal-apple-darwin$")
     # Don't specify the target for macOS universal builds, we'll do that manually for each build.
     list(APPEND CARGO_ARGS "--target" ${RUST_COMPILER_TARGET})
 endif()
 
 set(RUSTFLAGS "")
 if(NOT CMAKE_BUILD_TYPE)
-    set(LIB_BUILD_TYPE "debug")
+    set(CARGO_BUILD_TYPE "debug")
 elseif(${CMAKE_BUILD_TYPE} STREQUAL "Release" OR ${CMAKE_BUILD_TYPE} STREQUAL "MinSizeRel")
-    set(LIB_BUILD_TYPE "release")
+    set(CARGO_BUILD_TYPE "release")
     list(APPEND CARGO_ARGS "--release")
 elseif(${CMAKE_BUILD_TYPE} STREQUAL "RelWithDebInfo")
-    set(LIB_BUILD_TYPE "release")
+    set(CARGO_BUILD_TYPE "release")
     list(APPEND CARGO_ARGS "--release")
     set(RUSTFLAGS "-g")
 else()
-    set(LIB_BUILD_TYPE "debug")
+    set(CARGO_BUILD_TYPE "debug")
 endif()
 
-find_package_handle_standard_args( Rust
+find_package_handle_standard_args(Rust
     REQUIRED_VARS cargo_EXECUTABLE
     VERSION_VAR cargo_VERSION
 )

--- a/libclamav/others.c
+++ b/libclamav/others.c
@@ -80,7 +80,7 @@
 #include "stats.h"
 #include "json_api.h"
 
-#include "libclamav_rust/clamav_rust.h"
+#include "clamav_rust.h"
 
 cl_unrar_error_t (*cli_unrar_open)(const char *filename, void **hArchive, char **comment, uint32_t *comment_size, uint8_t debug_flag);
 cl_unrar_error_t (*cli_unrar_peek_file_header)(void *hArchive, unrar_metadata_t *file_metadata);

--- a/libclamav_rust/CMakeLists.txt
+++ b/libclamav_rust/CMakeLists.txt
@@ -6,7 +6,8 @@
 
 # libclamav rust static library
 add_rust_library(TARGET clamav_rust
-    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    SOURCE_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    BINARY_DIRECTORY "${CMAKE_BINARY_DIR}"
     # Tests cannot be pre-compiled here, because there are circular dependencies
     # between libclamav_rust and libclamav to include calls like `cli_getdsig()`
     # as well as the logging functions.

--- a/libclamav_rust/CMakeLists.txt
+++ b/libclamav_rust/CMakeLists.txt
@@ -5,7 +5,13 @@
 #
 
 # libclamav rust static library
-add_rust_library(TARGET clamav_rust WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
+add_rust_library(TARGET clamav_rust
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    # Tests cannot be pre-compiled here, because there are circular dependencies
+    # between libclamav_rust and libclamav to include calls like `cli_getdsig()`
+    # as well as the logging functions.
+    PRECOMPILE_TESTS FALSE
+)
 if (WIN32)
     target_link_libraries(clamav_rust PUBLIC INTERFACE Userenv)
 endif()

--- a/libclamav_rust/build.rs
+++ b/libclamav_rust/build.rs
@@ -121,7 +121,7 @@ fn main() -> Result<(), &'static str> {
 /// Use bindgen to generate Rust bindings to call into C libraries.
 fn execute_bindgen() -> Result<(), &'static str> {
     let build_dir = PathBuf::from(env::var("CARGO_TARGET_DIR").unwrap_or_else(|_| ".".into()));
-    let build_include_path = format!("-I{}", build_dir.join("..").to_str().unwrap());
+    let build_include_path = format!("-I{}", build_dir.join(".").to_str().unwrap());
 
     // Configure and generate bindings.
     let mut builder = builder()
@@ -150,10 +150,13 @@ fn execute_bindgen() -> Result<(), &'static str> {
     }
 
     // Generate!
-    let bindings = builder.generate().unwrap();
+    builder
+        .generate()
+        .expect("Generating Rust bindings for C code")
+        .write_to_file(BINDGEN_OUTPUT_FILE)
+        .expect("Writing Rust bindings to output file");
 
-    // Write the generated bindings to an output file.
-    bindings.write_to_file(BINDGEN_OUTPUT_FILE).unwrap();
+    eprintln!("bindgen outputting \"{}\"", BINDGEN_OUTPUT_FILE);
 
     Ok(())
 }

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -349,9 +349,7 @@ endif()
 add_rust_test(NAME libclamav_rust
     SOURCE_DIRECTORY "${CMAKE_SOURCE_DIR}/libclamav_rust"
     BINARY_DIRECTORY "${CMAKE_BINARY_DIR}"
-    PRECOMPILE_TESTS TRUE
-    DEPENDS ClamAV::libclamav
-    ENVIRONMENT "${ENVIRONMENT}"
+    PRECOMPILE_TESTS FALSE # Cannot precompile, because `sudo make install` will fail. See notes in FindRust.cmake.
 )
 set_property(TEST libclamav_rust PROPERTY ENVIRONMENT ${ENVIRONMENT})
 

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -346,7 +346,13 @@ if(Valgrind_FOUND)
     set_property(TEST libclamav_valgrind PROPERTY ENVIRONMENT ${ENVIRONMENT} VALGRIND=${Valgrind_EXECUTABLE})
 endif()
 
-add_rust_test(NAME libclamav_rust WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/libclamav_rust" PRECOMPILE_TESTS TRUE DEPENDS ClamAV::libclamav ENVIRONMENT "${ENVIRONMENT}")
+add_rust_test(NAME libclamav_rust
+    SOURCE_DIRECTORY "${CMAKE_SOURCE_DIR}/libclamav_rust"
+    BINARY_DIRECTORY "${CMAKE_BINARY_DIR}"
+    PRECOMPILE_TESTS TRUE
+    DEPENDS ClamAV::libclamav
+    ENVIRONMENT "${ENVIRONMENT}"
+)
 set_property(TEST libclamav_rust PROPERTY ENVIRONMENT ${ENVIRONMENT})
 
 if(ENABLE_APP)

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -291,9 +291,6 @@ set(ENVIRONMENT
     CK_DEFAULT_TIMEOUT=300
     LD_LIBRARY_PATH=${LD_LIBRARY_PATH}
     DYLD_LIBRARY_PATH=${LD_LIBRARY_PATH}
-    SOURCE=${SOURCE}
-    BUILD=${BUILD}
-    TMP=${TMP}
     PATH=${NEW_PATH}
     LIBSSL=${LIBSSL}
     LIBCRYPTO=${LIBCRYPTO}
@@ -349,7 +346,7 @@ if(Valgrind_FOUND)
     set_property(TEST libclamav_valgrind PROPERTY ENVIRONMENT ${ENVIRONMENT} VALGRIND=${Valgrind_EXECUTABLE})
 endif()
 
-add_rust_test(NAME libclamav_rust WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/libclamav_rust")
+add_rust_test(NAME libclamav_rust WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/libclamav_rust" PRECOMPILE_TESTS TRUE DEPENDS ClamAV::libclamav ENVIRONMENT "${ENVIRONMENT}")
 set_property(TEST libclamav_rust PROPERTY ENVIRONMENT ${ENVIRONMENT})
 
 if(ENABLE_APP)


### PR DESCRIPTION
This PR solves two issues:
1. precompiling the rust unit test executable so it is not compiled during test run time.
2. building all rust modules in same target directory, so we don't recompile any dependencies.

This significantly reduces test time in this project, and the equivalent changes in my CMake-Rust Demo project found a more significant improvement in build time because it has more than one Rust target, with some common dependencies: https://github.com/micahsnyder/cmake-rust-demo/pull/9