### PR TITLE
CLAM-2159: logg init refactor

### DIFF
--- a/clamonacc/clamonacc.c
+++ b/clamonacc/clamonacc.c
@@ -67,9 +67,9 @@ static struct onas_context *g_ctx = NULL;
 
 static void onas_clamonacc_exit(int sig)
 {
-    logg(LOGG_DEBUG, "Clamonacc: onas_clamonacc_exit(), signal %d\n", sig);
+    mprintf(LOGG_DEBUG, "Clamonacc: onas_clamonacc_exit(), signal %d\n", sig);
     if (sig == 11) {
-        logg(LOGG_ERROR, "Clamonacc: clamonacc has experienced a fatal error, if you continue to see this error, please run clamonacc with --verbose and report the issue and crash report to the developers\n");
+        mprintf(LOGG_ERROR, "Clamonacc: clamonacc has experienced a fatal error, if you continue to see this error, please run clamonacc with --verbose and report the issue and crash report to the developers\n");
     }
 
     if (g_ctx) {
@@ -79,21 +79,21 @@ static void onas_clamonacc_exit(int sig)
         g_ctx->fan_fd = 0;
     }
 
-    logg(LOGG_DEBUG, "Clamonacc: attempting to stop ddd thread ... \n");
+    mprintf(LOGG_DEBUG, "Clamonacc: attempting to stop ddd thread ... \n");
     if (ddd_pid > 0) {
         pthread_cancel(ddd_pid);
         pthread_join(ddd_pid, NULL);
     }
     ddd_pid = 0;
 
-    logg(LOGG_DEBUG, "Clamonacc: attempting to stop event consumer thread ...\n");
+    mprintf(LOGG_DEBUG, "Clamonacc: attempting to stop event consumer thread ...\n");
     if (scan_queue_pid > 0) {
         pthread_cancel(scan_queue_pid);
         pthread_join(scan_queue_pid, NULL);
     }
     scan_queue_pid = 0;
 
-    logg(LOGG_INFO, "Clamonacc: stopped\n");
+    mprintf(LOGG_INFO, "Clamonacc: stopped\n");
     onas_cleanup(g_ctx);
     pthread_exit(NULL);
 }
@@ -101,6 +101,7 @@ static void onas_clamonacc_exit(int sig)
 int main(int argc, char **argv)
 {
     const struct optstruct *opts;
+    const struct optstruct *opt;
     const struct optstruct *clamdopts;
     struct onas_context *ctx;
     int ret = 0;
@@ -108,17 +109,29 @@ int main(int argc, char **argv)
     /* Initialize context */
     ctx = onas_init_context();
     if (ctx == NULL) {
-        logg(LOGG_ERROR, "Clamonacc: can't initialize context\n");
+        mprintf(LOGG_ERROR, "Clamonacc: can't initialize context\n");
         return 2;
     }
 
     /* Parse out all our command line options */
     opts = optparse(NULL, argc, argv, 1, OPT_CLAMONACC, OPT_CLAMSCAN, NULL);
     if (opts == NULL) {
-        logg(LOGG_ERROR, "Clamonacc: can't parse command line options\n");
+        mprintf(LOGG_ERROR, "Clamonacc: can't parse command line options\n");
         return 2;
     }
     ctx->opts = opts;
+
+    /* initialize logger */
+
+    if ((opt = optget(opts, "log"))->enabled) {
+        logg_file = opt->strarg;
+        if (logg(LOGG_INFO, "--------------------------------------\n")) {
+            mprintf(LOGG_ERROR, "ClamClient: problem with internal logger\n");
+            return CL_EARG;
+        }
+    } else {
+        logg_file = NULL;
+    }
 
     if (optget(opts, "verbose")->enabled) {
         mprintf_verbose = 1;

--- a/clamonacc/client/client.c
+++ b/clamonacc/client/client.c
@@ -418,18 +418,6 @@ cl_error_t onas_setup_client(struct onas_context **ctx)
         (*ctx)->printinfected = 1;
     }
 
-    /* initialize logger */
-
-    if ((opt = optget(opts, "log"))->enabled) {
-        logg_file = opt->strarg;
-        if (logg(LOGG_INFO, "--------------------------------------\n")) {
-            logg(LOGG_ERROR, "ClamClient: problem with internal logger\n");
-            return CL_EARG;
-        }
-    } else {
-        logg_file = NULL;
-    }
-
     if (actsetup(opts)) {
         return CL_EARG;
     }


### PR DESCRIPTION
Moves logg setup to start of clamonacc.c main()
Changes all calls to logg which may occure before init to mprintf

Addresses https://github.com/Cisco-Talos/clamav/issues/168