### PR TITLE
Add a version script for libclamunrar and libclamunrar_iface.

### DIFF
--- a/libclamunrar/CMakeLists.txt
+++ b/libclamunrar/CMakeLists.txt
@@ -70,7 +70,8 @@ if(ENABLE_SHARED_LIB)
     add_library( clamunrar SHARED )
     set_target_properties(clamunrar PROPERTIES
         VERSION ${LIBCLAMAV_VERSION}
-        SOVERSION ${LIBCLAMAV_SOVERSION})
+        SOVERSION ${LIBCLAMAV_SOVERSION}
+        LINK_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/libclamunrar.map)
     target_sources( clamunrar
         PRIVATE
             ${UNRAR_SOURCES}
@@ -95,6 +96,9 @@ if(ENABLE_SHARED_LIB)
 
     if(WIN32)
         set_target_properties(clamunrar PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
+    elseif(UNIX AND NOT APPLE)
+        set_target_properties(clamunrar PROPERTIES LINK_FLAGS
+                   "-Wl,--version-script='${CMAKE_CURRENT_SOURCE_DIR}/libclamunrar.map'")
     endif()
 
     if(WIN32)

--- a/libclamunrar_iface/CMakeLists.txt
+++ b/libclamunrar_iface/CMakeLists.txt
@@ -36,7 +36,8 @@ if(ENABLE_UNRAR)
         add_library( clamunrar_iface SHARED )
         set_target_properties(clamunrar_iface PROPERTIES
             VERSION ${LIBCLAMAV_VERSION}
-            SOVERSION ${LIBCLAMAV_SOVERSION})
+            SOVERSION ${LIBCLAMAV_SOVERSION}
+            LINK_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/libclamunrar_iface.map)
 
         target_sources( clamunrar_iface
             PRIVATE
@@ -62,6 +63,9 @@ if(ENABLE_UNRAR)
 
         if(WIN32)
             set_target_properties(clamunrar_iface PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
+        elseif(UNIX AND NOT APPLE)
+            set_target_properties(clamunrar_iface PROPERTIES LINK_FLAGS
+                 "-Wl,--version-script='${CMAKE_CURRENT_SOURCE_DIR}/libclamunrar_iface.map'")
         endif()
 
         # Private (internal-only) dependencies.


### PR DESCRIPTION
Without a version script all symbols will be exported which are public within the libclamunrar* libraries. This is true for the officially exported symbols as well as all the public symbols which are used within libraries and are not inteded for export.

There is already a .map preset to limit the exported symbols of libclamunrar and libclamunrar_iface. Use it.

Signed-off-by: Sebastian Andrzej Siewior <sebastian@breakpoint.cc>