### PR TITLE
Fix a few minor compiler/standards issues (clang-16 porting) (0.103.9)

### DIFF
--- a/clamonacc/c-thread-pool/thpool.c
+++ b/clamonacc/c-thread-pool/thpool.c
@@ -8,7 +8,7 @@
  *
  ********************************/
 
-#define _POSIX_C_SOURCE 200809L
+#define _GNU_SOURCE
 #include <unistd.h>
 #include <signal.h>
 #include <stdio.h>

--- a/clamonacc/clamonacc.c
+++ b/clamonacc/clamonacc.c
@@ -61,7 +61,7 @@
 pthread_t ddd_pid        = 0;
 pthread_t scan_queue_pid = 0;
 
-static void onas_handle_signals();
+static void onas_handle_signals(void);
 static int startup_checks(struct onas_context *ctx);
 static struct onas_context *g_ctx = NULL;
 

--- a/clamonacc/client/socket.h
+++ b/clamonacc/client/socket.h
@@ -31,4 +31,4 @@ struct onas_sock_t {
 };
 
 cl_error_t onas_set_sock_only_once(struct onas_context *ctx);
-int onas_get_sockd();
+int onas_get_sockd(void);

--- a/clamonacc/inotif/hash.c
+++ b/clamonacc/inotif/hash.c
@@ -58,7 +58,7 @@
 
 #if defined(HAVE_SYS_FANOTIFY_H)
 
-static struct onas_bucket *onas_bucket_init();
+static struct onas_bucket *onas_bucket_init(void);
 static void onas_free_bucket(struct onas_bucket *bckt);
 static int onas_bucket_insert(struct onas_bucket *bckt, struct onas_element *elem);
 static int onas_bucket_remove(struct onas_bucket *bckt, struct onas_element *elem);

--- a/clamonacc/inotif/inotif.c
+++ b/clamonacc/inotif/inotif.c
@@ -66,7 +66,7 @@
 
 static int onas_ddd_init_ht(uint32_t ht_size);
 static int onas_ddd_init_wdlt(uint64_t nwatches);
-static int onas_ddd_grow_wdlt();
+static int onas_ddd_grow_wdlt(void);
 
 static int onas_ddd_watch(const char *pathname, int fan_fd, uint64_t fan_mask, int in_fd, uint64_t in_mask);
 static int onas_ddd_watch_hierarchy(const char *pathname, size_t len, int fd, uint64_t mask, uint32_t type);

--- a/clamonacc/scan/onas_queue.c
+++ b/clamonacc/scan/onas_queue.c
@@ -82,7 +82,7 @@ static cl_error_t onas_new_event_queue_node(struct onas_event_queue_node **node)
     return CL_SUCCESS;
 }
 
-static void *onas_init_event_queue()
+static void *onas_init_event_queue(void)
 {
 
     if (CL_EMEM == onas_new_event_queue_node(&g_onas_event_queue_head)) {
@@ -122,7 +122,7 @@ static void onas_destroy_event_queue_node(struct onas_event_queue_node *node)
     return;
 }
 
-static void onas_destroy_event_queue()
+static void onas_destroy_event_queue(void)
 {
 
     if (NULL == g_onas_event_queue_head) {
@@ -200,7 +200,7 @@ void *onas_scan_queue_th(void *arg)
     pthread_cleanup_pop(1);
 }
 
-static int onas_queue_is_b_empty()
+static int onas_queue_is_b_empty(void)
 {
 
     if (g_onas_event_queue.head->next == g_onas_event_queue.tail) {

--- a/libclamav/matcher-pcre.h
+++ b/libclamav/matcher-pcre.h
@@ -68,11 +68,11 @@ struct cli_pcre_meta {
 };
 
 /* PCRE PERFORMANCE DECLARATIONS */
-void cli_pcre_perf_print();
-void cli_pcre_perf_events_destroy();
+void cli_pcre_perf_print(void);
+void cli_pcre_perf_events_destroy(void);
 
 /* PCRE MATCHER DECLARATIONS */
-int cli_pcre_init();
+int cli_pcre_init(void);
 cl_error_t cli_pcre_addpatt(struct cli_matcher *root, const char *virname, const char *trigger, const char *pattern, const char *cflags, const char *offset, const uint32_t *lsigid, unsigned int options);
 cl_error_t cli_pcre_build(struct cli_matcher *root, long long unsigned match_limit, long long unsigned recmatch_limit, const struct cli_dconf *dconf);
 cl_error_t cli_pcre_recaloff(struct cli_matcher *root, struct cli_pcre_off *data, struct cli_target_info *info, cli_ctx *ctx);

--- a/libclamav/regex_pcre.h
+++ b/libclamav/regex_pcre.h
@@ -76,7 +76,7 @@ struct cli_pcre_results {
 };
 #endif
 
-cl_error_t cli_pcre_init_internal();
+cl_error_t cli_pcre_init_internal(void);
 cl_error_t cli_pcre_addoptions(struct cli_pcre_data *pd, const char **opt, int errout);
 cl_error_t cli_pcre_compile(struct cli_pcre_data *pd, long long unsigned match_limit, long long unsigned match_limit_recursion, unsigned int options, int opt_override);
 int cli_pcre_match(struct cli_pcre_data *pd, const unsigned char *buffer, size_t buflen, size_t override_offset, int options, struct cli_pcre_results *results);

--- a/m4/reorganization/compiler_checks.m4
+++ b/m4/reorganization/compiler_checks.m4
@@ -121,7 +121,7 @@ extern void abort(void);
   ((bb_size) > 0 && (sb_size) > 0 && (size_t)(sb_size) <= (size_t)(bb_size) \
    && (sb) >= (bb) && ((sb) + (sb_size)) <= ((bb) + (bb_size)) && ((sb) + (sb_size)) > (bb) && (sb) < ((bb) + (bb_size)))
 
-int crashtest()
+int crashtest(void)
 {
 	unsigned int backsize, dcur;
 	int dval=0x12000, unp_offset;

--- a/shared/misc.h
+++ b/shared/misc.h
@@ -72,7 +72,7 @@ int daemonize(void);
 /*closes stdin, stdout, stderr.  This is called by daemonize, but not
  * daemonize_all_return.  Users of daemonize_all_return should call this
  * when initialization is complete.*/
-int close_std_descriptors();
+int close_std_descriptors(void);
 
 /*Returns the return value of fork.  All processes return */
 int daemonize_all_return(void);


### PR DESCRIPTION
The next major version of clang has threatened to enable some strictness flags by default:

  https://bugs.gentoo.org/show_bug.cgi?id=clang-16-porting

Specifically,

* -Werror=implicit-function-declaration
* -Werror=implicit-int
* -Werror=strict-prototypes

Whether or not they all wind up on by default, the problems they catch are easy to fix and usually beneficial for e.g. further compiler diagnostics. Here I've fixed what I had to in order to build v0.103.7.

For the autotools build system, the following autoconf fix (and an `autoreconf -fi`) is also required:

  https://git.savannah.gnu.org/gitweb/?p=autoconf.git;a=commit;h=8b5e2016c7ed2d67f31b03a3d2e361858ff5299b

Otherwise, the checks that are emitted will unduly fail.