### PR TITLE
Fix allmatch issue with preclass bytecode (1.0.1)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,9 @@ differ slightly from third-party binary packages.
 
 ClamAV 1.0.1 is a critical patch release with the following fixes:
 
+- Fix allmatch detection issue with the preclass bytecode hook.
+  - GitHub pull request: https://github.com/Cisco-Talos/clamav/pull/825
+
 ## 1.0.0
 
 ClamAV 1.0.0 includes the following improvements and changes.


### PR DESCRIPTION
The verdict is being recorded before the preclass bytecode hook meaning that the final verdict may come back as "clean" in allmatch mode, even if the preclass bytecode hook matches something.

This commit moves the verdict check to occur AFTER the preclass bytecode hook executes.

---

This is a backport of https://github.com/Cisco-Talos/clamav/pull/823