### PR TITLE
CMake: link openssl 3.x with clamsubmit on macOS (1.1.1)

### DIFF
--- a/clamsubmit/CMakeLists.txt
+++ b/clamsubmit/CMakeLists.txt
@@ -34,6 +34,8 @@ target_link_libraries( clamsubmit
     PRIVATE
         ClamAV::libclamav
         ClamAV::common
+        OpenSSL::SSL
+        OpenSSL::Crypto
         JSONC::jsonc
         CURL::libcurl )
 if(APPLE)

--- a/cmake/FindRust.cmake
+++ b/cmake/FindRust.cmake
@@ -294,6 +294,21 @@ function(add_rust_library)
             WORKING_DIRECTORY "${ARGS_SOURCE_DIRECTORY}"
             DEPENDS ${LIB_SOURCES}
             COMMENT "Building ${ARGS_TARGET} in ${ARGS_BINARY_DIRECTORY} with:  ${cargo_EXECUTABLE} ${MY_CARGO_ARGS_STRING}")
+    elseif("${CMAKE_OSX_ARCHITECTURES}" MATCHES "^(arm64)$")
+        add_custom_command(
+            OUTPUT "${OUTPUT}"
+            COMMAND ${CMAKE_COMMAND} -E env "CARGO_CMD=build" "CARGO_TARGET_DIR=${ARGS_BINARY_DIRECTORY}" "MAINTAINER_MODE=${MAINTAINER_MODE}" "RUSTFLAGS=${RUSTFLAGS}" ${cargo_EXECUTABLE} ${MY_CARGO_ARGS} --target=aarch64-apple-darwin
+            WORKING_DIRECTORY "${ARGS_SOURCE_DIRECTORY}"
+            DEPENDS ${LIB_SOURCES}
+            COMMENT "Building ${ARGS_TARGET} in ${ARGS_BINARY_DIRECTORY} with:  ${cargo_EXECUTABLE} ${MY_CARGO_ARGS_STRING}")
+    elseif("${CMAKE_OSX_ARCHITECTURES}" MATCHES "^(x86_64)$")
+        add_custom_command(
+            OUTPUT "${OUTPUT}"
+            COMMAND ${CMAKE_COMMAND} -E env "CARGO_CMD=build" "CARGO_TARGET_DIR=${ARGS_BINARY_DIRECTORY}" "MAINTAINER_MODE=${MAINTAINER_MODE}" "RUSTFLAGS=${RUSTFLAGS}" ${cargo_EXECUTABLE} ${MY_CARGO_ARGS} --target=x86_64-apple-darwin
+            COMMAND ${CMAKE_COMMAND} -E make_directory "${ARGS_BINARY_DIRECTORY}/${RUST_COMPILER_TARGET}/${CARGO_BUILD_TYPE}"
+            WORKING_DIRECTORY "${ARGS_SOURCE_DIRECTORY}"
+            DEPENDS ${LIB_SOURCES}
+            COMMENT "Building ${ARGS_TARGET} in ${ARGS_BINARY_DIRECTORY} with:  ${cargo_EXECUTABLE} ${MY_CARGO_ARGS_STRING}")
     else()
         add_custom_command(
             OUTPUT "${OUTPUT}"


### PR DESCRIPTION
When switching to openssl 3.x, linking with clamsubmit fails with undefined openssl symbols. The error message from Xcode is crazy obtuse:

ld: initializer '_OPENSSL_cpuid_setup' is >4GB from start of image in 'anon' from /Users/clamav_jenkins_svc/clamav-mussels-cookbook/test/install-x86_64/lib/libcrypto.a(libcrypto-lib-x86_64cpuid.o)
clang: error: linker command failed with exit code 1 (use -v to see invocation)

Anyhow... It seems that we must explicitly link clamsubmit with openssl now in order for this to work.

In addition to this change, I also found that the CMake FindRust.cmake  module breaks the ability to build specifically for just x86_64 or arm64 (i.e. possibly cross-compiling. 
This commit includes a change to accommodate that scenario.