### PR TITLE
Avoid altering signature for .cargo/vendor files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,6 +9,9 @@
 # Files that should be left untouched (binary is macro for -text -diff)
 *.ref           binary
 
+# Preserve signature for .cargo/vendor files (from the tarabll)
++/.cargo/vendor binary
+
 #
 # Exclude files from exporting
 #


### PR DESCRIPTION
When using the content of the `clamav` tarball in a git repository to version a debian or RedHat package for example. We should never alter the files from cargo or this result in corrupted signature and thus we cannot install the files.

As the repo provides its own `.gitattributes` we cannot easily overwrite it without manually updating `.git/info/attributes`.

Alternatively we could remove the `.gitattributes` file from the tarball when generating it.