### PR TITLE
Check scanoptions for null pointer

### DIFF
--- a/libclamav/scanners.c
+++ b/libclamav/scanners.c
@@ -5330,7 +5330,7 @@ static cl_error_t scan_common(cl_fmap_t *map, const char *filepath, const char *
     time_t current_time;
     struct tm tm_struct;
 
-    if (NULL == map) {
+    if (NULL == map || NULL == scanoptions) {
         return CL_ENULLARG;
     }
 


### PR DESCRIPTION
I've passed several times inadvertently a null pointer to scanoptions, and only found out through the segmentation fault in memcpy that something went wrong.