### PR TITLE
Abort signature load for short signature patterns

### DIFF
--- a/libclamav/matcher-ac.c
+++ b/libclamav/matcher-ac.c
@@ -2951,6 +2951,7 @@ cl_error_t cli_ac_addsig(struct cli_matcher *root, const char *virname, const ch
             cli_warnmsg("cli_ac_addsig: cannot use filter for trie\n");
             MPOOL_FREE(root->mempool, root->filter);
             root->filter = NULL;
+            return CL_EMALFDB;
         }
 
         /* TODO: should this affect maxpatlen? */

--- a/libclamav/matcher-bm.c
+++ b/libclamav/matcher-bm.c
@@ -72,6 +72,7 @@ cl_error_t cli_bm_addpatt(struct cli_matcher *root, struct cli_bm_patt *pattern,
             cli_warnmsg("cli_bm_addpatt: cannot use filter for trie\n");
             MPOOL_FREE(root->mempool, root->filter);
             root->filter = NULL;
+            return CL_EMALFDB;
         }
         /* TODO: should this affect maxpatlen? */
     }

--- a/libclamav/readdb.c
+++ b/libclamav/readdb.c
@@ -4862,9 +4862,11 @@ cl_error_t cli_load(const char *filename, struct cl_engine *engine, unsigned int
     if (fs)
         fclose(fs);
 
-    if (engine->cb_sigload_progress) {
-        /* Let the progress callback function know how we're doing */
-        (void)engine->cb_sigload_progress(engine->num_total_signatures, *signo, engine->cb_sigload_progress_ctx);
+    if (CL_SUCCESS == ret) {
+        if (engine->cb_sigload_progress) {
+            /* Let the progress callback function know how we're doing */
+            (void)engine->cb_sigload_progress(engine->num_total_signatures, *signo, engine->cb_sigload_progress_ctx);
+        }
     }
 
     return ret;


### PR DESCRIPTION
Backport of https://github.com/Cisco-Talos/clamav/pull/934

---

If a signature has a pattern that is too short will fail to load the signature but does not cause the entire load process to abort. This is bad for two reasons:
1) It is not immediately apparent that the signature is bad, and so it could be published accidentally.
2) The signature is partially loaded by the time the bad pattern is observed and that may cause a crash later.

Because of (1), it is not worth it to try to unload the first part of the signature. Instead, we should just abort the signature load.

Fixes: https://github.com/Cisco-Talos/clamav/issues/923

We should also abort loading if the filter pattern for the boyer-moore matcher is shorter than 2 bytes.

Also, do not print the final "Loading" progress bar if an error occurred.