### PR TITLE
Fix build issue in oss-fuzz environment (1.1.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -823,9 +823,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,7 +37,7 @@ properties(
                        defaultValue: 'fuzz-regression-1.1',
                        description: 'test-pipelines branch for fuzz regression tests'),
                 string(name: 'FUZZ_CORPUS_BRANCH',
-                       defaultValue: 'master',
+                       defaultValue: '1.1',
                        description: 'private-fuzz-corpus branch'),
                 string(name: 'SHARED_LIB_BRANCH',
                        defaultValue: 'master',


### PR DESCRIPTION
There is an error building clam with the rust nightly compiler:

error[E0635]: unknown feature `proc_macro_span_shrink`
  --> /rust/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.56/src/lib.rs:92:30
   |
92 |     feature(proc_macro_span, proc_macro_span_shrink)
   |                              ^^^^^^^^^^^^^^^^^^^^^^

We need this to work because oss-fuzz is apparently using rust nightly in their image.

Bumping the proc-macro2 crate version in Cargo.lock resolves the error.