### PR TITLE
Clam-2111 Part 1: Fix possible crash with bugged bytecode signature

### DIFF
--- a/libclamav/c++/bytecode2llvm.cpp
+++ b/libclamav/c++/bytecode2llvm.cpp
@@ -986,12 +986,19 @@ class LLVMCodegen
             Value *idxs[1] = {
                 ConstantInt::get(Type::getInt64Ty(Context), components[c++])};
             unsigned idx = components[c++];
-            if (!idx)
+            if (!idx) {
                 return ConstantPointerNull::get(PTy);
+            }
+            if (idx >= globals.size()) {
+                return ConstantPointerNull::get(PTy);
+            }
             assert(idx < globals.size());
-            GlobalVariable *GV = cast<GlobalVariable>(globals[idx]);
-            Type *IP8Ty        = PointerType::getUnqual(Type::getInt8Ty(Ty->getContext()));
-            Constant *C        = ConstantExpr::getPointerCast(GV, IP8Ty);
+            GlobalVariable *GV = dyn_cast<GlobalVariable>(globals[idx]);
+            if (nullptr == GV) {
+                return ConstantPointerNull::get(PTy);
+            }
+            Type *IP8Ty = PointerType::getUnqual(Type::getInt8Ty(Ty->getContext()));
+            Constant *C = ConstantExpr::getPointerCast(GV, IP8Ty);
             // TODO: check constant bounds here
             return ConstantExpr::getPointerCast(
                 ConstantExpr::getInBoundsGetElementPtr(C->getType(), C, idxs),


### PR DESCRIPTION
The bytecode compiler has a bug that was observed to cause a crash with a specific signature when testing on FreeBSD.
This PR adds an index size check and a NULL check to prevent this crash in a bugged signature gets through signature QA. 
A separate PR will be put in for the compiler to fix the root issue, there. 