### PR TITLE
gitattributes cargo vendor (1.0.2)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,6 +9,9 @@
 # Files that should be left untouched (binary is macro for -text -diff)
 *.ref           binary
 
+# Preserve signature for .cargo/vendor files (from the tarabll)
++/.cargo/vendor binary
+
 #
 # Exclude files from exporting
 #


### PR DESCRIPTION
Backport of https://github.com/Cisco-Talos/clamav/pull/800 for 1.0 LTS. 

Thanks @atoomic, @toddr 