### PR TITLE
Clam 2269 cdiff unlink

### DIFF
--- a/libclamav_rust/build.rs
+++ b/libclamav_rust/build.rs
@@ -55,7 +55,13 @@ const BINDGEN_FUNCTIONS: &[&str] = &[
 ];
 
 // Generate bindings for these types (structs, enums):
-const BINDGEN_TYPES: &[&str] = &["cli_matcher", "cli_ac_data", "cli_ac_result", "css_image_extractor_t", "css_image_handle_t"];
+const BINDGEN_TYPES: &[&str] = &[
+    "cli_matcher",
+    "cli_ac_data",
+    "cli_ac_result",
+    "css_image_extractor_t",
+    "css_image_handle_t",
+];
 
 // Find the required functions and types in these headers:
 const BINDGEN_HEADERS: &[&str] = &[
@@ -186,7 +192,7 @@ fn detect_clamav_build() -> Result<(), &'static str> {
 
         // LLVM is optional, and don't have a path to each library like we do with the other libs.
         let llvm_libs = env::var("LLVM_LIBS").unwrap_or("".into());
-        if llvm_libs != "" {
+        if !llvm_libs.is_empty() {
             match env::var("LLVM_DIRS") {
                 Err(env::VarError::NotPresent) => eprintln!("LLVM_DIRS not set"),
                 Err(env::VarError::NotUnicode(_)) => return Err("environment value not unicode"),
@@ -203,7 +209,7 @@ fn detect_clamav_build() -> Result<(), &'static str> {
 
             llvm_libs
                 .split(',')
-                .for_each(|filepath_str| match parse_lib_path(&filepath_str) {
+                .for_each(|filepath_str| match parse_lib_path(filepath_str) {
                     Ok(parsed_path) => {
                         println!("cargo:rustc-link-search={}", parsed_path.dir);
                         eprintln!("  - requesting that rustc link {:?}", &parsed_path.libname);
@@ -282,7 +288,7 @@ struct ParsedLibraryPath {
 
 // Parse a library path, returning the portion expected after the `-l`, and the
 // directory containing the library
-fn parse_lib_path<'a>(path: &'a str) -> Result<ParsedLibraryPath, &'static str> {
+fn parse_lib_path(path: &str) -> Result<ParsedLibraryPath, &'static str> {
     let path = PathBuf::from(path);
     let file_name = path
         .file_name()

--- a/libclamav_rust/src/cdiff.rs
+++ b/libclamav_rust/src/cdiff.rs
@@ -477,7 +477,7 @@ pub fn script2cdiff(script_file_name: &str, builder: &str, server: &str) -> Resu
         .map_err(|e| CdiffError::FileCreate(cdiff_file_name.to_owned(), e))?;
 
     // Open the original script file for reading
-    let script_file: File = File::open(&script_file_name)
+    let script_file: File = File::open(script_file_name)
         .map_err(|e| CdiffError::FileOpen(script_file_name.to_owned(), e))?;
 
     // Get file length
@@ -599,7 +599,7 @@ pub fn cdiff_apply(file: &mut File, mode: ApplyMode) -> Result<(), CdiffError> {
             let dsig = read_dsig(file)?;
             debug!("cdiff_apply() - final dsig length is {}", dsig.len());
             if is_debug_enabled() {
-                print_file_data(dsig.clone(), dsig.len() as usize);
+                print_file_data(dsig.clone(), dsig.len());
             }
 
             // Get file length
@@ -1022,7 +1022,7 @@ where
             0 => break,
             n_read => {
                 decompressed_bytes = decompressed_bytes + n_read + 1;
-                match linebuf.get(0) {
+                match linebuf.first() {
                     // Skip comment lines
                     Some(b'#') => continue,
                     _ => process_line(ctx, &linebuf).map_err(|e| CdiffError::Input(line_no, e))?,
@@ -1071,7 +1071,7 @@ fn read_dsig(file: &mut File) -> Result<Vec<u8>, SignatureError> {
 // as the offset in the file that the header ends.
 fn read_size(file: &mut File) -> Result<(u32, usize), HeaderError> {
     // Seek to beginning of file.
-    file.seek(SeekFrom::Start(0))?;
+    file.rewind()?;
 
     // File should always start with "ClamAV-Diff".
     let prefix = b"ClamAV-Diff";
@@ -1116,7 +1116,7 @@ fn get_hash(file: &mut File, len: usize) -> Result<[u8; 32], CdiffError> {
     let mut hasher = Sha256::new();
 
     // Seek to beginning of file
-    file.seek(SeekFrom::Start(0))?;
+    file.rewind()?;
 
     let mut sum: usize = 0;
 

--- a/libclamav_rust/src/css_image_extract.rs
+++ b/libclamav_rust/src/css_image_extract.rs
@@ -22,7 +22,7 @@
 
 use std::{ffi::CStr, mem::ManuallyDrop, os::raw::c_char};
 
-use base64::{Engine as _, engine::general_purpose as base64_engine_standard};
+use base64::{engine::general_purpose as base64_engine_standard, Engine as _};
 use log::{debug, error, warn};
 use thiserror::Error;
 
@@ -194,7 +194,7 @@ impl<'a> CssImageExtractor<'a> {
             // So we'll just skip until after the next ';'.
 
             // Find contents after ";"
-            if let Some(pos) = url_parameter.find(";") {
+            if let Some(pos) = url_parameter.find(';') {
                 (_, url_parameter) = url_parameter.split_at(pos + ";".len());
                 // Found ";"
             } else {
@@ -267,7 +267,7 @@ impl<'a> Iterator for CssImageExtractor<'a> {
             // Decode the base64 encoded image
             base64_engine_standard::STANDARD.decode(base64_image).ok()
         } else {
-            return None;
+            None
         }
     }
 }
@@ -297,9 +297,9 @@ pub unsafe extern "C" fn new_css_image_extractor(
     };
 
     if let Ok(extractor) = CssImageExtractor::new(css_input) {
-        return Box::into_raw(Box::new(extractor)) as sys::css_image_extractor_t;
+        Box::into_raw(Box::new(extractor)) as sys::css_image_extractor_t
     } else {
-        return 0 as sys::css_image_extractor_t;
+        0 as sys::css_image_extractor_t
     }
 }
 
@@ -334,11 +334,9 @@ pub unsafe extern "C" fn css_image_extract_next(
             *image_out = image.as_ptr();
             *image_out_len = image.len();
             *image_out_handle = Box::into_raw(Box::new(image)) as sys::css_image_handle_t;
-            return true;
+            true
         }
-        None => {
-            return false;
-        }
+        None => false,
     }
 }
 

--- a/libclamav_rust/src/evidence.rs
+++ b/libclamav_rust/src/evidence.rs
@@ -70,7 +70,7 @@ pub struct IndicatorMeta {
 /// Initialize a match vector
 #[no_mangle]
 pub extern "C" fn evidence_new() -> sys::evidence_t {
-    Box::into_raw(Box::new(Evidence::default())) as sys::evidence_t
+    Box::into_raw(Box::<Evidence>::default()) as sys::evidence_t
 }
 
 /// Free the evidence
@@ -147,7 +147,7 @@ pub unsafe extern "C" fn _evidence_get_indicator(
                 return meta.last().unwrap().static_virname as *const c_char;
             } else {
                 // no alert at that index. return NULL
-                return std::ptr::null();
+                std::ptr::null()
             }
         }
         IndicatorType::PotentiallyUnwanted => {
@@ -155,7 +155,7 @@ pub unsafe extern "C" fn _evidence_get_indicator(
                 return meta.last().unwrap().static_virname as *const c_char;
             } else {
                 // no alert at that index. return NULL
-                return std::ptr::null();
+                std::ptr::null()
             }
         }
     }

--- a/libclamav_rust/src/fuzzy_hash.rs
+++ b/libclamav_rust/src/fuzzy_hash.rs
@@ -123,7 +123,7 @@ pub struct FuzzyHashMeta {
 /// Initialize the hashmap
 #[no_mangle]
 pub extern "C" fn fuzzy_hashmap_new() -> sys::fuzzyhashmap_t {
-    Box::into_raw(Box::new(FuzzyHashMap::default())) as sys::fuzzyhashmap_t
+    Box::into_raw(Box::<FuzzyHashMap>::default()) as sys::fuzzyhashmap_t
 }
 
 /// Free the hashmap

--- a/libclamav_rust/src/logging.rs
+++ b/libclamav_rust/src/logging.rs
@@ -88,8 +88,12 @@ mod tests {
 /// API exported for C code to log to standard error using Rust.
 /// This would be be an alternative to fputs, and reliably prints
 /// non-ASCII UTF8 characters on Windows, where fputs does not.
+///
+/// # Safety
+///
+/// This function dereferences the c_buff raw pointer. Pointer must be valid.
 #[no_mangle]
-pub extern "C" fn clrs_eprint(c_buf: *const c_char) -> () {
+pub unsafe extern "C" fn clrs_eprint(c_buf: *const c_char) {
     if c_buf.is_null() {
         return;
     }


### PR DESCRIPTION
Fix issue applying cdiffs that unlink a file (e.g. dropping a CBC signature from bytecode.cvd). 
Also some minor code cleanup to resolve linter errors. 