### PR TITLE
Prevent -f file disclosure

### DIFF
--- a/clamscan/manager.c
+++ b/clamscan/manager.c
@@ -978,8 +978,12 @@ static int scan_files(struct cl_engine *engine, const struct optstruct *opts, st
             ret = scanstdin(engine, options);
         } else if (LSTAT(file, &sb) == -1) {
             /* Can't access the file */
-            perror(file);
-            logg(LOGG_WARNING, "%s: Can't access file\n", file);
+            perror("Error");  // change the argument to a constant string
+            if(optget(opts, "file-list")->enabled){
+                logg(LOGG_WARNING, "ERROR: Unable to access file on line %d\n", get_filelist_line_number());
+            } else {
+                logg(LOGG_WARNING, "ERROR: Unable to access a file\n");
+            }
             ret = 2;
         } else {
             /* Can access the file. Now have to identify what type of file it is */
@@ -1116,8 +1120,6 @@ int scanmanager(const struct optstruct *opts)
 #endif
     }
 
-    if ((opt = optget(opts, "cache-size"))->enabled)
-        cl_engine_set_num(engine, CL_ENGINE_CACHE_SIZE, opt->numarg);
     if (optget(opts, "disable-cache")->enabled)
         cl_engine_set_num(engine, CL_ENGINE_DISABLE_CACHE, 1);
 

--- a/common/misc.c
+++ b/common/misc.c
@@ -191,6 +191,13 @@ int check_flevel(void)
     return 0;
 }
 
+
+static unsigned int line_number = 0; // Add this line to keep track of the current line number
+
+unsigned int get_filelist_line_number() {
+    return line_number;
+}
+
 const char *filelist(const struct optstruct *opts, int *err)
 {
     static char buff[1025];
@@ -220,6 +227,7 @@ const char *filelist(const struct optstruct *opts, int *err)
             len--;
             while (len && ((buff[len] == '\n') || (buff[len] == '\r')))
                 buff[len--] = '\0';
+            line_number++;
             return buff;
         } else {
             fclose(fs);


### PR DESCRIPTION
If a user is give sudo access to clamscan, they can point `--file-list` at a file owned by the sudo user, usually root, and they can parse the errors to read the file. for example `sudo clamscan -f /etc/shadow`. This can be easily resolved by adding line number tracking with a corresponding update to the error output.

Changing the error output to a line number will clearly indicate where the problem is to a legitimate user while giving nothing to an attacker. PSRT decided this wasn't something they wanted to patch, so here's a patch.

I don't believe this will interfere with other parts of ClamAV.

Before: 
![image](https://github.com/Cisco-Talos/clamav/assets/983663/e2d0a8c5-2a21-4256-b1ca-d7f318647e4c)
After: 
![image](https://github.com/Cisco-Talos/clamav/assets/983663/daf7c743-f3ad-444f-a297-b8b2a5566652)
