### PR TITLE
Raise artificial 4G limit for MaxScanSize

### DIFF
--- a/common/optparser.h
+++ b/common/optparser.h
@@ -38,8 +38,9 @@
 
 #define CLOPT_TYPE_STRING   1    /* quoted/regular string */
 #define CLOPT_TYPE_NUMBER   2    /* raw number */
-#define CLOPT_TYPE_SIZE     3    /* number possibly followed by modifiers (M/m or K/k) */
+#define CLOPT_TYPE_SIZE     3    /* number possibly followed by modifiers (K/k, M/m or G/g) */
 #define CLOPT_TYPE_BOOL     4    /* boolean */
+#define CLOPT_TYPE_SIZE64   5    /* 64-bit number possibly followed by modifiers (K/k, M/m or G/g) */
 
 #ifdef _WIN32
 extern char _DATADIR[MAX_PATH];


### PR DESCRIPTION
This limit is internally "long long", so >=64-bit even on 32-bit platforms. Also fixes a related issue where limits could have been set to negative values on 64-bit platforms where setting a "long long" (64-bit signed) can overflow if assigned from an "unsigned long" (64-bit unsigned).

Resolves: https://github.com/Cisco-Talos/clamav/issues/809