### PR TITLE
Missing command line option documentation

### DIFF
--- a/clamav-milter/clamav-milter.c
+++ b/clamav-milter/clamav-milter.c
@@ -129,7 +129,7 @@ int main(int argc, char **argv)
         printf("    --help                   -h             Show this help\n");
         printf("    --version                -V             Show version\n");
         printf("    --config-file <file>     -c             Read configuration from file\n");
-        printf("    --pid=FILE               -p FILE        Write daemon's pid to FILE\n");
+        printf("    --pid=FILE               -p FILE        Write the daemon's pid to FILE\n");
         printf("\n");
         optfree(opts);
         return 0;

--- a/clamav-milter/clamav-milter.c
+++ b/clamav-milter/clamav-milter.c
@@ -126,9 +126,10 @@ int main(int argc, char **argv)
         printf("\n");
         printf("    %s [-c <config-file>]\n\n", argv[0]);
         printf("\n");
-        printf("    --help                   -h       Show this help\n");
-        printf("    --version                -V       Show version\n");
-        printf("    --config-file <file>     -c       Read configuration from file\n");
+        printf("    --help                   -h             Show this help\n");
+        printf("    --version                -V             Show version\n");
+        printf("    --config-file <file>     -c             Read configuration from file\n");
+        printf("    --pid=FILE               -p FILE        Write daemon's pid to FILE\n");
         printf("\n");
         optfree(opts);
         return 0;

--- a/clamd/clamd.c
+++ b/clamd/clamd.c
@@ -108,7 +108,7 @@ static void help(void)
     printf("    --config-file=FILE       -c FILE        Read configuration from FILE\n");
     printf("    --fail-if-cvd-older-than=days           Return with a nonzero error code if virus database outdated\n");
     printf("    --datadir=DIRECTORY                     Load signatures from DIRECTORY\n");
-    printf("    --pid=FILE               -p FILE        Write daemon's pid to FILE\n");
+    printf("    --pid=FILE               -p FILE        Write the daemon's pid to FILE\n");
     printf("\n");
     printf("Pass in - as the filename for stdin.\n");
     printf("\n");

--- a/clamd/clamd.c
+++ b/clamd/clamd.c
@@ -106,7 +106,9 @@ static void help(void)
     printf("    --debug                                 Enable debug mode\n");
     printf("    --log=FILE               -l FILE        Log into FILE\n");
     printf("    --config-file=FILE       -c FILE        Read configuration from FILE\n");
-    printf("    --fail-if-cvd-older-than=days           Return with a nonzero error code if virus database outdated.\n");
+    printf("    --fail-if-cvd-older-than=days           Return with a nonzero error code if virus database outdated\n");
+    printf("    --datadir=DIRECTORY                     Load signatures from DIRECTORY\n");
+    printf("    --pid=FILE               -p FILE        Write daemon's pid to FILE\n");
     printf("\n");
     printf("Pass in - as the filename for stdin.\n");
     printf("\n");

--- a/docs/man/clamav-milter.conf.5.in
+++ b/docs/man/clamav-milter.conf.5.in
@@ -73,7 +73,7 @@ Chroot to the specified directory. Chrooting is performed just after reading the
 Default: unset (don\'t chroot)
 .TP
 \fBPidFile STRING\fR
-Save the process identifier of a clamav-milter (main thread) to a specified file.
+Write the daemon's pid to the specified file.
 .br
 Default: disabled
 .TP

--- a/docs/man/clamd.8.in
+++ b/docs/man/clamd.8.in
@@ -120,7 +120,7 @@ Return with a nonzero error code if the virus database is older than the specifi
 Load signatures from DIRECTORY.
 .TP
 \fB\-p FILE, \-\-pid=FILE\fR
-Write daemon's pid to FILE.
+Write the daemon's pid to FILE.
 
 .SH "ENVIRONMENT VARIABLES"
 .LP

--- a/docs/man/clamd.8.in
+++ b/docs/man/clamd.8.in
@@ -115,6 +115,12 @@ Read configuration from FILE.
 .TP
 \fB\-\-fail\-if\-cvd\-older\-than=days\fR
 Return with a nonzero error code if the virus database is older than the specified number of days.
+.TP
+\fB\-\-datadir=DIRECTORY\fR
+Load signatures from DIRECTORY.
+.TP
+\fB\-p FILE, \-\-pid=FILE\fR
+Write daemon's pid to FILE.
 
 .SH "ENVIRONMENT VARIABLES"
 .LP

--- a/docs/man/clamd.conf.5.in
+++ b/docs/man/clamd.conf.5.in
@@ -83,7 +83,7 @@ Log additional information about the infected file, such as its size and hash, t
 Default: no
 .TP
 \fBPidFile STRING\fR
-Write daemon's pid to FILE.
+Write the daemon's pid to the specified file.
 .br
 Default: disabled
 .TP

--- a/docs/man/clamd.conf.5.in
+++ b/docs/man/clamd.conf.5.in
@@ -83,7 +83,7 @@ Log additional information about the infected file, such as its size and hash, t
 Default: no
 .TP
 \fBPidFile STRING\fR
-Save the process identifier of a listening daemon (main thread) to a specified file.
+Write daemon's pid to FILE.
 .br
 Default: disabled
 .TP

--- a/docs/man/freshclam.1.in
+++ b/docs/man/freshclam.1.in
@@ -46,7 +46,7 @@ Log report to FILE.
 Run in a daemon mode. Defaults to 12 checks per day unless otherwise specified by \-\-checks or freshclam.conf.
 .TP
 \fB\-p FILE, \-\-pid=FILE\fR
-Write daemon's pid to FILE.
+Write the daemon's pid to FILE.
 .TP
 \fB\-F, \-\-foreground\fR
 Don't fork into background (for use in daemon mode).

--- a/docs/man/freshclam.conf.5.in
+++ b/docs/man/freshclam.conf.5.in
@@ -57,7 +57,7 @@ Rotate log file. Requires LogFileMaxSize option set prior to this option.
 Default: no
 .TP
 \fBPidFile STRING\fR
-This option allows you to save the process identifier of the daemon to a file specified in the argument.
+Write the daemon's pid to the specified file.
 .br
 Default: disabled
 .TP

--- a/etc/clamav-milter.conf.sample
+++ b/etc/clamav-milter.conf.sample
@@ -58,7 +58,7 @@ Example
 #Chroot /newroot
 
 # This option allows you to save a process identifier of the listening
-# daemon (main thread).
+# daemon.
 # This file will be owned by root, as long as clamav-milter was started by
 # root.  It is recommended that the directory where this file is stored is
 # also owned by root to keep other users from tampering with it.

--- a/etc/clamd.conf.sample
+++ b/etc/clamd.conf.sample
@@ -69,7 +69,7 @@ Example
 #ExtendedDetectionInfo yes
 
 # This option allows you to save a process identifier of the listening
-# daemon (main thread).
+# daemon.
 # This file will be owned by root, as long as clamd was started by root.
 # It is recommended that the directory where this file is stored is
 # also owned by root to keep other users from tampering with it.

--- a/etc/freshclam.conf.sample
+++ b/etc/freshclam.conf.sample
@@ -46,7 +46,8 @@ Example
 # Default: no
 #LogRotate yes
 
-# This option allows you to save the process identifier of the daemon.
+# Write the daemon's pid to the specified file.
+# You must run freshclam with --daemon (-d) for freshclam to run as a daemon.
 # This file will be owned by root, as long as freshclam was started by root.
 # It is recommended that the directory where this file is stored is
 # also owned by root to keep other users from tampering with it.

--- a/etc/freshclam.conf.sample
+++ b/etc/freshclam.conf.sample
@@ -46,7 +46,7 @@ Example
 # Default: no
 #LogRotate yes
 
-# This option allows you to save the process identifier of the daemon
+# This option allows you to save the process identifier of the daemon.
 # This file will be owned by root, as long as freshclam was started by root.
 # It is recommended that the directory where this file is stored is
 # also owned by root to keep other users from tampering with it.

--- a/freshclam/freshclam.c
+++ b/freshclam/freshclam.c
@@ -182,7 +182,7 @@ static void help(void)
     printf("    --uninstall-service                  Uninstall Windows Service\n");
 #endif
     printf("    --daemon             -d              Run in daemon mode\n");
-    printf("    --pid=FILE           -p FILE         Write daemon's pid to FILE\n");
+    printf("    --pid=FILE           -p FILE         Write the daemon's pid to FILE\n");
 #ifndef _WIN32
     printf("    --foreground         -F              Don't fork into background (for use in daemon mode).\n");
     printf("    --user=USER          -u USER         Run as USER\n");

--- a/freshclam/freshclam.c
+++ b/freshclam/freshclam.c
@@ -182,7 +182,7 @@ static void help(void)
     printf("    --uninstall-service                  Uninstall Windows Service\n");
 #endif
     printf("    --daemon             -d              Run in daemon mode\n");
-    printf("    --pid=FILE           -p FILE         Save daemon's pid in FILE\n");
+    printf("    --pid=FILE           -p FILE         Write daemon's pid to FILE\n");
 #ifndef _WIN32
     printf("    --foreground         -F              Don't fork into background (for use in daemon mode).\n");
     printf("    --user=USER          -u USER         Run as USER\n");

--- a/win32/conf_examples/clamd.conf.sample
+++ b/win32/conf_examples/clamd.conf.sample
@@ -60,7 +60,7 @@ Example
 #ExtendedDetectionInfo yes
 
 # This option allows you to save a process identifier of the listening
-# daemon (main thread).
+# daemon.
 # Default: disabled
 #PidFile "C:\Program Files\ClamAV\clamd.pid"
 

--- a/win32/conf_examples/freshclam.conf.sample
+++ b/win32/conf_examples/freshclam.conf.sample
@@ -46,7 +46,8 @@ Example
 # Default: no
 #LogRotate yes
 
-# This option allows you to save the process identifier of the daemon.
+# Write the daemon's pid to the specified file.
+# You must run freshclam with --daemon (-d) for freshclam to run as a daemon.
 # Default: disabled
 #PidFile "C:\Program Files\ClamAV\freshclam.pid"
 

--- a/win32/conf_examples/freshclam.conf.sample
+++ b/win32/conf_examples/freshclam.conf.sample
@@ -46,7 +46,7 @@ Example
 # Default: no
 #LogRotate yes
 
-# This option allows you to save the process identifier of the daemon
+# This option allows you to save the process identifier of the daemon.
 # Default: disabled
 #PidFile "C:\Program Files\ClamAV\freshclam.pid"
 


### PR DESCRIPTION
The clamd and clamav-milter `--help` message and manpages do not mention the `--pid` (`-p`) option.

The clamd `--help` message and manpage do not mention the `--datadir` option.

Also corrected minor punctuation issues, and removed the meaningless jargon about the "main thread" which has nothing to do with the PID.