### PR TITLE
Fix infinite loop when scanning some DMG archives

### DIFF
--- a/libclamav/hfsplus.c
+++ b/libclamav/hfsplus.c
@@ -1323,6 +1323,11 @@ static cl_error_t hfsplus_walk_catalog(cli_ctx *ctx, hfsPlusVolumeHeader *volHea
                                                         stream.next_out  = uncompressed_block;
 
                                                         extracted_file = true;
+
+                                                        if (stream.avail_in > 0 && Z_STREAM_END == z_ret) {
+                                                            cli_dbgmsg("hfsplus_walk_catalog: Reached end of stream even though there's still some available bytes left!\n");
+                                                            break;
+                                                        }
                                                     }
                                                 } else {
                                                     if (cli_writen(ofd, &block[streamBeginning ? 1 : 0], readLen - (streamBeginning ? 1 : 0)) != readLen - (streamBeginning ? 1 : 0)) {


### PR DESCRIPTION
Note: this was already reviewed internally and included in:
- 1.1.1:  https://github.com/Cisco-Talos/clamav/commit/c48f15f9fb7f73b0731b1642a15bc333c3232e66
- 1.0.2: https://github.com/Cisco-Talos/clamav/commit/f20a12480dbb06a114621d6e7e81ed593e0c31c1
- 0.103.9: https://github.com/Cisco-Talos/clamav/commit/86d451c3d700c21ce3c23e182e20435bd490e0cd

This PR is just to fix it in `main` now towards 1.2.0.

--- 

When decompressing a zlib stream, it's possible to reach end of stream before running out of available bytes. In the DMG parser, this may cause an infinite loop.

This commit adds a check for the condition where stream has ended before running out of input.

Fixes: https://github.com/Cisco-Talos/clamav/issues/925