### PR TITLE
CMake: Enable selection of a specific python impl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,20 +223,26 @@ if(ENABLE_TESTS)
     find_package(Libcheck REQUIRED)
 
     # Used to generate the test files and for the application feature test framework
-    find_package(Python3 REQUIRED)
-
-    # First try using pytest from the PATH
-    execute_process(
-        COMMAND pytest --version
-        RESULT_VARIABLE PYTEST_EXIT_CODE
-        ERROR_QUIET OUTPUT_QUIET
-    )
-
-    if(${PYTEST_EXIT_CODE} EQUAL 0)
-        # pytest found in the path.
-        set(PythonTest_COMMAND "pytest;-v")
+    # In distros that support multiple implementations of python it is helpful to specify the impl to use
+    if(DEFINED PYTHON_FIND_VERSION)
+        find_package(Python3 EXACT ${PYTHON_FIND_VERSION} REQUIRED)
     else()
-        # Not in the path, try using: python3 -m pytest
+        find_package(Python3 REQUIRED)
+        # Not requesting a specific python impl; try using pytest from the PATH
+        execute_process(
+            COMMAND pytest --version
+            RESULT_VARIABLE PYTEST_EXIT_CODE
+            ERROR_QUIET OUTPUT_QUIET
+        )
+
+        if(${PYTEST_EXIT_CODE} EQUAL 0)
+            # pytest found in the path.
+            set(PythonTest_COMMAND "pytest;-v")
+        endif()
+    endif()
+
+    if("${PythonTest_COMMAND}" STREQUAL "")
+        # Not in the path or specified a python impl; try using: python3 -m pytest
         execute_process(
             COMMAND ${Python3_EXECUTABLE} -m pytest --version
             RESULT_VARIABLE PYTEST_MODULE_EXIT_CODE

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -89,6 +89,11 @@ For Maintainer-mode only (not recommended):
 - Bison
 - Gperf
 
+On systems with multiple implementations of build-time tools it may be
+desirable to select a specific implementation to use rather than relying on
+CMake's logic. See [Custom CMake Config Options](#custom-cmake-config-options)
+for information on this topic.
+
 ### External Library Dependencies
 
 For installation instructions, see our online documentation:
@@ -502,6 +507,11 @@ The following is a complete list of CMake options unique to configuring ClamAV:
 
 - `SYSTEMD_UNIT_DIR`: Install SystemD service files to a specific directory.
   This will fail the build if SystemD not found.
+
+  _Default: not set_
+
+- `PYTHON_FIND_VER`: Select a specific implementation of Python that will
+  be called during the test phase.
 
   _Default: not set_
 


### PR DESCRIPTION
On distros with multiple python impls it can be useful to select a specific version rather than whatever CMake thinks is appopriate.

This patch enables users to instruct CMake to look for a specific version of python by passing `-DPYTHON_FIND_VER`.