### PR TITLE
Clam 2269 & 2271: CDIFF: unlink, close issues. Freshclam: download whole CVD if failure applying CDIFF

### DIFF
--- a/libclamav_rust/build.rs
+++ b/libclamav_rust/build.rs
@@ -55,7 +55,13 @@ const BINDGEN_FUNCTIONS: &[&str] = &[
 ];
 
 // Generate bindings for these types (structs, enums):
-const BINDGEN_TYPES: &[&str] = &["cli_matcher", "cli_ac_data", "cli_ac_result", "css_image_extractor_t", "css_image_handle_t"];
+const BINDGEN_TYPES: &[&str] = &[
+    "cli_matcher",
+    "cli_ac_data",
+    "cli_ac_result",
+    "css_image_extractor_t",
+    "css_image_handle_t",
+];
 
 // Find the required functions and types in these headers:
 const BINDGEN_HEADERS: &[&str] = &[
@@ -186,7 +192,7 @@ fn detect_clamav_build() -> Result<(), &'static str> {
 
         // LLVM is optional, and don't have a path to each library like we do with the other libs.
         let llvm_libs = env::var("LLVM_LIBS").unwrap_or("".into());
-        if llvm_libs != "" {
+        if !llvm_libs.is_empty() {
             match env::var("LLVM_DIRS") {
                 Err(env::VarError::NotPresent) => eprintln!("LLVM_DIRS not set"),
                 Err(env::VarError::NotUnicode(_)) => return Err("environment value not unicode"),
@@ -203,7 +209,7 @@ fn detect_clamav_build() -> Result<(), &'static str> {
 
             llvm_libs
                 .split(',')
-                .for_each(|filepath_str| match parse_lib_path(&filepath_str) {
+                .for_each(|filepath_str| match parse_lib_path(filepath_str) {
                     Ok(parsed_path) => {
                         println!("cargo:rustc-link-search={}", parsed_path.dir);
                         eprintln!("  - requesting that rustc link {:?}", &parsed_path.libname);
@@ -282,7 +288,7 @@ struct ParsedLibraryPath {
 
 // Parse a library path, returning the portion expected after the `-l`, and the
 // directory containing the library
-fn parse_lib_path<'a>(path: &'a str) -> Result<ParsedLibraryPath, &'static str> {
+fn parse_lib_path(path: &str) -> Result<ParsedLibraryPath, &'static str> {
     let path = PathBuf::from(path);
     let file_name = path
         .file_name()

--- a/libclamav_rust/src/cdiff.rs
+++ b/libclamav_rust/src/cdiff.rs
@@ -477,7 +477,7 @@ pub fn script2cdiff(script_file_name: &str, builder: &str, server: &str) -> Resu
         .map_err(|e| CdiffError::FileCreate(cdiff_file_name.to_owned(), e))?;
 
     // Open the original script file for reading
-    let script_file: File = File::open(&script_file_name)
+    let script_file: File = File::open(script_file_name)
         .map_err(|e| CdiffError::FileOpen(script_file_name.to_owned(), e))?;
 
     // Get file length
@@ -599,7 +599,7 @@ pub fn cdiff_apply(file: &mut File, mode: ApplyMode) -> Result<(), CdiffError> {
             let dsig = read_dsig(file)?;
             debug!("cdiff_apply() - final dsig length is {}", dsig.len());
             if is_debug_enabled() {
-                print_file_data(dsig.clone(), dsig.len() as usize);
+                print_file_data(dsig.clone(), dsig.len());
             }
 
             // Get file length
@@ -1022,7 +1022,7 @@ where
             0 => break,
             n_read => {
                 decompressed_bytes = decompressed_bytes + n_read + 1;
-                match linebuf.get(0) {
+                match linebuf.first() {
                     // Skip comment lines
                     Some(b'#') => continue,
                     _ => process_line(ctx, &linebuf).map_err(|e| CdiffError::Input(line_no, e))?,
@@ -1071,7 +1071,7 @@ fn read_dsig(file: &mut File) -> Result<Vec<u8>, SignatureError> {
 // as the offset in the file that the header ends.
 fn read_size(file: &mut File) -> Result<(u32, usize), HeaderError> {
     // Seek to beginning of file.
-    file.seek(SeekFrom::Start(0))?;
+    file.rewind()?;
 
     // File should always start with "ClamAV-Diff".
     let prefix = b"ClamAV-Diff";
@@ -1116,7 +1116,7 @@ fn get_hash(file: &mut File, len: usize) -> Result<[u8; 32], CdiffError> {
     let mut hasher = Sha256::new();
 
     // Seek to beginning of file
-    file.seek(SeekFrom::Start(0))?;
+    file.rewind()?;
 
     let mut sum: usize = 0;
 

--- a/libclamav_rust/src/css_image_extract.rs
+++ b/libclamav_rust/src/css_image_extract.rs
@@ -22,7 +22,7 @@
 
 use std::{ffi::CStr, mem::ManuallyDrop, os::raw::c_char};
 
-use base64::{Engine as _, engine::general_purpose as base64_engine_standard};
+use base64::{engine::general_purpose as base64_engine_standard, Engine as _};
 use log::{debug, error, warn};
 use thiserror::Error;
 
@@ -194,7 +194,7 @@ impl<'a> CssImageExtractor<'a> {
             // So we'll just skip until after the next ';'.
 
             // Find contents after ";"
-            if let Some(pos) = url_parameter.find(";") {
+            if let Some(pos) = url_parameter.find(';') {
                 (_, url_parameter) = url_parameter.split_at(pos + ";".len());
                 // Found ";"
             } else {
@@ -267,7 +267,7 @@ impl<'a> Iterator for CssImageExtractor<'a> {
             // Decode the base64 encoded image
             base64_engine_standard::STANDARD.decode(base64_image).ok()
         } else {
-            return None;
+            None
         }
     }
 }
@@ -297,9 +297,9 @@ pub unsafe extern "C" fn new_css_image_extractor(
     };
 
     if let Ok(extractor) = CssImageExtractor::new(css_input) {
-        return Box::into_raw(Box::new(extractor)) as sys::css_image_extractor_t;
+        Box::into_raw(Box::new(extractor)) as sys::css_image_extractor_t
     } else {
-        return 0 as sys::css_image_extractor_t;
+        0 as sys::css_image_extractor_t
     }
 }
 
@@ -334,11 +334,9 @@ pub unsafe extern "C" fn css_image_extract_next(
             *image_out = image.as_ptr();
             *image_out_len = image.len();
             *image_out_handle = Box::into_raw(Box::new(image)) as sys::css_image_handle_t;
-            return true;
+            true
         }
-        None => {
-            return false;
-        }
+        None => false,
     }
 }
 

--- a/libclamav_rust/src/evidence.rs
+++ b/libclamav_rust/src/evidence.rs
@@ -70,7 +70,7 @@ pub struct IndicatorMeta {
 /// Initialize a match vector
 #[no_mangle]
 pub extern "C" fn evidence_new() -> sys::evidence_t {
-    Box::into_raw(Box::new(Evidence::default())) as sys::evidence_t
+    Box::into_raw(Box::<Evidence>::default()) as sys::evidence_t
 }
 
 /// Free the evidence
@@ -147,7 +147,7 @@ pub unsafe extern "C" fn _evidence_get_indicator(
                 return meta.last().unwrap().static_virname as *const c_char;
             } else {
                 // no alert at that index. return NULL
-                return std::ptr::null();
+                std::ptr::null()
             }
         }
         IndicatorType::PotentiallyUnwanted => {
@@ -155,7 +155,7 @@ pub unsafe extern "C" fn _evidence_get_indicator(
                 return meta.last().unwrap().static_virname as *const c_char;
             } else {
                 // no alert at that index. return NULL
-                return std::ptr::null();
+                std::ptr::null()
             }
         }
     }

--- a/libclamav_rust/src/fuzzy_hash.rs
+++ b/libclamav_rust/src/fuzzy_hash.rs
@@ -123,7 +123,7 @@ pub struct FuzzyHashMeta {
 /// Initialize the hashmap
 #[no_mangle]
 pub extern "C" fn fuzzy_hashmap_new() -> sys::fuzzyhashmap_t {
-    Box::into_raw(Box::new(FuzzyHashMap::default())) as sys::fuzzyhashmap_t
+    Box::into_raw(Box::<FuzzyHashMap>::default()) as sys::fuzzyhashmap_t
 }
 
 /// Free the hashmap

--- a/libclamav_rust/src/logging.rs
+++ b/libclamav_rust/src/logging.rs
@@ -88,8 +88,12 @@ mod tests {
 /// API exported for C code to log to standard error using Rust.
 /// This would be be an alternative to fputs, and reliably prints
 /// non-ASCII UTF8 characters on Windows, where fputs does not.
+///
+/// # Safety
+///
+/// This function dereferences the c_buff raw pointer. Pointer must be valid.
 #[no_mangle]
-pub extern "C" fn clrs_eprint(c_buf: *const c_char) -> () {
+pub unsafe extern "C" fn clrs_eprint(c_buf: *const c_char) {
     if c_buf.is_null() {
         return;
     }

--- a/libfreshclam/dns.c
+++ b/libfreshclam/dns.c
@@ -71,12 +71,12 @@ dnsquery(const char *domain, int qtype, unsigned int *ttl)
         if (qtype == T_TXT)
             qtype = T_ANY;
         if ((len = res_query(domain, C_IN, qtype, answer, PACKETSZ)) < 0) {
-            logg(LOGG_INFO, "%cCan't query %s\n",
-                 (qtype == T_TXT || qtype == T_ANY) ? '^' : '*', domain);
+            logg((qtype == T_TXT || qtype == T_ANY) ? LOGG_WARNING : LOGG_DEBUG, "Can't query %s\n",
+                 domain);
             return NULL;
         }
 #else
-        logg(LOGG_INFO, "%cCan't query %s\n", (qtype == T_TXT) ? '^' : '*', domain);
+        logg((qtype == T_TXT) ? LOGG_WARNING : LOGG_DEBUG, "Can't query %s\n", domain);
         return NULL;
 #endif
     }

--- a/libfreshclam/libfreshclam.c
+++ b/libfreshclam/libfreshclam.c
@@ -56,6 +56,7 @@
 
 // libclamav
 #include "clamav.h"
+#include "clamav_rust.h"
 #include "others.h"
 #include "regex_list.h"
 #include "str.h"
@@ -130,6 +131,12 @@ fc_error_t fc_initialize(fc_config *fcConfig)
     if (NULL == fcConfig) {
         printf("fc_initialize: Invalid arguments.\n");
         return status;
+    }
+
+    /* Rust logging initialization */
+    if (!clrs_log_init()) {
+        cli_dbgmsg("Unexpected problem occurred while setting up rust logging... continuing without rust logging. \
+                    Please submit an issue to https://github.com/Cisco-Talos/clamav");
     }
 
     /* Initilize libcurl */

--- a/libfreshclam/libfreshclam_internal.c
+++ b/libfreshclam/libfreshclam_internal.c
@@ -2351,6 +2351,7 @@ fc_error_t updatedb(
 
         if (
             (FC_EEMPTYFILE == ret) ||                                 /* Request a new CVD if we got an empty CDIFF.      */
+            (FC_EFAILEDUPDATE == ret) ||                              /* Request a new CVD if we failed to apply a CDIFF. */
             (FC_SUCCESS != ret && (                                   /* Or if the incremental update failed:             */
                                    (0 == numPatchesReceived) &&       /* 1. Ask for the CVD if we didn't get any patches, */
                                    (localVersion < remoteVersion - 1) /* 2. AND if we're more than 1 version out of date. */

--- a/libfreshclam/libfreshclam_internal.c
+++ b/libfreshclam/libfreshclam_internal.c
@@ -987,11 +987,11 @@ static fc_error_t remote_cvdhead(
          * show the more generic information from curl_easy_strerror instead.
          */
         size_t len = strlen(errbuf);
-        logg(LOGG_INFO, "%cremote_cvdhead: Download failed (%d) ", logerr ? '!' : '^', curl_ret);
+        logg(logerr ? LOGG_ERROR : LOGG_WARNING, "remote_cvdhead: Download failed (%d) ", curl_ret);
         if (len)
-            logg(LOGG_INFO, "%c Message: %s%s", logerr ? '!' : '^', errbuf, ((errbuf[len - 1] != '\n') ? "\n" : ""));
+            logg(logerr ? LOGG_ERROR : LOGG_WARNING, " Message: %s%s", errbuf, ((errbuf[len - 1] != '\n') ? "\n" : ""));
         else
-            logg(LOGG_INFO, "%c Message: %s\n", logerr ? '!' : '^', curl_easy_strerror(curl_ret));
+            logg(logerr ? LOGG_ERROR : LOGG_WARNING, " Message: %s\n", curl_easy_strerror(curl_ret));
         status = FC_ECONNECTION;
         goto done;
     }
@@ -1057,11 +1057,11 @@ static fc_error_t remote_cvdhead(
         }
         default: {
             if (g_proxyServer)
-                logg(LOGG_INFO, "%cremote_cvdhead: Unexpected response (%li) from %s (Proxy: %s:%u)\n",
-                     logerr ? '!' : '^', http_code, server, g_proxyServer, g_proxyPort);
+                logg(logerr ? LOGG_ERROR : LOGG_WARNING, "remote_cvdhead: Unexpected response (%li) from %s (Proxy: %s:%u)\n",
+                     http_code, server, g_proxyServer, g_proxyPort);
             else
-                logg(LOGG_INFO, "%cremote_cvdhead: Unexpected response (%li) from %s\n",
-                     logerr ? '!' : '^', http_code, server);
+                logg(logerr ? LOGG_ERROR : LOGG_WARNING, "remote_cvdhead: Unexpected response (%li) from %s\n",
+                     http_code, server);
             status = FC_EFAILEDGET;
             goto done;
         }
@@ -1071,7 +1071,7 @@ static fc_error_t remote_cvdhead(
      * Identify start of CVD header in response body.
      */
     if (receivedData.size < CVD_HEADER_SIZE) {
-        logg(LOGG_INFO, "%cremote_cvdhead: Malformed CVD header (too short)\n", logerr ? '!' : '^');
+        logg(logerr ? LOGG_ERROR : LOGG_WARNING, "remote_cvdhead: Malformed CVD header (too short)\n");
         status = FC_EFAILEDGET;
         goto done;
     }
@@ -1087,7 +1087,7 @@ static fc_error_t remote_cvdhead(
             (receivedData.buffer && !*receivedData.buffer) ||
             (receivedData.buffer && !isprint(receivedData.buffer[i]))) {
 
-            logg(LOGG_INFO, "%cremote_cvdhead: Malformed CVD header (bad chars)\n", logerr ? '!' : '^');
+            logg(logerr ? LOGG_ERROR : LOGG_WARNING, "remote_cvdhead: Malformed CVD header (bad chars)\n");
             status = FC_EFAILEDGET;
             goto done;
         }
@@ -1098,7 +1098,7 @@ static fc_error_t remote_cvdhead(
      * Parse CVD info into CVD info struct.
      */
     if (!(cvdhead = cl_cvdparse(head))) {
-        logg(LOGG_INFO, "%cremote_cvdhead: Malformed CVD header (can't parse)\n", logerr ? '!' : '^');
+        logg(logerr ? LOGG_ERROR : LOGG_WARNING, "remote_cvdhead: Malformed CVD header (can't parse)\n");
         status = FC_EFAILEDGET;
         goto done;
     } else {
@@ -1289,17 +1289,18 @@ static fc_error_t downloadFile(
          * show the more generic information from curl_easy_strerror instead.
          */
         size_t len = strlen(errbuf);
-        logg(LOGG_INFO, "%cDownload failed (%d) ", logerr ? '!' : '^', curl_ret);
+        logg(logerr ? LOGG_ERROR : LOGG_WARNING, "Download failed (%d) ", curl_ret);
         if (len)
-            logg(LOGG_INFO, "%c Message: %s%s", logerr ? '!' : '^', errbuf, ((errbuf[len - 1] != '\n') ? "\n" : ""));
+            logg(logerr ? LOGG_ERROR : LOGG_WARNING, " Message: %s%s", errbuf, ((errbuf[len - 1] != '\n') ? "\n" : ""));
         else
-            logg(LOGG_INFO, "%c Message: %s\n", logerr ? '!' : '^', curl_easy_strerror(curl_ret));
+            logg(logerr ? LOGG_ERROR : LOGG_WARNING, " Message: %s\n", curl_easy_strerror(curl_ret));
         status = FC_ECONNECTION;
         goto done;
     }
 
     /* Check HTTP code */
     curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
+    logg(LOGG_WARNING, " ******* RESULT %ld, SIZE: %zu ******* \n", http_code, receivedFile.size);
     switch (http_code) {
         case 200:
         case 206: {
@@ -1363,11 +1364,11 @@ static fc_error_t downloadFile(
         }
         default: {
             if (g_proxyServer)
-                logg(LOGG_INFO, "%cdownloadFile: Unexpected response (%li) from %s (Proxy: %s:%u)\n",
-                     logerr ? '!' : '^', http_code, url, g_proxyServer, g_proxyPort);
+                logg(logerr ? LOGG_ERROR : LOGG_WARNING, "downloadFile: Unexpected response (%li) from %s (Proxy: %s:%u)\n",
+                     http_code, url, g_proxyServer, g_proxyPort);
             else
-                logg(LOGG_INFO, "%cdownloadFile: Unexpected response (%li) from %s\n",
-                     logerr ? '!' : '^', http_code, url);
+                logg(logerr ? LOGG_ERROR : LOGG_WARNING, "downloadFile: Unexpected response (%li) from %s\n",
+                     http_code, url);
             status = FC_EFAILEDGET;
         }
     }
@@ -1426,7 +1427,7 @@ static fc_error_t getcvd(
         status = ret;
         goto done;
     } else if (ret > FC_UPTODATE) {
-        logg(LOGG_INFO, "%cCan't download %s from %s\n", logerr ? '!' : '^', cvdfile, url);
+        logg(logerr ? LOGG_ERROR : LOGG_WARNING, "Can't download %s from %s\n", cvdfile, url);
         status = ret;
         goto done;
     }
@@ -1634,7 +1635,7 @@ static fc_error_t downloadPatch(
         if (ret == FC_EEMPTYFILE) {
             logg(LOGG_INFO, "Empty script %s, need to download entire database\n", patch);
         } else {
-            logg(LOGG_INFO, "%cdownloadPatch: Can't download %s from %s\n", logerr ? '!' : '^', patch, url);
+            logg(logerr ? LOGG_ERROR : LOGG_WARNING, "downloadPatch: Can't download %s from %s\n", patch, url);
         }
         status = ret;
         goto done;
@@ -2397,7 +2398,7 @@ fc_error_t updatedb(
             size_t newLocalFilenameLen = 0;
             if (FC_SUCCESS != buildcld(tmpdir, database, tmpfile, g_bCompressLocalDatabase)) {
                 logg(LOGG_ERROR, "updatedb: Incremental update failed. Failed to build CLD.\n");
-                status = FC_EFAILEDUPDATE;
+                status = FC_EBADCVD;
                 goto done;
             }
 
@@ -2611,7 +2612,7 @@ fc_error_t updatecustomdb(
             logg(LOGG_INFO, "%s is up-to-date (version: custom database)\n", databaseName);
             goto up_to_date;
         } else if (ret > FC_UPTODATE) {
-            logg(LOGG_INFO, "%cCan't download %s from %s\n", logerr ? '!' : '^', databaseName, url);
+            logg(logerr ? LOGG_ERROR : LOGG_WARNING, "Can't download %s from %s\n", databaseName, url);
             status = ret;
             goto done;
         }

--- a/sigtool/sigtool.c
+++ b/sigtool/sigtool.c
@@ -3570,6 +3570,12 @@ int main(int argc, char **argv)
     }
     ret = 1;
 
+    /* Rust logging initialization */
+    if (!clrs_log_init()) {
+        cli_dbgmsg("Unexpected problem occurred while setting up rust logging... continuing without rust logging. \
+                    Please submit an issue to https://github.com/Cisco-Talos/clamav");
+    }
+
     opts = optparse(NULL, argc, argv, 1, OPT_SIGTOOL, 0, NULL);
     if (!opts) {
         mprintf(LOGG_ERROR, "Can't parse command line options\n");

--- a/unit_tests/clamscan/container_sigs_test.py
+++ b/unit_tests/clamscan/container_sigs_test.py
@@ -90,7 +90,7 @@ class TC(testcase.TestCase):
 
         not_eicar_file = TC.path_tmp / 'not_eicar'
         if not not_eicar_file.exists():
-            with open(not_eicar_file, 'wb') as f:
+            with not_eicar_file.open('wb') as f:
                 f.write(b"CLAMAV-TEST-STRING-NOT-EICAR")
 
         not_eicar_zip = TC.path_tmp / 'not_eicar.zip'
@@ -131,7 +131,7 @@ class TC(testcase.TestCase):
 
         not_eicar_file = TC.path_tmp / 'not_eicar'
         if not not_eicar_file.exists():
-            with open(not_eicar_file, 'wb') as f:
+            with not_eicar_file.open('wb') as f:
                 f.write(b"CLAMAV-TEST-STRING-NOT-EICAR")
 
         not_eicar_zip = TC.path_tmp / 'not_eicar.zip'

--- a/unit_tests/clamscan/fp_check_test.py
+++ b/unit_tests/clamscan/fp_check_test.py
@@ -19,7 +19,7 @@ class TC(testcase.TestCase):
         super(TC, cls).setUpClass()
 
         TC.test_file = TC.path_tmp / "test_file"
-        with open(TC.test_file, "wb") as testfile:
+        with TC.test_file.open('wb') as testfile:
             testfile.write(
                 b"""<?php
 IGNORE_user_abort(asdf) scandir(asdfasdfasf]);
@@ -50,7 +50,7 @@ rename()
         TC.test_file_zipped = TC.path_tmp / 'test_file.zip'
         with ZipFile(str(TC.test_file_zipped), 'w', ZIP_DEFLATED) as zf:
             # Add truncted PNG file that will alert with  --alert-broken-media
-            with open(TC.path_source / 'logo.png', 'br') as logo_png:
+            with (TC.path_source / 'logo.png').open('br') as logo_png:
                 zf.writestr('test_file', b"""<?php
 IGNORE_user_abort(asdf) scandir(asdfasdfasf]);
 foreach(asdfasfs) strpos(asdfasfsfasf) sdfasdfasdf .php.suspected

--- a/unit_tests/clamscan/heuristics_test.py
+++ b/unit_tests/clamscan/heuristics_test.py
@@ -29,7 +29,7 @@ class TC(testcase.TestCase):
         TC.heuristics_testfile = TC.path_tmp / 'heuristics-test.zip'
         with ZipFile(str(TC.heuristics_testfile), 'w', ZIP_DEFLATED) as zf:
             # Add truncted PNG file that will alert with  --alert-broken-media
-            with open(TC.path_source / 'logo.png', 'br') as logo_png:
+            with (TC.path_source / 'logo.png').open('br') as logo_png:
                 zf.writestr('logo.png.truncated', logo_png.read(6378))
 
             # Add clam.exe which will alert normally

--- a/unit_tests/freshclam_test.py
+++ b/unit_tests/freshclam_test.py
@@ -87,7 +87,7 @@ class TC(testcase.TestCase):
             port=TC.mock_mirror_port,
         ))
 
-        command = '{valgrind} {valgrind_args} {freshclam} --config-file={freshclam_config} -V'.format(
+        command = '{valgrind} {valgrind_args} {freshclam} --no-dns --config-file={freshclam_config} -V'.format(
             valgrind=TC.valgrind, valgrind_args=TC.valgrind_args, freshclam=TC.freshclam, freshclam_config=TC.freshclam_config
         )
         output = self.execute_command(command)
@@ -133,7 +133,7 @@ class TC(testcase.TestCase):
             user=getpass.getuser(),
         ))
 
-        command = '{valgrind} {valgrind_args} {freshclam} --config-file={freshclam_config}'.format(
+        command = '{valgrind} {valgrind_args} {freshclam} --no-dns --config-file={freshclam_config}'.format(
             valgrind=TC.valgrind, valgrind_args=TC.valgrind_args, freshclam=TC.freshclam, freshclam_config=TC.freshclam_config
         )
         output = self.execute_command(command)
@@ -174,7 +174,7 @@ class TC(testcase.TestCase):
             port=TC.mock_mirror_port,
             user=getpass.getuser(),
         ))
-        command = '{valgrind} {valgrind_args} {freshclam} --config-file={freshclam_config} --update-db=daily'.format(
+        command = '{valgrind} {valgrind_args} {freshclam} --no-dns --config-file={freshclam_config} --update-db=daily'.format(
             valgrind=TC.valgrind, valgrind_args=TC.valgrind_args, freshclam=TC.freshclam, freshclam_config=TC.freshclam_config
         )
         output = self.execute_command(command)
@@ -189,7 +189,7 @@ class TC(testcase.TestCase):
         # verify stderr
         self.verify_output(output.err, expected=expected_stderr)
 
-        command = '{valgrind} {valgrind_args} {freshclam} --config-file={freshclam_config} --update-db=daily'.format(
+        command = '{valgrind} {valgrind_args} {freshclam} --no-dns --config-file={freshclam_config} --update-db=daily'.format(
             valgrind=TC.valgrind, valgrind_args=TC.valgrind_args, freshclam=TC.freshclam, freshclam_config=TC.freshclam_config
         )
         output = self.execute_command(command)
@@ -229,7 +229,7 @@ class TC(testcase.TestCase):
             port=TC.mock_mirror_port,
             user=getpass.getuser(),
         ))
-        command = '{valgrind} {valgrind_args} {freshclam} --config-file={freshclam_config} --update-db=daily --daemon -F'.format(
+        command = '{valgrind} {valgrind_args} {freshclam} --no-dns --config-file={freshclam_config} --update-db=daily --daemon -F'.format(
             valgrind=TC.valgrind, valgrind_args=TC.valgrind_args, freshclam=TC.freshclam, freshclam_config=TC.freshclam_config
         )
         output = self.execute_command(command)
@@ -269,7 +269,7 @@ class TC(testcase.TestCase):
             port=TC.mock_mirror_port,
             user=getpass.getuser(),
         ))
-        command = '{valgrind} {valgrind_args} {freshclam} --config-file={freshclam_config} --update-db=daily'.format(
+        command = '{valgrind} {valgrind_args} {freshclam} --no-dns --config-file={freshclam_config} --update-db=daily'.format(
             valgrind=TC.valgrind, valgrind_args=TC.valgrind_args, freshclam=TC.freshclam, freshclam_config=TC.freshclam_config
         )
         output = self.execute_command(command)
@@ -322,7 +322,7 @@ class TC(testcase.TestCase):
             port=TC.mock_mirror_port,
             user=getpass.getuser(),
         ))
-        command = '{valgrind} {valgrind_args} {freshclam} --config-file={freshclam_config} --update-db=test'.format(
+        command = '{valgrind} {valgrind_args} {freshclam} --no-dns --config-file={freshclam_config} --update-db=test'.format(
             valgrind=TC.valgrind, valgrind_args=TC.valgrind_args, freshclam=TC.freshclam, freshclam_config=TC.freshclam_config
         )
         output = self.execute_command(command)
@@ -384,7 +384,7 @@ class TC(testcase.TestCase):
             port=TC.mock_mirror_port,
             user=getpass.getuser(),
         ))
-        command = '{valgrind} {valgrind_args} {freshclam} --config-file={freshclam_config} --update-db=test'.format(
+        command = '{valgrind} {valgrind_args} {freshclam} --no-dns --config-file={freshclam_config} --update-db=test'.format(
             valgrind=TC.valgrind, valgrind_args=TC.valgrind_args, freshclam=TC.freshclam, freshclam_config=TC.freshclam_config
         )
         output = self.execute_command(command)
@@ -440,7 +440,7 @@ class TC(testcase.TestCase):
             port=TC.mock_mirror_port,
             user=getpass.getuser(),
         ))
-        command = '{valgrind} {valgrind_args} {freshclam} --config-file={freshclam_config} --update-db=test'.format(
+        command = '{valgrind} {valgrind_args} {freshclam} --no-dns --config-file={freshclam_config} --update-db=test'.format(
             valgrind=TC.valgrind, valgrind_args=TC.valgrind_args, freshclam=TC.freshclam, freshclam_config=TC.freshclam_config
         )
         output = self.execute_command(command)
@@ -465,7 +465,7 @@ class TC(testcase.TestCase):
         #
         # Try again, we should be 1 behind which is tolerable and should not trigger a full CVD download
         #
-        command = '{valgrind} {valgrind_args} {freshclam} --config-file={freshclam_config} --update-db=test'.format(
+        command = '{valgrind} {valgrind_args} {freshclam} --no-dns --config-file={freshclam_config} --update-db=test'.format(
             valgrind=TC.valgrind, valgrind_args=TC.valgrind_args, freshclam=TC.freshclam, freshclam_config=TC.freshclam_config
         )
         output = self.execute_command(command)
@@ -526,7 +526,7 @@ class TC(testcase.TestCase):
             port=TC.mock_mirror_port,
             user=getpass.getuser(),
         ))
-        command = '{valgrind} {valgrind_args} {freshclam} --config-file={freshclam_config} --update-db=test'.format(
+        command = '{valgrind} {valgrind_args} {freshclam} --no-dns --config-file={freshclam_config} --update-db=test'.format(
             valgrind=TC.valgrind, valgrind_args=TC.valgrind_args, freshclam=TC.freshclam, freshclam_config=TC.freshclam_config
         )
         output = self.execute_command(command)
@@ -551,7 +551,7 @@ class TC(testcase.TestCase):
         #
         # Try again, we should be 2 behind which is NOT tolerable and SHOULD trigger a full CVD download
         #
-        command = '{valgrind} {valgrind_args} {freshclam} --config-file={freshclam_config} --update-db=test'.format(
+        command = '{valgrind} {valgrind_args} {freshclam} --no-dns --config-file={freshclam_config} --update-db=test'.format(
             valgrind=TC.valgrind, valgrind_args=TC.valgrind_args, freshclam=TC.freshclam, freshclam_config=TC.freshclam_config
         )
         output = self.execute_command(command)
@@ -617,7 +617,7 @@ class TC(testcase.TestCase):
         #
         # 1st attempt
         #
-        command = '{valgrind} {valgrind_args} {freshclam} --config-file={freshclam_config} --update-db=test'.format(
+        command = '{valgrind} {valgrind_args} {freshclam} --no-dns --config-file={freshclam_config} --update-db=test'.format(
             valgrind=TC.valgrind, valgrind_args=TC.valgrind_args, freshclam=TC.freshclam, freshclam_config=TC.freshclam_config
         )
         output = self.execute_command(command)
@@ -637,7 +637,7 @@ class TC(testcase.TestCase):
         #
         # 2nd attempt
         #
-        command = '{valgrind} {valgrind_args} {freshclam} --config-file={freshclam_config} --update-db=test'.format(
+        command = '{valgrind} {valgrind_args} {freshclam} --no-dns --config-file={freshclam_config} --update-db=test'.format(
             valgrind=TC.valgrind, valgrind_args=TC.valgrind_args, freshclam=TC.freshclam, freshclam_config=TC.freshclam_config
         )
         output = self.execute_command(command)
@@ -663,7 +663,7 @@ class TC(testcase.TestCase):
         #
         # 3rd attempt
         #
-        command = '{valgrind} {valgrind_args} {freshclam} --config-file={freshclam_config} --update-db=test'.format(
+        command = '{valgrind} {valgrind_args} {freshclam} --no-dns --config-file={freshclam_config} --update-db=test'.format(
             valgrind=TC.valgrind, valgrind_args=TC.valgrind_args, freshclam=TC.freshclam, freshclam_config=TC.freshclam_config
         )
         output = self.execute_command(command)
@@ -724,7 +724,7 @@ class TC(testcase.TestCase):
         #
         # Now run the update for the first set up updates.
         #
-        command = '{valgrind} {valgrind_args} {freshclam} --config-file={freshclam_config} --update-db=test'.format(
+        command = '{valgrind} {valgrind_args} {freshclam} --no-dns --config-file={freshclam_config} --update-db=test'.format(
             valgrind=TC.valgrind, valgrind_args=TC.valgrind_args, freshclam=TC.freshclam, freshclam_config=TC.freshclam_config
         )
         output = self.execute_command(command)
@@ -755,7 +755,7 @@ class TC(testcase.TestCase):
         #
         # Now re-run the update for more updates.
         #
-        command = '{valgrind} {valgrind_args} {freshclam} --config-file={freshclam_config} --update-db=test'.format(
+        command = '{valgrind} {valgrind_args} {freshclam} --no-dns --config-file={freshclam_config} --update-db=test'.format(
             valgrind=TC.valgrind, valgrind_args=TC.valgrind_args, freshclam=TC.freshclam, freshclam_config=TC.freshclam_config
         )
         output = self.execute_command(command)

--- a/unit_tests/sigtool_test.py
+++ b/unit_tests/sigtool_test.py
@@ -58,11 +58,13 @@ class TC(testcase.TestCase):
         super(TC, cls).tearDownClass()
 
     def setUp(self):
+        TC.original_cwd = os.getcwd()
         super(TC, self).setUp()
 
     def tearDown(self):
         super(TC, self).tearDown()
         self.verify_valgrind_log()
+        os.chdir(TC.original_cwd)
 
     def test_sigtool_00_version(self):
         self.step_name('sigtool version test')
@@ -79,3 +81,79 @@ class TC(testcase.TestCase):
             'ClamAV {}'.format(TC.version),
         ]
         self.verify_output(output.out, expected=expected_results)
+
+    def test_sigtool_01_run_cdiff(self):
+        self.step_name('sigtool run cdiff test')
+        # In addition to testing that running a cdiff works, this also tests a regression.
+        # Applying test-3.cdiff was failing because UNLINK wasn't properly implemented (since 0.105.0).
+        # We didn't notice it because logging wasn't enabled, and leniency in our freshclam cdiff process
+        # allowed the test to pass without noticing the bug.
+
+        self.log.warning('VG: {}'.format(os.getenv("VG")))
+
+        (TC.path_tmp / 'run_cdiff').mkdir()
+        os.chdir(TC.path_tmp / 'run_cdiff')
+
+        command = '{valgrind} {valgrind_args} {sigtool} --unpack {cvd}'.format(
+            valgrind=TC.valgrind, valgrind_args=TC.valgrind_args, sigtool=TC.sigtool,
+            cvd=TC.path_source / 'unit_tests' / 'input' / 'freshclam_testfiles' / 'test-1.cvd'
+        )
+        output = self.execute_command(command)
+
+        assert output.ec == 0  # success
+
+        # Apply 1st cdiff.
+
+        command = '{valgrind} {valgrind_args} {sigtool} --run-cdiff={cdiff}'.format(
+            valgrind=TC.valgrind, valgrind_args=TC.valgrind_args, sigtool=TC.sigtool,
+            cdiff=TC.path_source / 'unit_tests' / 'input' / 'freshclam_testfiles' / 'test-2.cdiff'
+        )
+        output = self.execute_command(command)
+
+        # Apply 2nd cdiff. This one failed because the CLOSE operation should create a file
+        # if it didn't exist, and it was only appending but not creating.
+
+        command = '{valgrind} {valgrind_args} {sigtool} --run-cdiff={cdiff}'.format(
+            valgrind=TC.valgrind, valgrind_args=TC.valgrind_args, sigtool=TC.sigtool,
+            cdiff=TC.path_source / 'unit_tests' / 'input' / 'freshclam_testfiles' / 'test-3.cdiff'
+        )
+        output = self.execute_command(command)
+
+        assert output.ec == 0  # success
+
+    def test_sigtool_02_rust_logs_messages_work(self):
+        self.step_name('sigtool test rust log macros work')
+        # In addition to testing that running a cdiff works, this also tests a regression.
+        # Applying test-3.cdiff was failing because UNLINK wasn't properly implemented (since 0.105.0).
+        # We didn't notice it because logging wasn't enabled, and leniency in our freshclam cdiff process
+        # allowed the test to pass without noticing the bug.
+
+        self.log.warning('VG: {}'.format(os.getenv("VG")))
+
+        (TC.path_tmp / 'run_cdiff_log').mkdir()
+        os.chdir(TC.path_tmp / 'run_cdiff_log')
+
+        command = '{valgrind} {valgrind_args} {sigtool} --unpack {cvd}'.format(
+            valgrind=TC.valgrind, valgrind_args=TC.valgrind_args, sigtool=TC.sigtool,
+            cvd=TC.path_source / 'unit_tests' / 'input' / 'freshclam_testfiles' / 'test-1.cvd'
+        )
+        output = self.execute_command(command)
+
+        assert output.ec == 0  # success
+
+        # Apply cdiffs in wrong order. Should fail and print a message.
+
+        command = '{valgrind} {valgrind_args} {sigtool} --run-cdiff={cdiff}'.format(
+            valgrind=TC.valgrind, valgrind_args=TC.valgrind_args, sigtool=TC.sigtool,
+            cdiff=TC.path_source / 'unit_tests' / 'input' / 'freshclam_testfiles' / 'test-3.cdiff'
+        )
+        output = self.execute_command(command)
+
+        assert output.ec == 1  # failure
+
+        # Verify that the `error!()` message was printed to stderr.
+        # This didn't happen before when we didn't initialize the rust logging lib at the top of sigtool.
+        expected_results = [
+            'LibClamAV Error',
+        ]
+        self.verify_output(output.err, expected=expected_results)

--- a/unit_tests/sigtool_test.py
+++ b/unit_tests/sigtool_test.py
@@ -92,7 +92,7 @@ class TC(testcase.TestCase):
         self.log.warning('VG: {}'.format(os.getenv("VG")))
 
         (TC.path_tmp / 'run_cdiff').mkdir()
-        os.chdir(TC.path_tmp / 'run_cdiff')
+        os.chdir(str(TC.path_tmp / 'run_cdiff'))
 
         command = '{valgrind} {valgrind_args} {sigtool} --unpack {cvd}'.format(
             valgrind=TC.valgrind, valgrind_args=TC.valgrind_args, sigtool=TC.sigtool,
@@ -131,7 +131,7 @@ class TC(testcase.TestCase):
         self.log.warning('VG: {}'.format(os.getenv("VG")))
 
         (TC.path_tmp / 'run_cdiff_log').mkdir()
-        os.chdir(TC.path_tmp / 'run_cdiff_log')
+        os.chdir(str(TC.path_tmp / 'run_cdiff_log'))
 
         command = '{valgrind} {valgrind_args} {sigtool} --unpack {cvd}'.format(
             valgrind=TC.valgrind, valgrind_args=TC.valgrind_args, sigtool=TC.sigtool,


### PR DESCRIPTION
In the event that there is an issue with the CDIFF process, freshclam is treating it as thought no patch was downloaded.

If freshclam fails to apply the patch because of an issue with the patch, or some bug in the CDIFF module, it should retry for the whole CVD.