### PR TITLE
Systemd timer for freshclam updates

### DIFF
--- a/freshclam/CMakeLists.txt
+++ b/freshclam/CMakeLists.txt
@@ -61,4 +61,18 @@ if(SYSTEMD_FOUND)
         FILES ${CMAKE_CURRENT_BINARY_DIR}/clamav-freshclam.service
         DESTINATION ${SYSTEMD_UNIT_DIR}
         COMPONENT programs)
+    configure_file(
+        ${CMAKE_CURRENT_SOURCE_DIR}/clamav-freshclam-once.service.in
+        ${CMAKE_CURRENT_BINARY_DIR}/clamav-freshclam-once.service @ONLY)
+    install(
+        FILES ${CMAKE_CURRENT_BINARY_DIR}/clamav-freshclam-once.service
+        DESTINATION ${SYSTEMD_UNIT_DIR}
+        COMPONENT programs)
+    configure_file(
+        ${CMAKE_CURRENT_SOURCE_DIR}/clamav-freshclam-once.timer.in
+        ${CMAKE_CURRENT_BINARY_DIR}/clamav-freshclam-once.timer @ONLY)
+    install(
+        FILES ${CMAKE_CURRENT_BINARY_DIR}/clamav-freshclam-once.timer
+        DESTINATION ${SYSTEMD_UNIT_DIR}
+        COMPONENT programs)
 endif()

--- a/freshclam/clamav-freshclam-once.service.in
+++ b/freshclam/clamav-freshclam-once.service.in
@@ -1,0 +1,12 @@
+[Unit]
+Description=Update ClamAV virus database once
+Documentation=man:freshclam(1) man:freshclam.conf(5) https://docs.clamav.net/
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=@prefix@/bin/freshclam
+
+[Install]
+WantedBy=multi-user.target

--- a/freshclam/clamav-freshclam-once.timer.in
+++ b/freshclam/clamav-freshclam-once.timer.in
@@ -1,0 +1,11 @@
+[Unit]
+Description=Daily ClamAV virus database update
+
+[Timer]
+OnCalendar=daily
+AccuracySec=1h
+RandomizedDelaySec=1h
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
This PR implements a systemd unit that **updates freshclam once**, without sending freshclam into the background.

It comes with a systemd timer which, when activated, will call this unit periodically. This takes the "burden of timing the updates" off of freshclam and puts it onto systemd. The timer can then easily activated, audited and the logs inspected:

```
sudo systemctl enable --now clamav-freshclam-once.timer
sudo systemctl list-timers
sudo systemctl status clamav-freshclam-once.timer
sudo systemctl status clamav-freshclam-once.service
journalctl -u clamav-freshclam-once.service
```

And if you want a different update interval you can edit the timer unit file using

```
sudo systemctl edit clamav-freshclam-once.timer
```