### PR TITLE
unit_tests/freshclam_test.py: fix unit test

### DIFF
--- a/unit_tests/freshclam_test.py
+++ b/unit_tests/freshclam_test.py
@@ -671,7 +671,7 @@ class TC(testcase.TestCase):
         assert output.ec == 0  # success
 
         expected_stdout = [
-            'already up-to-date',
+            'database is up-to-date',
         ]
         unexpected_results = [
             'test.cld updated \\(version: 6',


### PR DESCRIPTION
Somehow the tests returns a different result than expected. Not sure if the expected result should be changed (this patch) or that the message emitted by freshclam should be changed.