### PR TITLE
Clam 1933 remove rc2 suffix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ cmake_policy(SET CMP0087 NEW) # support generator expressions in install(CODE) a
 #  For release candidate:     set(VERSION_SUFFIX "-rc")
 #  For release:               set(VERSION_SUFFIX "")
 string(TIMESTAMP TODAY "%Y%m%d")
-set(VERSION_SUFFIX "-rc2")
+set(VERSION_SUFFIX "")
 
 project( ClamAV
          VERSION "1.0.0"

--- a/clamd/session.c
+++ b/clamd/session.c
@@ -189,11 +189,11 @@ int conn_reply_errno(const client_conn_t *conn, const char *path,
  */
 int command(client_conn_t *conn, int *virus)
 {
-    int desc                        = conn->sd;
-    struct cl_engine *engine        = conn->engine;
+    int desc                 = conn->sd;
+    struct cl_engine *engine = conn->engine;
     struct cl_scan_options options;
-    const struct optstruct *opts    = conn->opts;
-    enum scan_type type             = TYPE_INIT;
+    const struct optstruct *opts = conn->opts;
+    enum scan_type type          = TYPE_INIT;
     int maxdirrec;
     int ret   = 0;
     int flags = CLI_FTW_STD;

--- a/libclamav/bytecode.c
+++ b/libclamav/bytecode.c
@@ -240,7 +240,8 @@ static void bytecode_context_reset(struct cli_bc_ctx *ctx)
     ctx->containertype = CL_TYPE_ANY;
 }
 
-static inline void bytecode_context_initialize(struct cli_bc_ctx *ctx) {
+static inline void bytecode_context_initialize(struct cli_bc_ctx *ctx)
+{
     memset(ctx, 0, sizeof(*ctx));
 
     ctx->bytecode_timeout = 60000;

--- a/libclamav/clamav.h
+++ b/libclamav/clamav.h
@@ -493,8 +493,8 @@ extern void cl_engine_set_clcb_pre_cache(struct cl_engine *engine, clcb_pre_cach
  * Attributes of each layer in scan.
  */
 #define LAYER_ATTRIBUTES_NONE 0x0
-#define LAYER_ATTRIBUTES_NORMALIZED 0x1    /** This layer was modified to make matching more generic, reliable. */
-#define LAYER_ATTRIBUTES_DECRYPTED 0x2     /** Decryption was used to extract this layer. I.e. had to decrypt some previous layer. */
+#define LAYER_ATTRIBUTES_NORMALIZED 0x1 /** This layer was modified to make matching more generic, reliable. */
+#define LAYER_ATTRIBUTES_DECRYPTED 0x2  /** Decryption was used to extract this layer. I.e. had to decrypt some previous layer. */
 
 /**
  * @brief File inspection callback.

--- a/libclamav/others_common.c
+++ b/libclamav/others_common.c
@@ -223,7 +223,7 @@ void *cli_malloc(size_t size)
     if (!size || size > CLI_MAX_ALLOCATION) {
         cli_warnmsg("cli_malloc(): File or section is too large to scan (%zu bytes). \
                      For your safety, ClamAV limits how much memory an operation can allocate to %zu bytes\n",
-                     size, CLI_MAX_ALLOCATION);
+                    size, CLI_MAX_ALLOCATION);
         return NULL;
     }
 
@@ -244,7 +244,7 @@ void *cli_calloc(size_t nmemb, size_t size)
     if (!nmemb || !size || size > CLI_MAX_ALLOCATION || nmemb > CLI_MAX_ALLOCATION || (nmemb * size > CLI_MAX_ALLOCATION)) {
         cli_warnmsg("cli_calloc2(): File or section is too large to scan (%zu bytes). \
                      For your safety, ClamAV limits how much memory an operation can allocate to %zu bytes\n",
-                     size, CLI_MAX_ALLOCATION);
+                    size, CLI_MAX_ALLOCATION);
         return NULL;
     }
 
@@ -265,7 +265,7 @@ void *cli_realloc(void *ptr, size_t size)
     if (!size || size > CLI_MAX_ALLOCATION) {
         cli_warnmsg("cli_realloc(): File or section is too large to scan (%zu bytes). \
                      For your safety, ClamAV limits how much memory an operation can allocate to %zu bytes\n",
-                     size, CLI_MAX_ALLOCATION);
+                    size, CLI_MAX_ALLOCATION);
         return NULL;
     }
 
@@ -286,7 +286,7 @@ void *cli_realloc2(void *ptr, size_t size)
     if (!size || size > CLI_MAX_ALLOCATION) {
         cli_warnmsg("cli_realloc2(): File or section is too large to scan (%zu bytes). \
                      For your safety, ClamAV limits how much memory an operation can allocate to %zu bytes\n",
-                     size, CLI_MAX_ALLOCATION);
+                    size, CLI_MAX_ALLOCATION);
         return NULL;
     }
 

--- a/libclamav/readdb.c
+++ b/libclamav/readdb.c
@@ -366,7 +366,7 @@ static cl_error_t readdb_load_regex_subsignature(struct cli_matcher *root, const
         if (subtokens_count == 2) {
             // Offset was specified
             offset = subtokens[0];
-            sig = subtokens[1];
+            sig    = subtokens[1];
         } else {
             sig = subtokens[0];
         }


### PR DESCRIPTION
Remove -rc2 suffix in preparation for stable release.

Also clang-format touch-up.