### PR TITLE
Add an option to avoid setting RPATH on unix systems.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,13 +174,13 @@ endif()
 #
 # Set RPATH for custom install prefixes
 #
-if(APPLE)
+if(APPLE AND NOT DO_NOT_SET_RPATH)
     set(CMAKE_MACOSX_RPATH 1)
 endif()
 
 include(GNUInstallDirs)
 
-if (NOT DEFINED CMAKE_INSTALL_RPATH)
+if (NOT DEFINED CMAKE_INSTALL_RPATH AND NOT DO_NOT_SET_RPATH)
     if(CMAKE_INSTALL_FULL_LIBDIR)
         set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_FULL_LIBDIR}")
     else()

--- a/CMakeOptions.cmake
+++ b/CMakeOptions.cmake
@@ -122,4 +122,4 @@ option(RUST_COMPILER_TARGET
     "Use a custom target triple to build the Rust components. Needed for cross-compiling.")
 
 option(DO_NOT_SET_RPATH
-	"Don't set the RPATH on UNIX systems.")
+    "Don't set the RPATH on UNIX systems.")

--- a/CMakeOptions.cmake
+++ b/CMakeOptions.cmake
@@ -120,3 +120,6 @@ option(ENABLE_SYSTEMD
 #  Rust Targets:  https://doc.rust-lang.org/nightly/rustc/platform-support.html
 option(RUST_COMPILER_TARGET
     "Use a custom target triple to build the Rust components. Needed for cross-compiling.")
+
+option(DO_NOT_SET_RPATH
+	"Don't set the RPATH on UNIX systems.")

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -401,6 +401,8 @@ The following is a complete list of CMake options unique to configuring ClamAV:
   paths set at build time instead of using system defaults. By setting this
   `ON` system defaults are used.
 
+  _Default: `OFF`_
+
 - `ENABLE_WERROR`: Compile time warnings will cause build failures (i.e.
   `-Werror`)
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -397,6 +397,10 @@ The following is a complete list of CMake options unique to configuring ClamAV:
 
   _Default: `ON`_
 
+- `DO_NOT_SET_RPATH`: By default RPATH is set in executeables resulting using
+  paths set at build time instead of using system defaults. By setting this
+  `ON` system defaults are used.
+
 - `ENABLE_WERROR`: Compile time warnings will cause build failures (i.e.
   `-Werror`)
 


### PR DESCRIPTION
RPATH overrides the normal library search path, possibly interfering with local policy and causing problems for multilib, among other issues.

Add an option to avoid setting it with letting it enabled by default.

Signed-off-by: Sebastian Andrzej Siewior <sebastian@breakpoint.cc>