### PR TITLE
Clam 2310 cargo update 2

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,7 +47,7 @@ properties(
     ]
 )
 
-node('master') {
+node('ubuntu-18-x64') {
     stage('Generate Tarball') {
         cleanWs()
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -68,7 +68,6 @@ node('master') {
 
         dir(path: 'build') {
             sh """# CPack
-                cargo update
                 cmake .. -D VENDOR_DEPENDENCIES=ON
                 cpack --config CPackSourceConfig.cmake """
             archiveArtifacts(artifacts: "clamav-${params.VERSION}*.tar.gz", onlyIfSuccessful: true)


### PR DESCRIPTION
This is a copy of https://github.com/Cisco-Talos/clamav/pull/898 but with the changes to the cargo-vendor stuff stripped out, to what happens in test.  
Context: testing on our freebsd 12.2 jail is failing in a weird way with:

```
[ 32%] Building clamav_rust in /tmp/testPath-4TQWVU8A3/clamav-build with:  /usr/local/bin/cargo build --target x86_64-unknown-freebsd --release --target-dir /tmp/testPath-4TQWVU8A3/clamav-build
error: failed to get `base64` as a dependency of package `clamav_rust v0.0.1 (/tmp/testPath-4TQWVU8A3/clamav-devel/libclamav_rust)`

Caused by:
  failed to create directory `/home/clamav_jenkins_svc/.cargo/registry/index/github.com-1ecc6299db9ec823`

Caused by:
  Permission denied (os error 13)
gmake[2]: *** [libclamav_rust/CMakeFiles/clamav_rust_target.dir/build.make:82: x86_64-unknown-freebsd/release/libclamav_rust.a] Error 101
gmake[1]: *** [CMakeFiles/Makefile2:1712: libclamav_rust/CMakeFiles/clamav_rust_target.dir/all] Error 2
```

This worked fine on the exact same Jail with same source when built by hand instead of through automation.  And it works everywhere else except this one machine.

So I've made this PR to see if the changes to how we vendor dependencies are what's causing the problem on that freebsd-12.2 jail. That is, this PR is the same as the other one but omits that change. 