### PR TITLE
Windows: json-c 0.17 compatibility with ssize_t type definition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -682,13 +682,13 @@ check_type_size("ssize_t" SIZEOF_SSIZE_T)
 if(SIZEOF_SSIZE_T STREQUAL "")
     # ssize_t is a signed type in POSIX storing at least -1.
     # Set it to "int" to match the behavior of AC_TYPE_SSIZE_T (autotools).
-    set(ssize_t int)
+    set(SSIZE_T_DEF "typedef int ssize_t;")
 endif()
 check_type_size("off_t" SIZEOF_OFF_T)
 if(SIZEOF_OFF_T STREQUAL "")
     # off_t is a signed type in POSIX no narrower than int.
     # Set it to "long int" to match the behavior of AC_TYPE_OFF_T (autotools).
-    set(off_t long int)
+    set(OFF_T_DEF "typedef long int off_t;")
 endif()
 
 check_type_size("int" SIZEOF_INT)

--- a/clamav-config.h.cmake.in
+++ b/clamav-config.h.cmake.in
@@ -587,11 +587,22 @@
 #define inline @INLINE_KEYWORD@
 #endif
 
-/* Define to `long int' if <sys/types.h> does not define. */
-#cmakedefine off_t @off_t@
-
 /* Define to `int' if <sys/types.h> does not define. */
-#cmakedefine ssize_t @ssize_t@
+#ifndef SSIZE_T_DEFINED
+   #if defined(_MSC_VER)
+      #include <BaseTsd.h>
+      typedef SSIZE_T ssize_t;
+   #else
+      @SSIZE_T_DEF@
+   #endif
+   # define SSIZE_T_DEFINED
+#endif
+
+/* Define to `long int' if <sys/types.h> does not define. */
+#ifndef OFF_T_DEFINED
+   @OFF_T_DEF@
+   #define OFF_T_DEFINED
+#endif
 
 /* Define to the equivalent of the C99 'restrict' keyword, or to
    nothing if this is not supported.  Do not define if restrict is

--- a/examples/ex_file_inspection_callback.c
+++ b/examples/ex_file_inspection_callback.c
@@ -210,9 +210,9 @@ int main(int argc, char **argv)
 
     /* scan file descriptor */
     memset(&options, 0, sizeof(struct cl_scan_options));
-    options.parse |= ~0;                                 /* enable all parsers */
-    options.general |= CL_SCAN_GENERAL_HEURISTICS;       /* enable heuristic alert options */
-    options.general |= CL_SCAN_GENERAL_ALLMATCHES;       /* run in all-match mode, so it keeps looking for alerts after the first one */
+    options.parse |= ~0;                           /* enable all parsers */
+    options.general |= CL_SCAN_GENERAL_HEURISTICS; /* enable heuristic alert options */
+    options.general |= CL_SCAN_GENERAL_ALLMATCHES; /* run in all-match mode, so it keeps looking for alerts after the first one */
 
     options.heuristic |= CL_SCAN_HEURISTIC_ENCRYPTED_ARCHIVE;
     options.heuristic |= CL_SCAN_HEURISTIC_ENCRYPTED_DOC;

--- a/win32/compat/net.h
+++ b/win32/compat/net.h
@@ -24,8 +24,14 @@
 
 /* Don't include clamav-config.h, because that brings in platform.h
    and platform.h will make these functions recursive ;-). */
-#ifndef ssize_t
+#ifndef SSIZE_T_DEFINED
+#if defined(_MSC_VER)
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+#else
 typedef int ssize_t;
+#endif
+#define SSIZE_T_DEFINED
 #endif
 
 #define F_GETFL 1


### PR DESCRIPTION
json-c 0.17 defines the ssize_t type using a typedef on Windows. We have been setting ssize_t for Windows to a different type using a #define instead of a typedef.

We should have been using a typedef since it is a type. However, we must also match the exact type they're setting it to or else the compiler will baulk because the types are different.

Note: in C11, it's fine to use typedef the same type more than once, so long as you're defining it the same every time.