### PR TITLE
Fix bounds check issue in PDF parser

### DIFF
--- a/libclamav/pdf.c
+++ b/libclamav/pdf.c
@@ -928,7 +928,7 @@ static size_t find_length(struct pdf_struct *pdf, struct pdf_obj *obj, const cha
 
     /* Step the index into the "/Length" string. */
     index++;
-    bytes_remaining -= index - obj_start;
+    bytes_remaining--;
 
     /* Find the start of the next direct or indirect object.
      * pdf_nextobject() assumes we started searching from within a previous object */


### PR DESCRIPTION
The bytes_remaining variable may be set negative by mistake, when really we just want to decrement it.
This issue may result in a 1-byte over read but does not cause any crash.

We determined that this issue is not a vulnerability.

Fixes: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=58475