### PR TITLE
Clam 2191 wdb load bug

### DIFF
--- a/libclamav/others_common.c
+++ b/libclamav/others_common.c
@@ -221,8 +221,8 @@ void *cli_malloc(size_t size)
     void *alloc;
 
     if (!size || size > CLI_MAX_ALLOCATION) {
-        cli_warnmsg("cli_malloc(): File or section is too large to scan (%zu bytes). \
-                     For your safety, ClamAV limits how much memory an operation can allocate to %zu bytes\n",
+        cli_warnmsg("cli_malloc(): File or section is too large to scan (%zu bytes). "
+                    "For your safety, ClamAV limits how much memory an operation can allocate to %zu bytes\n",
                     size, CLI_MAX_ALLOCATION);
         return NULL;
     }
@@ -242,8 +242,8 @@ void *cli_calloc(size_t nmemb, size_t size)
     void *alloc;
 
     if (!nmemb || !size || size > CLI_MAX_ALLOCATION || nmemb > CLI_MAX_ALLOCATION || (nmemb * size > CLI_MAX_ALLOCATION)) {
-        cli_warnmsg("cli_calloc2(): File or section is too large to scan (%zu bytes). \
-                     For your safety, ClamAV limits how much memory an operation can allocate to %zu bytes\n",
+        cli_warnmsg("cli_calloc2(): File or section is too large to scan (%zu bytes). "
+                    "For your safety, ClamAV limits how much memory an operation can allocate to %zu bytes\n",
                     size, CLI_MAX_ALLOCATION);
         return NULL;
     }
@@ -263,8 +263,8 @@ void *cli_realloc(void *ptr, size_t size)
     void *alloc;
 
     if (!size || size > CLI_MAX_ALLOCATION) {
-        cli_warnmsg("cli_realloc(): File or section is too large to scan (%zu bytes). \
-                     For your safety, ClamAV limits how much memory an operation can allocate to %zu bytes\n",
+        cli_warnmsg("cli_realloc(): File or section is too large to scan (%zu bytes). "
+                    "For your safety, ClamAV limits how much memory an operation can allocate to %zu bytes\n",
                     size, CLI_MAX_ALLOCATION);
         return NULL;
     }
@@ -284,8 +284,8 @@ void *cli_realloc2(void *ptr, size_t size)
     void *alloc;
 
     if (!size || size > CLI_MAX_ALLOCATION) {
-        cli_warnmsg("cli_realloc2(): File or section is too large to scan (%zu bytes). \
-                     For your safety, ClamAV limits how much memory an operation can allocate to %zu bytes\n",
+        cli_warnmsg("cli_realloc2(): File or section is too large to scan (%zu bytes). "
+                    "For your safety, ClamAV limits how much memory an operation can allocate to %zu bytes\n",
                     size, CLI_MAX_ALLOCATION);
         return NULL;
     }

--- a/libclamav/regex_list.c
+++ b/libclamav/regex_list.c
@@ -817,8 +817,11 @@ static cl_error_t add_pattern_suffix(void *cbdata, const char *suffix, size_t su
 
         if (CL_SUCCESS != ret) {
             cli_hashtab_delete(&matcher->suffix_hash, suffix, suffix_len);
-            /*shrink the size back to what it was.*/
-            CLI_REALLOC(matcher->suffix_regexes, n * sizeof(*matcher->suffix_regexes));
+            /* shrink the size back to what it was.
+               unless n == 0, because we don't want to realloc to zero. */
+            if (n > 0) {
+                CLI_REALLOC(matcher->suffix_regexes, n * sizeof(*matcher->suffix_regexes));
+            }
         } else {
             matcher->suffix_cnt++;
         }


### PR DESCRIPTION
- Fix error when loading some WDB databases

  An error occurs when loading the WDB database with this line:

    X:urldefense\.com:.+

  This happens because it goes to add a new suffix for the second domain
  but there is nothing there, so it attempts to undo by shrinking the
  suffix list back to original size. The suffix list in this case goes
  back to zero, and our custom CLI_REALLOC function balks at reallocing to
  zero.

  I think the correct solution is to not free if it goes to zero, just in
  case it is dereferenced later. It at least doesn't leak, so this is a
  safe solution.
    
- Fix formatting for memory allocation warning messages

  The indentation shows up in the message, which is not desired.

Fixes: https://github.com/Cisco-Talos/clamav/issues/771