### PR TITLE
Jenkins: switch to ubuntu for package stage for newer Rust. CMake-Rust: vendor dependencies in top level directory

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,7 +10,7 @@
 *.ref           binary
 
 # Preserve signature for .cargo/vendor files (from the tarabll)
-+/.cargo/vendor binary
+.cargo/vendor   binary
 
 #
 # Exclude files from exporting

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,7 +47,7 @@ properties(
     ]
 )
 
-node('master') {
+node('ubuntu-18-x64') {
     stage('Generate Tarball') {
         cleanWs()
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -68,7 +68,6 @@ node('master') {
 
         dir(path: 'build') {
             sh """# CPack
-                cargo update
                 cmake .. -D VENDOR_DEPENDENCIES=ON
                 cpack --config CPackSourceConfig.cmake """
             archiveArtifacts(artifacts: "clamav-${params.VERSION}*.tar.gz", onlyIfSuccessful: true)

--- a/cmake/FindRust.cmake
+++ b/cmake/FindRust.cmake
@@ -184,28 +184,28 @@ function(cargo_vendor)
     set(oneValueArgs TARGET SOURCE_DIRECTORY BINARY_DIRECTORY)
     cmake_parse_arguments(ARGS "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
-    if(NOT EXISTS ${ARGS_SOURCE_DIRECTORY}/.cargo/config.toml)
-        # Vendor the dependencies and create .cargo/config.toml
-        # Vendored dependencies will be used during the build.
-        # This will allow us to package vendored dependencies in source tarballs
-        # for online builds when we run `cpack --config CPackSourceConfig.cmake`
-        message(STATUS "Running `cargo vendor` to collect dependencies for ${ARGS_TARGET}. This may take a while if the local crates.io index needs to be updated ...")
-        make_directory(${ARGS_SOURCE_DIRECTORY}/.cargo)
-        execute_process(
-            COMMAND ${CMAKE_COMMAND} -E env "CARGO_TARGET_DIR=${ARGS_BINARY_DIRECTORY}" ${cargo_EXECUTABLE} vendor ".cargo/vendor"
-            WORKING_DIRECTORY "${ARGS_SOURCE_DIRECTORY}"
-            OUTPUT_VARIABLE CARGO_VENDOR_OUTPUT
-            ERROR_VARIABLE CARGO_VENDOR_ERROR
-            RESULT_VARIABLE CARGO_VENDOR_RESULT
-        )
+    # Vendor the dependencies and create .cargo/config.toml
+    # Vendored dependencies will be used during the build.
+    # This will allow us to package vendored dependencies in source tarballs
+    # for online builds when we run `cpack --config CPackSourceConfig.cmake`
+    message(STATUS "Running `cargo vendor` to collect dependencies for ${ARGS_TARGET}. This may take a while if the local crates.io index needs to be updated ...")
+    make_directory(${CMAKE_SOURCE_DIR}/.cargo)
+    execute_process(
+        COMMAND ${CMAKE_COMMAND} -E env "CARGO_TARGET_DIR=${ARGS_BINARY_DIRECTORY}" ${cargo_EXECUTABLE} vendor "${CMAKE_SOURCE_DIR}/.cargo/vendor"
+        WORKING_DIRECTORY "${ARGS_SOURCE_DIRECTORY}"
+        OUTPUT_VARIABLE CARGO_VENDOR_OUTPUT
+        ERROR_VARIABLE CARGO_VENDOR_ERROR
+        RESULT_VARIABLE CARGO_VENDOR_RESULT
+    )
 
-        if(NOT ${CARGO_VENDOR_RESULT} EQUAL 0)
-            message(FATAL_ERROR "Failed!\n${CARGO_VENDOR_ERROR}")
-        else()
-            message("Success!")
-        endif()
+    if(NOT ${CARGO_VENDOR_RESULT} EQUAL 0)
+        message(FATAL_ERROR "Failed!\n${CARGO_VENDOR_ERROR}")
+    else()
+        message("Success!")
+    endif()
 
-        write_file(${ARGS_SOURCE_DIRECTORY}/.cargo/config.toml "
+    if(NOT EXISTS ${CMAKE_SOURCE_DIR}/.cargo/config.toml)
+        write_file(${CMAKE_SOURCE_DIR}/.cargo/config.toml "
 [source.crates-io]
 replace-with = \"vendored-sources\"
 


### PR DESCRIPTION
### Problem statement

Adding Cargo.lock file caused the cmake tarball build that we run on Jenkins to fail unless we ran `cargo update` directly before (as seen in the Jenkinsfile).

We wanted to make it "just work" and so set out to update the FindRust.cmake to run `cargo update` for us as a part of the build.

### Summary of this PR

Initially we wanted to update the FindRust.cmake to run `cargo update` for us as a part of the build.  What we didn't realize is that `cargo update` was in fact modifying the Cargo.lock file and rolling BACK the dependency version numbers to match what Cargo thought was available for the current version of Cargo/Rust. 

My understanding now is that the reason the build was failing to begin with wasn't because it was failing to update, but because Rust itself was too old to build the latest version of the `image` crate.  So now this PR has been updated to do two things:

1. Don't run `cargo update`.  Instead, use a different Jenkins node that has access to a more recent version of Rust.
2. Change how we vendor the dependencies. Vendor them at the top level `SRC/.cargo/vendor` **instead** of in a `.cargo/vendor` subdirectory for **each** Rust crate. This second part is only because I happened to make this improvement while working on the FindRust.cmake and not because it is actually required to fix the issue. 

Regarding the 2nd change (the more complicated part of the PR):  This change was required to be able to easily check if the Rust dependencies were already vendored to know if we needed to do an "offline build" or if we should run cargo update.   We're not doing that after all, so the 2nd change is not technically required.  But it is an improvement, which is why I thought I'd keep it in the PR.