### PR TITLE
Clam 2001 regex slash colon fixup

### DIFF
--- a/unit_tests/clamscan_test.py
+++ b/unit_tests/clamscan_test.py
@@ -571,7 +571,7 @@ rule regex
         #
         yara_db = TC.path_tmp / 'regex-slash-colon.ldb'
         yara_db.write_text(
-            r'regex;Engine:81-255,Target:0;1;68656c6c6f20;0/hello blee/blah: bleh/'
+            r'regex;Engine:81-255,Target:0;1;68656c6c6f20;0/hello blee\/blah: bleh/'
         )
         command = '{valgrind} {valgrind_args} {clamscan} -d {path_db} {testfiles}'.format(
             valgrind=TC.valgrind, valgrind_args=TC.valgrind_args, clamscan=TC.clamscan, path_db=yara_db, testfiles=testfile,
@@ -616,3 +616,166 @@ rule regex
             'Infected files: 1',
         ]
         self.verify_output(output.out, expected=expected_results)
+
+    def test_clamscan_18_ldb_offset_pcre(self):
+        self.step_name('Test LDB regex rules with an offset')
+        # The offset feature starts the match some # of bytes after start of the pattern match
+        # The offset is EXACT, meaning it's no longer wildcard.
+        # The match must occur exactly that number of bytes from the start of the file.
+
+        # using 'MZ' prefix so it is detected as MSEXE and not TEXT. This is to avoid normalization.
+        testfile = TC.path_tmp / 'ldb_offset_pcre'
+        testfile.write_text('MZ hello blee')
+
+        # First without the offset, make sure it matches
+        yara_db = TC.path_tmp / 'ldb_pcre_no_offset.ldb'
+        yara_db.write_text(
+            r'ldb_pcre_no_offset;Engine:81-255,Target:0;0&1;68656c6c6f20;0/hello blee/'
+        )
+        command = '{valgrind} {valgrind_args} {clamscan} -d {path_db} {testfiles}'.format(
+            valgrind=TC.valgrind, valgrind_args=TC.valgrind_args, clamscan=TC.clamscan, path_db=yara_db, testfiles=testfile,
+        )
+        output = self.execute_command(command)
+
+        assert output.ec == 1  # virus found
+
+        expected_results = [
+            'ldb_offset_pcre: ldb_pcre_no_offset.UNOFFICIAL FOUND',
+            'Infected files: 1',
+        ]
+
+        # Next, with the offset, but it won't match, because the regex pattern is "hello blee"
+        # and with the offset of 5 (from start of file) means it should start the pcre matching at "llo blee"
+        yara_db = TC.path_tmp / 'ldb_pcre_offset_no_match.ldb'
+        yara_db.write_text(
+            r'ldb_pcre_offset_no_match;Engine:81-255,Target:0;0&1;68656c6c6f20;5:0/hello blee/'
+        )
+        command = '{valgrind} {valgrind_args} {clamscan} -d {path_db} {testfiles}'.format(
+            valgrind=TC.valgrind, valgrind_args=TC.valgrind_args, clamscan=TC.clamscan, path_db=yara_db, testfiles=testfile,
+        )
+        output = self.execute_command(command)
+
+        assert output.ec == 0  # virus NOT found
+
+        expected_results = [
+            'ldb_offset_pcre: OK',
+        ]
+
+        # Next, with the offset, and it SHOULD match, because the regex pattern is "llo blee"
+        # and with the offset of 5 (from start of file) means it should start the pcre matching at "llo blee"
+        yara_db = TC.path_tmp / 'ldb_pcre_offset_match.ldb'
+        yara_db.write_text(
+            r'ldb_pcre_offset_match;Engine:81-255,Target:0;0&1;68656c6c6f20;5:0/llo blee/'
+        )
+        command = '{valgrind} {valgrind_args} {clamscan} -d {path_db} {testfiles}'.format(
+            valgrind=TC.valgrind, valgrind_args=TC.valgrind_args, clamscan=TC.clamscan, path_db=yara_db, testfiles=testfile,
+        )
+        output = self.execute_command(command)
+
+        assert output.ec == 1  # virus found
+
+        expected_results = [
+            'ldb_offset_pcre: ldb_pcre_offset_match.UNOFFICIAL FOUND',
+            'Infected files: 1',
+        ]
+
+    def test_clamscan_18_ldb_pcre_flag(self):
+        self.step_name('Test LDB regex rules with case insensitive flag')
+        # This test validates that the flags field is, and more specifically the case-insensitive flag is working.
+
+        # using 'MZ' prefix so it is detected as MSEXE and not TEXT. This is to avoid normalization.
+        testfile = TC.path_tmp / 'ldb_pcre_flag'
+        testfile.write_text('MZ hello blee / BlAh')
+
+        # First test withOUT the case-insensitive flag. It should NOT match.
+        yara_db = TC.path_tmp / 'ldb_pcre_case.ldb'
+        yara_db.write_text(
+            r'ldb_pcre_case;Engine:81-255,Target:0;0&1;68656c6c6f20;0/blah/'
+        )
+        command = '{valgrind} {valgrind_args} {clamscan} -d {path_db} {testfiles}'.format(
+            valgrind=TC.valgrind, valgrind_args=TC.valgrind_args, clamscan=TC.clamscan, path_db=yara_db, testfiles=testfile,
+        )
+        output = self.execute_command(command)
+
+        assert output.ec == 0  # virus NOT found
+
+        expected_results = [
+            'ldb_pcre_flag: OK',
+        ]
+
+        # First test WITH the case-insensitive flag. It SHOULD match.
+        yara_db = TC.path_tmp / 'ldb_pcre_nocase.ldb'
+        yara_db.write_text(
+            r'ldb_pcre_nocase;Engine:81-255,Target:0;0&1;68656c6c6f20;0/blah/i'
+        )
+        command = '{valgrind} {valgrind_args} {clamscan} -d {path_db} {testfiles}'.format(
+            valgrind=TC.valgrind, valgrind_args=TC.valgrind_args, clamscan=TC.clamscan, path_db=yara_db, testfiles=testfile,
+        )
+        output = self.execute_command(command)
+
+        assert output.ec == 1  # virus found
+
+        expected_results = [
+            'ldb_pcre_flag: ldb_pcre_nocase.UNOFFICIAL FOUND',
+            'Infected files: 1',
+        ]
+
+    def test_clamscan_18_ldb_multi_pcre(self):
+        self.step_name('Test LDB and Yara regex rules with / and : in the string work')
+        # This is a regression test for a bug where :'s in a PCRE regex would act
+        # as delimiters if there was also a / in the regex before the :
+
+        # using 'MZ' prefix so it is detected as MSEXE and not TEXT. This is to avoid normalization.
+        testfile = TC.path_tmp / 'ldb_multi_pcre'
+        testfile.write_text('MZ hello blee / BlAh')
+
+        # Verify first with two subsigs that should match, that the alert has found.
+        yara_db = TC.path_tmp / 'ldb_multi_pcre.ldb'
+        yara_db.write_text(
+            r'ldb_multi_pcre;Engine:81-255,Target:0;0&1&2;68656c6c6f20;0/hello blee/;0/blah/i'
+        )
+        command = '{valgrind} {valgrind_args} {clamscan} -d {path_db} {testfiles}'.format(
+            valgrind=TC.valgrind, valgrind_args=TC.valgrind_args, clamscan=TC.clamscan, path_db=yara_db, testfiles=testfile,
+        )
+        output = self.execute_command(command)
+
+        assert output.ec == 1  # virus found
+
+        expected_results = [
+            'ldb_multi_pcre: ldb_multi_pcre.UNOFFICIAL FOUND',
+            'Infected files: 1',
+        ]
+
+        # Verify next that if one of the two subsigs do not match, the whole thing does not match.
+        yara_db = TC.path_tmp / 'ldb_multi_pcre.ldb'
+        yara_db.write_text(
+            r'ldb_multi_pcre;Engine:81-255,Target:0;0&1&2;68656c6c6f20;0/hello blee/;0/bloh/i'
+        )
+        command = '{valgrind} {valgrind_args} {clamscan} -d {path_db} {testfiles}'.format(
+            valgrind=TC.valgrind, valgrind_args=TC.valgrind_args, clamscan=TC.clamscan, path_db=yara_db, testfiles=testfile,
+        )
+        output = self.execute_command(command)
+
+        assert output.ec == 0  # virus NOT found
+
+        expected_results = [
+            'ldb_multi_pcre: OK',
+            'Infected files: 0',
+        ]
+
+        # Verify next that if the other of the two subsigs do not match, the whole thing does not match.
+        yara_db = TC.path_tmp / 'ldb_multi_pcre.ldb'
+        yara_db.write_text(
+            r'ldb_multi_pcre;Engine:81-255,Target:0;0&1&2;68656c6c6f20;0/hella blee/;0/blah/i'
+        )
+        command = '{valgrind} {valgrind_args} {clamscan} -d {path_db} {testfiles}'.format(
+            valgrind=TC.valgrind, valgrind_args=TC.valgrind_args, clamscan=TC.clamscan, path_db=yara_db, testfiles=testfile,
+        )
+        output = self.execute_command(command)
+
+        assert output.ec == 0  # virus NOT found
+
+        expected_results = [
+            'ldb_multi_pcre: OK',
+            'Infected files: 0',
+        ]


### PR DESCRIPTION
### Fix issue preventing multiple LDB PCRE subsignatures

My recent fix for the issue where a '\' followed by ':' in a Yara regex
string would fail to parse introduced a new issue that broke loading a
signature in the current daily.ldb database.

Unbeknownst to me at the time, you can have multiple PCRE subsignatures
in a logical signature, so long as they're the last subsignatures.
The previous fix made it so the signature parser muddled more than one
PCRE subsignature into one messed up regex string.

This commit essentially reverts the previous fix, while keeping some of
the code readability improvements in that function.
Instead, it addresses the problem a different way. To resolve the
original problem, I'm simply checking if the signame starts with "YARA".
If it does, we don't tokenize it by ':' delimiters.

### Tests: Update LDB PCRE test per previous fix, and add more tests

I was unaware that while Yara rule regex strings may-or-may-not
escape '/' characters in the regex string, Clam logical sigs MUST escape
them. The Yara rule parser automatically removes the unnecessary '/':
https://github.com/Cisco-Talos/clamav/blob/clamav-0.105.1/libclamav/yara_lexer.l#L509-L514

That's a good feature, we don't want to remove that. But the Clam
logical sigs don't have an equivalent feature. So I changed the LDB
version of the regex '/' + ':' test to include the escape '\/'
character.

This commit also adds some new tests to make sure we don't break support
for LDB sigs with multiple PCRE subsignatures in the future, and to test
that the offset feature and the case-insensitive feature work for PCRE
subsignatures.