### PR TITLE
Jenkins: Moving appcheck-pipeline to daily triggers

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,9 +39,6 @@ properties(
                 string(name: 'FUZZ_CORPUS_BRANCH',
                        defaultValue: 'master',
                        description: 'private-fuzz-corpus branch'),
-                string(name: 'APPCHECK_PIPELINE',
-                       defaultValue: 'appcheck-1.1',
-                       description: 'test-pipelines branch for appcheck'),
                 string(name: 'SHARED_LIB_BRANCH',
                        defaultValue: 'master',
                        description: 'tests-jenkins-shared-libraries branch')
@@ -160,23 +157,6 @@ node('master') {
                     ]
                 )
                 echo "test-pipelines/${params.FUZZ_PIPELINE} #${fuzzResult.number} succeeded."
-            }
-        }
-
-        tasks["appcheck"] = {
-            stage("AppCheck") {
-                final appcheckResult = build(job: "test-pipelines/${params.APPCHECK_PIPELINE}",
-                    propagate: true,
-                    wait: true,
-                    parameters: [
-                        [$class: 'StringParameterValue', name: 'CLAMAV_JOB_NAME', value: "${JOB_NAME}"],
-                        [$class: 'StringParameterValue', name: 'CLAMAV_JOB_NUMBER', value: "${BUILD_NUMBER}"],
-                        [$class: 'StringParameterValue', name: 'BUILD_JOB_NAME', value: "test-pipelines/${params.BUILD_PIPELINE}"],
-                        [$class: 'StringParameterValue', name: 'BUILD_JOB_NUMBER', value: "${buildResult.number}"],
-                        [$class: 'StringParameterValue', name: 'VERSION', value: "${params.VERSION}"]
-                    ]
-                )
-                echo "test-pipelines/${params.APPCHECK_PIPELINE} #${appcheckResult.number} succeeded."
             }
         }
 


### PR DESCRIPTION
We are moving our appcheck pipeline from ClamAV project and instead will trigger them once a day.
Right now, it triggers with every PR and merges to the main branch.