### PR TITLE
Fix printf() argument type mismatch warnings

### DIFF
--- a/libclamav/others_common.c
+++ b/libclamav/others_common.c
@@ -222,7 +222,7 @@ void *cli_malloc(size_t size)
 
     if (!size || size > CLI_MAX_ALLOCATION) {
         cli_warnmsg("cli_malloc(): File or section is too large to scan (%zu bytes). \
-                     For your safety, ClamAV limits how much memory an operation can allocate to %zu bytes\n",
+                     For your safety, ClamAV limits how much memory an operation can allocate to %d bytes\n",
                     size, CLI_MAX_ALLOCATION);
         return NULL;
     }
@@ -243,7 +243,7 @@ void *cli_calloc(size_t nmemb, size_t size)
 
     if (!nmemb || !size || size > CLI_MAX_ALLOCATION || nmemb > CLI_MAX_ALLOCATION || (nmemb * size > CLI_MAX_ALLOCATION)) {
         cli_warnmsg("cli_calloc2(): File or section is too large to scan (%zu bytes). \
-                     For your safety, ClamAV limits how much memory an operation can allocate to %zu bytes\n",
+                     For your safety, ClamAV limits how much memory an operation can allocate to %d bytes\n",
                     size, CLI_MAX_ALLOCATION);
         return NULL;
     }
@@ -264,7 +264,7 @@ void *cli_realloc(void *ptr, size_t size)
 
     if (!size || size > CLI_MAX_ALLOCATION) {
         cli_warnmsg("cli_realloc(): File or section is too large to scan (%zu bytes). \
-                     For your safety, ClamAV limits how much memory an operation can allocate to %zu bytes\n",
+                     For your safety, ClamAV limits how much memory an operation can allocate to %d bytes\n",
                     size, CLI_MAX_ALLOCATION);
         return NULL;
     }
@@ -285,7 +285,7 @@ void *cli_realloc2(void *ptr, size_t size)
 
     if (!size || size > CLI_MAX_ALLOCATION) {
         cli_warnmsg("cli_realloc2(): File or section is too large to scan (%zu bytes). \
-                     For your safety, ClamAV limits how much memory an operation can allocate to %zu bytes\n",
+                     For your safety, ClamAV limits how much memory an operation can allocate to %d bytes\n",
                     size, CLI_MAX_ALLOCATION);
         return NULL;
     }


### PR DESCRIPTION
"format ‘%zu’ expects argument of type ‘size_t’, but argument 3 has type ‘int’ [-Wformat=]"