### PR TITLE
Don't set parent's "don't cache" to match child

### DIFF
--- a/libclamav/matcher.c
+++ b/libclamav/matcher.c
@@ -803,10 +803,6 @@ cl_error_t cli_scan_desc(int desc, cli_ctx *ctx, cli_file_t ftype, bool filetype
 
     status = cli_scan_fmap(ctx, ftype, filetype_only, ftoffset, acmode, acres, NULL);
 
-    map->dont_cache_flag = ctx->fmap->dont_cache_flag; /* Set the parent layer's "don't cache" flag to match the child.
-                                                          TODO: This may not be needed since `emax_reached()` should've
-                                                          already done that for us. */
-
     (void)cli_recursion_stack_pop(ctx); /* Restore the parent fmap */
 
 done:


### PR DESCRIPTION
Don't set the parent layer's "don't cache" flag to match the child.

`emax_reached()` already does the same thing so doing it again is unnecessary.

See https://github.com/Cisco-Talos/clamav/commit/db013a2bfda869072f72f22441e9be21c08580f7 to see when the code that this commit removes was added.