### PR TITLE
Clam 2167 freshclam cld incremental update

### DIFF
--- a/libclamav_rust/src/sys.rs
+++ b/libclamav_rust/src/sys.rs
@@ -112,7 +112,10 @@ pub type clcb_pre_cache = ::std::option::Option<
         context: *mut ::std::os::raw::c_void,
     ) -> cl_error_t,
 >;
-#[doc = " @brief Pre-scan callback."]
+#[doc = " @brief File inspection callback."]
+#[doc = ""]
+#[doc = " DISCLAIMER: This interface is to be considered unstable while we continue to evaluate it."]
+#[doc = " We may change this interface in the future."]
 #[doc = ""]
 #[doc = " Called for each NEW file (inner and outer)."]
 #[doc = " Provides capability to record embedded file information during a scan."]

--- a/libfreshclam/libfreshclam_internal.c
+++ b/libfreshclam/libfreshclam_internal.c
@@ -1527,6 +1527,7 @@ static fc_error_t mkdir_and_chdir_for_cdiff_tmp(const char *database, const char
          * yet exist.
          */
         int ret;
+        bool is_cld = false;
 
         /*
          * 1) Double-check that we have a CVD or CLD. Without either one, incremental update won't work.
@@ -1548,6 +1549,8 @@ static fc_error_t mkdir_and_chdir_for_cdiff_tmp(const char *database, const char
                 logg(LOGG_ERROR, "mkdir_and_chdir_for_cdiff_tmp: Can't find (or access) local CVD or CLD for %s database\n", database);
                 goto done;
             }
+
+            is_cld = true;
         }
 
         /*
@@ -1561,7 +1564,7 @@ static fc_error_t mkdir_and_chdir_for_cdiff_tmp(const char *database, const char
         /*
          * 3) Unpack the existing CVD/CLD database to this directory.
          */
-        if (CL_SUCCESS != cl_cvdunpack(cvdfile, tmpdir, false)) {
+        if (CL_SUCCESS != cl_cvdunpack(cvdfile, tmpdir, is_cld == true)) {
             logg(LOGG_ERROR, "mkdir_and_chdir_for_cdiff_tmp: Can't unpack %s into %s\n", cvdfile, tmpdir);
             cli_rmdirs(tmpdir);
             goto done;


### PR DESCRIPTION
- Freshclam: fix incremental update on CLD database

  When adding the `cl_cvdunpack()` API that (optionally) verifies the
  database signature, we used it in libfreshclam in a place where it may
  also unpack CLD database archives. CLD's may not be verified, because
  the signature information is no longer valid after incremental update.

  This commit fixes the issue by only verifying the unpack if the file is
  a CVD and not a CLD.

- Test: Add test for incremental update twice in a row

  This is a regression test to ensure that freshclam can update from a CVD
  to a CLD, and then update from the CLD to a (newer) CLD.

Fixes https://github.com/Cisco-Talos/clamav/issues/736