### PR TITLE
Fix "cli_strdup(): s == NULL" error with clamonacc --wait

### DIFF
--- a/clamonacc/client/client.c
+++ b/clamonacc/client/client.c
@@ -165,8 +165,8 @@ int onas_check_remote(struct onas_context **ctx, cl_error_t *err)
 int16_t onas_ping_clamd(struct onas_context **ctx)
 {
 
-    uint64_t attempts           = 0;
-    uint64_t interval           = 0;
+    uint64_t attempts           = ONAS_DEFAULT_PING_ATTEMPTS;
+    uint64_t interval           = ONAS_DEFAULT_PING_INTERVAL;
     char *attempt_str           = NULL;
     char *interval_str          = NULL;
     char *errchk                = NULL;
@@ -207,7 +207,7 @@ int16_t onas_ping_clamd(struct onas_context **ctx)
     /* ping command takes the form --ping [attempts[:interval]] */
     opt = optget((*ctx)->opts, "ping");
 
-    if (opt) {
+    if (opt->enabled) {
         attempt_str = cli_strdup(opt->strarg);
         if (attempt_str) {
             if (NULL == attempt_str) {
@@ -225,8 +225,6 @@ int16_t onas_ping_clamd(struct onas_context **ctx)
                     ret = -1;
                     goto done;
                 }
-            } else {
-                interval = ONAS_DEFAULT_PING_INTERVAL;
             }
             attempts = cli_strntoul(attempt_str, strlen(attempt_str), &errchk, 10);
             if (attempt_str + strlen(attempt_str) > errchk) {
@@ -234,9 +232,6 @@ int16_t onas_ping_clamd(struct onas_context **ctx)
                 ret = -1;
                 goto done;
             }
-        } else {
-            attempts = ONAS_DEFAULT_PING_ATTEMPTS;
-            interval = ONAS_DEFAULT_PING_INTERVAL;
         }
     }
 


### PR DESCRIPTION
Issue occured when --ping # option was missing.

Fixes #443.