### PR TITLE
Freshclam: remove curl result warning (1.1.1)

### DIFF
--- a/libfreshclam/libfreshclam_internal.c
+++ b/libfreshclam/libfreshclam_internal.c
@@ -1300,7 +1300,6 @@ static fc_error_t downloadFile(
 
     /* Check HTTP code */
     curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
-    logg(LOGG_WARNING, " ******* RESULT %ld, SIZE: %zu ******* \n", http_code, receivedFile.size);
     switch (http_code) {
         case 200:
         case 206: {


### PR DESCRIPTION
This is a cherry-pick backport of https://github.com/Cisco-Talos/clamav/pull/935

---

A warning printing the HTTP code and file size was accidentally committed at the end of ClamAV 1.1.0 dev when fixing a bug. Remove this warning.

Resolves: https://github.com/Cisco-Talos/clamav/issues/930