### PR TITLE
CMake+Rust: default build must be release with debug info

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,19 @@ set(ENABLE_SYSTEMD_DEFAULT          ON)
 # See CMakeOptions.cmake for additional options.
 include(CMakeOptions.cmake)
 
+# Set build type to RelWithDebInfo if not specified.
+# This must be done before pulling in the Rust module
+# or else the default build will be Debug for Rust stuffs.
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+    set(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING "Choose the build type" FORCE)
+
+    # Include "None" as option to disable any additional (optimization) flags,
+    # relying on just CMAKE_C_FLAGS and CMAKE_CXX_FLAGS (which are empty by
+    # default). These strings are presented in cmake-gui.
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+        "None" "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+endif()
+
 #
 # Find Build Tools
 #
@@ -577,16 +590,6 @@ foreach(_cxx1x_flag -std=c++14 -std=c++11)
         break()
     endif()
 endforeach()
-
-if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
-    set(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING "Choose the build type" FORCE)
-
-    # Include "None" as option to disable any additional (optimization) flags,
-    # relying on just CMAKE_C_FLAGS and CMAKE_CXX_FLAGS (which are empty by
-    # default). These strings are presented in cmake-gui.
-    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
-        "None" "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
-endif()
 
 # Always use '-fPIC'/'-fPIE' option.
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)

--- a/cmake/FindRust.cmake
+++ b/cmake/FindRust.cmake
@@ -339,7 +339,7 @@ function(add_rust_test)
         list(APPEND MY_CARGO_ARGS "--target" ${RUST_COMPILER_TARGET})
     endif()
 
-    if("${CMAKE_BUILD_TYPE}" STREQUAL "Release")
+    if("${CMAKE_BUILD_TYPE}" STREQUAL "Release" OR "${CMAKE_BUILD_TYPE}" STREQUAL "RelWithDebInfo")
         list(APPEND MY_CARGO_ARGS "--release")
     endif()
 
@@ -357,7 +357,7 @@ function(add_rust_test)
 
     add_test(
         NAME ${ARGS_NAME}
-        COMMAND ${CMAKE_COMMAND} -E env "CARGO_CMD=test" "CARGO_TARGET_DIR=${ARGS_BINARY_DIRECTORY}" ${cargo_EXECUTABLE} ${MY_CARGO_ARGS} --color always
+        COMMAND ${CMAKE_COMMAND} -E env "CARGO_CMD=test" "CARGO_TARGET_DIR=${ARGS_BINARY_DIRECTORY}" "RUSTFLAGS=${RUSTFLAGS}" ${cargo_EXECUTABLE} ${MY_CARGO_ARGS} --color always
         WORKING_DIRECTORY ${ARGS_SOURCE_DIRECTORY}
     )
 endfunction()


### PR DESCRIPTION
We already set the default build type to RelWithDebInfo for CMake, but we were setting it *after* adding the Rust module.  We need to do it before, or else the Rust stuff will still default to Debug, which makes for really slow scans of images that get fuzzy hashed.