### PR TITLE
Export symbols for calculating image fuzzy hash

### DIFF
--- a/libclamav/libclamav.map
+++ b/libclamav/libclamav.map
@@ -295,6 +295,8 @@ CLAMAV_PRIVATE {
     init_domain_list;
     lsig_increment_subsig_match;
     readdb_parse_ldb_subsignature;
+    fuzzy_hash_calculate_image;
+    ffierror_fmt;
 
     __cli_strcasestr;
     __cli_strndup;


### PR DESCRIPTION
These symbols are used by an internal python tool for generating signatures:
- fuzzy_hash_calculate_image
- ffierror_fmt

`ffierror_fmt` is required to free the error structure passed back in case of an error.

Since version 1.1.0 started using libclamav.map again, we need to explicitly export these symbols.