### PR TITLE
Increment libclamav SO version (11.0.0 instead of 9.2.0)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ HexVersion(PACKAGE_VERSION_NUM ${PROJECT_VERSION_MAJOR} ${PROJECT_VERSION_MINOR}
 # libtool library versioning rules: http://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html
 set(LIBCLAMAV_CURRENT  11)
 set(LIBCLAMAV_REVISION 0)
-set(LIBCLAMAV_AGE      2)
+set(LIBCLAMAV_AGE      0)
 
 math(EXPR LIBCLAMAV_SOVERSION "${LIBCLAMAV_CURRENT} - ${LIBCLAMAV_AGE}")
 set(LIBCLAMAV_VERSION "${LIBCLAMAV_SOVERSION}.${LIBCLAMAV_AGE}.${LIBCLAMAV_REVISION}")


### PR DESCRIPTION
The libclamav SO ABI has changed since 0.103 due to:
- Removal of the CLAMAV_PUBLIC namespace by no longer using libclamav.map
- Change of: extern const char *cl_strerror(int clerror); To: extern const char *cl_strerror(cl_error_t clerror); See: https://github.com/micahsnyder/clamav-micah/blob/e66c00f41c9b620a0f2ef67ae359c07049ace52f/libclamav/clamav.h#L1203
- Introduction of Rust symbols to namespace.

Ref: https://github.com/Cisco-Talos/clamav/issues/775

As such, it seems fair to increase the SO version. This is an amendment to this prior change for the ClamAV 1.0.0 version bump:
https://github.com/cisco-Talos/clamav/commit/0dd6ab3f16039e67b53ce609a0f04a6c6b75e3f9

Instead of incrementing SO Current version to 11, and Age to 2, we'll increment SO Current version to 11, and reset Age to 0.

So the SO version will effectively go from:
  9.1.0
to:
  11.0.0