### PR TITLE
Clam 1106 clamdscan allmatch stickiness

### DIFF
--- a/clamd/session.c
+++ b/clamd/session.c
@@ -191,12 +191,14 @@ int command(client_conn_t *conn, int *virus)
 {
     int desc                        = conn->sd;
     struct cl_engine *engine        = conn->engine;
-    struct cl_scan_options *options = conn->options;
+    struct cl_scan_options options;
     const struct optstruct *opts    = conn->opts;
     enum scan_type type             = TYPE_INIT;
     int maxdirrec;
     int ret   = 0;
     int flags = CLI_FTW_STD;
+
+    memcpy(&options, conn->options, sizeof(struct cl_scan_options));
 
     struct scan_cb_data scandata;
     struct cli_ftw_cbdata data;
@@ -218,7 +220,7 @@ int command(client_conn_t *conn, int *virus)
     scandata.group         = conn->group;
     scandata.odesc         = desc;
     scandata.conn          = conn;
-    scandata.options       = options;
+    scandata.options       = &options;
     scandata.engine        = engine;
     scandata.opts          = opts;
     scandata.thr_pool      = conn->thrpool;
@@ -296,7 +298,7 @@ int command(client_conn_t *conn, int *virus)
                 conn_reply_error(conn, "FILDES: didn't receive file descriptor.");
                 return 1;
             } else {
-                ret = scanfd(conn, NULL, engine, options, opts, desc, 0);
+                ret = scanfd(conn, NULL, engine, &options, opts, desc, 0);
                 if (ret == CL_VIRUS) {
                     *virus = 1;
                     ret    = 0;
@@ -327,7 +329,7 @@ int command(client_conn_t *conn, int *virus)
             return 0;
         case COMMAND_INSTREAMSCAN:
             thrmgr_setactivetask(NULL, "INSTREAM");
-            ret = scanfd(conn, NULL, engine, options, opts, desc, 1);
+            ret = scanfd(conn, NULL, engine, &options, opts, desc, 1);
             if (ret == CL_VIRUS) {
                 *virus = 1;
                 ret    = 0;


### PR DESCRIPTION

- Fix clamdscan --allmatch stickiness bug

  If you run clamdscan with the --allmatch option, it will cause all
  subsequent clamdscan scans to have all-match mode enabled.
  This bug is specific to clamd / clamdscan and does not affect clamscan.
  The problem was introduced when we converted the scan options from a
  single integer bitfield to a struct. The scan options set by the
  clamdscan parameters should be saved in a local copy of the scan
  options, but instead it is saving a copy of the pointer to the scan
  options struct, and so any changes to the scan options affect future
  scans.

- Test: Add clamdscan --allmatch stickiness regression test

  Test that clamdscan --allmatch does not cause future clamdscans to run
  in allmatch mode.

Fixes https://github.com/Cisco-Talos/clamav/issues/276 