### PR TITLE
Fix off by one in HTML parser

### DIFF
--- a/libclamav/htmlnorm.c
+++ b/libclamav/htmlnorm.c
@@ -1191,7 +1191,12 @@ static bool cli_html_normalise(cli_ctx *ctx, int fd, m_area_t *m_area, const cha
                         } else if ((strcmp(tag, "/style") == 0) && (in_tag == TAG_STYLE)) {
                             size_t chunk_size;
 
-                            style_end = ptr - strlen("</style>") - 1;
+                            style_end = ptr - strlen("</style>");
+
+                            if (style_end < style_begin) {
+                                cli_errmsg("cli_html_normalise: style chunk size underflow\n");
+                                goto done;
+                            }
 
                             chunk_size = style_end - style_begin;
 


### PR DESCRIPTION
The code to extract CSS from HTML <style> blocks contains an off by one in case there is no actual content it will have a chunk_size of -1. Whoops.

Removed the -1 so it is correct, and added an extra safety check in case something else crazy happens.

For anyone reading, this bug was introduced during 1.1 dev, so not in any released version.  Close one!