### PR TITLE
libclamav/pe: Use endian wrapper in more places.

### DIFF
--- a/libclamav/matcher.c
+++ b/libclamav/matcher.c
@@ -766,7 +766,7 @@ int32_t cli_bcapi_matchicon(struct cli_bc_ctx *ctx, const uint8_t *grp1, int32_t
             !ctx->hooks.pedata->dirs[2].Size)
             info.res_addr = 0;
         else
-            info.res_addr = le32_to_host(ctx->hooks.pedata->dirs[2].VirtualAddress);
+            info.res_addr = ctx->hooks.pedata->dirs[2].VirtualAddress;
     } else
         info.res_addr = ctx->resaddr; /* from target_info */
     info.sections  = (struct cli_exe_section *)ctx->sections;


### PR DESCRIPTION
A few user of VirtualAddress and Size in cli_exe_info::pe_image_data_dir don't use the endian wrapper while other places do. This leads to testsuite failures on big endian machines.

Use the endian wrapper in all places across pe.c for the two members.

Signed-off-by: Sebastian Andrzej Siewior <sebastian@breakpoint.cc>