### PR TITLE
Allow to use system's tomsfastmath library instead of the bundled one.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -466,6 +466,11 @@ if(ZLIB_FOUND)
     set(HAVE_LIBZ 1)
 endif()
 
+find_package(TOMSFASTMATH REQUIRED)
+if(TOMSFASTMATH_FOUND)
+   set(HAVE_TFM_H 1)
+endif()
+
 find_package(BZip2 REQUIRED)
 if(BZIP2_FOUND)
     set(HAVE_BZLIB_H 1)
@@ -1211,6 +1216,16 @@ ${_}                            ${e}${OPENSSL_LIBRARIES}
 ${b}        JSON support:       ${e}
 ${_}            json-c          ${e}${JSONC_INCLUDE_DIRS}
 ${_}                            ${e}${JSONC_LIBRARIES}
+${b}        Math support:       ${e}")
+if(TOMSFASTMATH_BUILTIN)
+message("\
+${_}            tomsfastmath    ${e}built-in")
+else()
+message("\
+${_}            tomsfastmath    ${e}${TOMSFASTMATH_INCLUDE_DIR}
+${_}                            ${e}${TOMSFASTMATH_LIBRARY}")
+endif()
+message("\
 ${b}        Threading support:  ${e}")
 if(WIN32)
 message("\

--- a/CMakeOptions.cmake
+++ b/CMakeOptions.cmake
@@ -116,6 +116,9 @@ option(ENABLE_SYSTEMD
     "Install systemd service files if systemd is found."
     ${ENABLE_SYSTEMD_DEFAULT})
 
+option(ENABLE_EXTERNAL_TOMSFASTMATH
+    "Use system's tomsfastmath instead of internal bundled version.")
+
 # For reference determining target platform:
 #  Rust Targets:  https://doc.rust-lang.org/nightly/rustc/platform-support.html
 option(RUST_COMPILER_TARGET

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -120,6 +120,7 @@ libclamav requires these library dependencies:
 - `json-c`
 - `libjson-c` / `json-c`
 - `libmspack` (built-in by default, enable with `ENABLE_EXTERNAL_MSPACK=ON`)
+- `tomsfastmath` (built-in by default, enable with `ENABLE_EXTERNAL_TOMsFASTMATH=ON`)
 - `libiconv` (built-in to `libc` 99% of the time, not requires on Windows)
 - `pthreads` (provided by Linux/Unix; requires `pthreads-win32` on Windows)
 - `llvm` (optional, see: [Bytecode Runtime](#bytecode-runtime), below)
@@ -422,6 +423,11 @@ The following is a complete list of CMake options unique to configuring ClamAV:
   _Default: `OFF`_
 
 - `ENABLE_EXTERNAL_MSPACK`: Use external mspack instead of internal libclammspack.
+
+  _Default: `OFF`_
+
+- `ENABLE_EXTERNAL_TOMsFASTMATH`: Use external tomsfastmath instead of internal.
+   The `pkg-config tomsfastmath` is used to determine additional options.
 
   _Default: `OFF`_
 

--- a/cmake/FindTOMSFASTMATH.cmake
+++ b/cmake/FindTOMSFASTMATH.cmake
@@ -1,0 +1,85 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+#[=======================================================================[.rst:
+FindTOMSFASTMATH
+-------
+
+Finds the TOMSFASTMATH library.
+
+Imported Targets
+^^^^^^^^^^^^^^^^
+
+This module provides the following imported targets, if found:
+
+``TOMSFASTMATH::tfm``
+The TOMSFASTMATH library
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This will define the following variables:
+
+``TOMSFASTMATH_FOUND``
+True if the system has the TOMSFASTMATH library.
+``TOMSFASTMATH_VERSION``
+The version of the TOMSFASTMATH library which was found.
+``TOMSFASTMATH_INCLUDE_DIRS``
+Include directories needed to use TOMSFASTMATH.
+``TOMSFASTMATH_LIBRARIES``
+Libraries needed to link to TOMSFASTMATH.
+
+Cache Variables
+^^^^^^^^^^^^^^^
+
+The following cache variables may also be set:
+
+``TOMSFASTMATH_INCLUDE_DIR``
+  The directory containing ``tfm.h``.
+  ``TOMSFASTMATH_LIBRARY``
+  The path to the TOMSFASTMATH library.
+
+#]=======================================================================]
+
+if(NOT ENABLE_EXTERNAL_TOMSFASTMATH)
+     set(TOMSFASTMATH_LIB_NAME "tomsfastmath")
+     set(TOMSFASTMATH_BUILTIN 1)
+else()
+     set(TOMSFASTMATH_LIB_NAME "tfm")
+     add_definitions(-DHAVE_SYSTEM_TOMSFASTMATH)
+
+find_package(PkgConfig QUIET)
+pkg_check_modules(PC_TOMSFASTMATH QUIET tomsfastmath)
+
+find_path(TOMSFASTMATH_INCLUDE_DIR
+  NAMES tfm.h
+  PATHS ${PC_TOMSFASTMATH_INCLUDE_DIRS}
+  PATH_SUFFIXES tfm
+)
+find_library(TOMSFASTMATH_LIBRARY
+  NAMES tfm
+  PATHS ${PC_TOMSFASTMATH_LIBRARY_DIRS}
+)
+
+set(TOMSFASTMATH_VERSION ${PC_TOMSFASTMATH_VERSION})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(TOMSFASTMATH
+	FOUND_VAR TOMSFASTMATH_FOUND
+  REQUIRED_VARS
+  TOMSFASTMATH_LIBRARY
+  TOMSFASTMATH_INCLUDE_DIR
+  VERSION_VAR TOMSFASTMATH_VERSION
+)
+
+if(TOMSFASTMATH_FOUND)
+	set(TOMSFASTMATH_LIBRARIES ${TOMSFASTMATH_LIBRARY})
+	set(TOMSFASTMATH_INCLUDE_DIRS ${TOMSFASTMATH_INCLUDE_DIR})
+	set(TOMSFASTMATH_DEFINITIONS ${PC_TOMSFASTMATH_CFLAGS_OTHER})
+endif()
+
+mark_as_advanced(
+	TOMSFASTMATH_INCLUDE_DIR
+	TOMSFASTMATH_LIBRARY
+)
+endif()

--- a/libclamav/CMakeLists.txt
+++ b/libclamav/CMakeLists.txt
@@ -3,6 +3,7 @@
 include_directories(
     ${LIBXML2_INCLUDE_DIR}
     ${OPENSSL_INCLUDE_DIR}
+    ${TOMSFASTMATH_INCLUDE_DIR}
     ${ZLIB_INCLUDE_DIR}
     ${CMAKE_CURRENT_BINARY_DIR}
     $<TARGET_PROPERTY:ClamAV::libunrar_iface_iface,INTERFACE_INCLUDE_DIRECTORIES>
@@ -166,6 +167,7 @@ target_link_libraries( yara
         PCRE2::pcre2
         JSONC::jsonc )
 
+if(TOMSFASTMATH_BUILTIN)
 add_library( tomsfastmath OBJECT )
 target_sources( tomsfastmath
     PRIVATE
@@ -259,6 +261,7 @@ target_include_directories( tomsfastmath
     PUBLIC  ${CMAKE_CURRENT_SOURCE_DIR} )
 set_target_properties( tomsfastmath PROPERTIES
     COMPILE_FLAGS "${WARNCFLAGS}" )
+endif()
 
 # Bytecode Runtime
 add_library( bytecode_runtime OBJECT )
@@ -525,7 +528,7 @@ if(ENABLE_SHARED_LIB)
             regex
             lzma_sdk
             yara
-            tomsfastmath
+	    ${TOMSFASTMATH_LIB_NAME}
             bytecode_runtime
             ${LIBMSPACK}
             ClamAV::libclamav_rust
@@ -635,7 +638,7 @@ if(ENABLE_STATIC_LIB)
             regex
             lzma_sdk
             yara
-            tomsfastmath
+	    ${TOMSFASTMATH_LIB_NAME}
             bytecode_runtime
             ${LIBMSPACK}
             ClamAV::libclamav_rust

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -49,7 +49,7 @@ if(ENABLE_APP)
         PRIVATE
             ClamAV::libclamav
             libcheck::check
-            tomsfastmath
+	    ${TOMSFASTMATH_LIB_NAME}
             JSONC::jsonc
             ${LIBMSPACK}
             OpenSSL::SSL
@@ -85,7 +85,7 @@ if(ENABLE_APP)
             ClamAV::libclamav
             ClamAV::common
             libcheck::check
-            tomsfastmath
+	    ${TOMSFASTMATH_LIB_NAME}
             JSONC::jsonc
             ${LIBMSPACK}
             OpenSSL::SSL
@@ -133,7 +133,7 @@ target_link_libraries(check_clamav
     PRIVATE
         ClamAV::libclamav
         libcheck::check
-        tomsfastmath
+	${TOMSFASTMATH_LIB_NAME}
         JSONC::jsonc
         ${LIBMSPACK}
         OpenSSL::SSL


### PR DESCRIPTION
By default the bundled tomsfastmath library is used. It can be overriden to use the library from the system if available. Should the system library only be able to handle RSA keys up to 2048 bits then the selftest will fail.

Signed-off-by: Sebastian Andrzej Siewior <sebastian@breakpoint.cc>