### PR TITLE
2287 - fix ole2 vba temp file leak

### DIFF
--- a/clamonacc/inotif/inotif.c
+++ b/clamonacc/inotif/inotif.c
@@ -226,7 +226,7 @@ static int onas_ddd_watch_hierarchy(const char *pathname, size_t len, int fd, ui
 
         hnode->watched |= ONAS_INWATCH;
     } else if (type & ONAS_FAN) {
-        if (fanotify_mark(fd, FAN_MARK_ADD, mask, AT_FDCWD, hnode->pathname) < 0) { 
+        if (fanotify_mark(fd, FAN_MARK_ADD, mask, AT_FDCWD, hnode->pathname) < 0) {
             logg(LOGG_ERROR, "ClamInotif: error when marking %s to be watched by fanotify\n", hnode->pathname);
             return CL_EARG;
         }
@@ -247,7 +247,7 @@ static int onas_ddd_watch_hierarchy(const char *pathname, size_t len, int fd, ui
         if (child_path == NULL) {
             logg(LOGG_ERROR, "ClamInotif: out of memory when when adding child for %s\n", hnode->pathname);
             return CL_EMEM;
-	}
+        }
 
         if (hnode->pathname[len - 1] == '/')
             snprintf(child_path, --size, "%s%s", hnode->pathname, curr->dirname);

--- a/libclamav/mbox.c
+++ b/libclamav/mbox.c
@@ -217,7 +217,7 @@ static int count_quotes(const char *buf);
 static bool next_is_folded_header(const text *t);
 static bool newline_in_header(const char *line);
 
-static blob *getHrefs(cli_ctx*, message *m, tag_arguments_t *hrefs);
+static blob *getHrefs(cli_ctx *, message *m, tag_arguments_t *hrefs);
 static void hrefs_done(blob *b, tag_arguments_t *hrefs);
 static void checkURLs(message *m, mbox_ctx *mctx, mbox_status *rc, int is_html);
 

--- a/libclamav/regex_list.c
+++ b/libclamav/regex_list.c
@@ -153,9 +153,9 @@ cl_error_t regex_list_match(struct regex_matcher *matcher, char *real_url, const
     struct regex_list *regex;
     size_t real_len, display_len, buffer_len;
 
-    char *buffer  = NULL;
-    char *bufrev  = NULL;
-    cl_error_t rc = CL_SUCCESS;
+    char *buffer         = NULL;
+    char *bufrev         = NULL;
+    cl_error_t rc        = CL_SUCCESS;
     int filter_search_rc = 0;
     int root;
     struct cli_ac_data mdata;
@@ -232,12 +232,12 @@ cl_error_t regex_list_match(struct regex_matcher *matcher, char *real_url, const
 
     filter_search_rc = filter_search(&matcher->filter, (const unsigned char *)bufrev, buffer_len);
     if (filter_search_rc == -1) {
-       free(buffer);
-       free(bufrev);
-       /* filter says this suffix doesn't match.
+        free(buffer);
+        free(bufrev);
+        /* filter says this suffix doesn't match.
         * The filter has false positives, but no false
         * negatives */
-       return CL_SUCCESS;
+        return CL_SUCCESS;
     }
 
     rc = cli_ac_scanbuff((const unsigned char *)bufrev, buffer_len, NULL, (void *)&regex, &res, &matcher->suffixes, &mdata, 0, 0, NULL, AC_SCAN_VIR, NULL);

--- a/libclamav/scanners.c
+++ b/libclamav/scanners.c
@@ -1632,8 +1632,8 @@ static cl_error_t cli_ole2_tempdir_scan_vba_new(const char *dir, cli_ctx *ctx, s
     char *hash       = NULL;
     char path[PATH_MAX];
     char filename[PATH_MAX];
-    int tempfd = -1;
-    char * tempfile = NULL;
+    int tempfd     = -1;
+    char *tempfile = NULL;
 
     if (CL_SUCCESS != (ret = uniq_get(U, "dir", 3, &hash, &hashcnt))) {
         cli_dbgmsg("cli_ole2_tempdir_scan_vba_new: uniq_get('dir') failed with ret code (%d)!\n", ret);
@@ -1691,7 +1691,7 @@ static cl_error_t cli_ole2_tempdir_scan_vba_new(const char *dir, cli_ctx *ctx, s
             if (CL_SUCCESS != ret) {
                 goto done;
             }
-            
+
             close(tempfd);
             tempfd = -1;
 

--- a/libclamav/vba_extract.c
+++ b/libclamav/vba_extract.c
@@ -358,7 +358,7 @@ static size_t vba_normalize(unsigned char *buffer, size_t size)
  * Read a VBA project in an OLE directory.
  * Contrary to cli_vba_readdir, this function uses the dir file to locate VBA modules.
  */
-cl_error_t cli_vba_readdir_new(cli_ctx *ctx, const char *dir, struct uniq *U, const char *hash, uint32_t which, int *tempfd, int *has_macros, char** tempfile)
+cl_error_t cli_vba_readdir_new(cli_ctx *ctx, const char *dir, struct uniq *U, const char *hash, uint32_t which, int *tempfd, int *has_macros, char **tempfile)
 {
     cl_error_t ret = CL_SUCCESS;
     char fullname[1024];

--- a/libclamav/vba_extract.c
+++ b/libclamav/vba_extract.c
@@ -358,7 +358,7 @@ static size_t vba_normalize(unsigned char *buffer, size_t size)
  * Read a VBA project in an OLE directory.
  * Contrary to cli_vba_readdir, this function uses the dir file to locate VBA modules.
  */
-cl_error_t cli_vba_readdir_new(cli_ctx *ctx, const char *dir, struct uniq *U, const char *hash, uint32_t which, int *tempfd, int *has_macros)
+cl_error_t cli_vba_readdir_new(cli_ctx *ctx, const char *dir, struct uniq *U, const char *hash, uint32_t which, int *tempfd, int *has_macros, char** tempfile)
 {
     cl_error_t ret = CL_SUCCESS;
     char fullname[1024];
@@ -367,7 +367,6 @@ cl_error_t cli_vba_readdir_new(cli_ctx *ctx, const char *dir, struct uniq *U, co
     size_t data_len;
     size_t data_offset;
     const char *stream_name = NULL;
-    char *tempfile          = NULL;
     uint16_t codepage       = CODEPAGE_ISO8859_1;
     unsigned i;
     char *mbcs_name = NULL, *utf16_name = NULL;
@@ -375,7 +374,7 @@ cl_error_t cli_vba_readdir_new(cli_ctx *ctx, const char *dir, struct uniq *U, co
     unsigned char *module_data = NULL, *module_data_utf8 = NULL;
     size_t module_data_size = 0, module_data_utf8_size = 0;
 
-    if (dir == NULL || hash == NULL || tempfd == NULL || has_macros == NULL) {
+    if (dir == NULL || hash == NULL || tempfd == NULL || has_macros == NULL || tempfile == NULL) {
         return CL_EARG;
     }
 
@@ -398,12 +397,12 @@ cl_error_t cli_vba_readdir_new(cli_ctx *ctx, const char *dir, struct uniq *U, co
 
     *has_macros = *has_macros + 1;
 
-    if ((ret = cli_gentempfd_with_prefix(ctx->sub_tmpdir, "vba_project", &tempfile, tempfd)) != CL_SUCCESS) {
+    if ((ret = cli_gentempfd_with_prefix(ctx->sub_tmpdir, "vba_project", tempfile, tempfd)) != CL_SUCCESS) {
         cli_warnmsg("vba_readdir_new: VBA project cannot be dumped to file\n");
         goto done;
     }
 
-    cli_dbgmsg("Dumping VBA project from dir %s to file %s\n", fullname, tempfile);
+    cli_dbgmsg("Dumping VBA project from dir %s to file %s\n", fullname, *tempfile);
 
 #define CLI_WRITEN(msg, size)                                                 \
     do {                                                                      \
@@ -1314,9 +1313,6 @@ done:
     }
     if (stream_name) {
         free((void *)stream_name);
-    }
-    if (tempfile) {
-        free(tempfile);
     }
     if (ret != CL_SUCCESS && *tempfd >= 0) {
         close(*tempfd);

--- a/libclamav/vba_extract.h
+++ b/libclamav/vba_extract.h
@@ -40,7 +40,7 @@ typedef struct vba_project_tag {
 } vba_project_t;
 
 vba_project_t *cli_vba_readdir(const char *dir, struct uniq *U, uint32_t which);
-cl_error_t cli_vba_readdir_new(cli_ctx *ctx, const char *dir, struct uniq *U, const char *hash, uint32_t which, int *tempfd, int *has_macros);
+cl_error_t cli_vba_readdir_new(cli_ctx *ctx, const char *dir, struct uniq *U, const char *hash, uint32_t which, int *tempfd, int *has_macros, char** tempfile);
 vba_project_t *cli_wm_readdir(int fd);
 void cli_free_vba_project(vba_project_t *vba_project);
 

--- a/libclamav/vba_extract.h
+++ b/libclamav/vba_extract.h
@@ -40,7 +40,7 @@ typedef struct vba_project_tag {
 } vba_project_t;
 
 vba_project_t *cli_vba_readdir(const char *dir, struct uniq *U, uint32_t which);
-cl_error_t cli_vba_readdir_new(cli_ctx *ctx, const char *dir, struct uniq *U, const char *hash, uint32_t which, int *tempfd, int *has_macros, char** tempfile);
+cl_error_t cli_vba_readdir_new(cli_ctx *ctx, const char *dir, struct uniq *U, const char *hash, uint32_t which, int *tempfd, int *has_macros, char **tempfile);
 vba_project_t *cli_wm_readdir(int fd);
 void cli_free_vba_project(vba_project_t *vba_project);
 

--- a/libclamav/xlm_extract.c
+++ b/libclamav/xlm_extract.c
@@ -4994,6 +4994,9 @@ done:
 
     FREE(data);
 
+    if (tempfile && !ctx->engine->keeptmp) {
+        remove(tempfile);
+    }
     FREE(tempfile);
 
     return status;


### PR DESCRIPTION
Previous behaviour would remove temp files by deleting the subdirectory This caused issues in cases (on Windows) where subdirectories aren't created due to performance concerns

This commit removes tempfiles individually if keeptemp is off

Original patch authored by Thomas Vy