### PR TITLE
Clam 2226 zip filenames

### DIFF
--- a/examples/ex_file_inspection_callback.c
+++ b/examples/ex_file_inspection_callback.c
@@ -213,7 +213,6 @@ int main(int argc, char **argv)
     options.parse |= ~0;                                 /* enable all parsers */
     options.general |= CL_SCAN_GENERAL_HEURISTICS;       /* enable heuristic alert options */
     options.general |= CL_SCAN_GENERAL_ALLMATCHES;       /* run in all-match mode, so it keeps looking for alerts after the first one */
-    options.general |= CL_SCAN_GENERAL_COLLECT_METADATA; /* collect metadata may enable collecting additional filenames (like in zip) */
 
     options.heuristic |= CL_SCAN_HEURISTIC_ENCRYPTED_ARCHIVE;
     options.heuristic |= CL_SCAN_HEURISTIC_ENCRYPTED_DOC;

--- a/libclamav/unzip.c
+++ b/libclamav/unzip.c
@@ -624,8 +624,8 @@ static unsigned int parse_local_file_header(
     uint32_t csize, usize;
     unsigned int size_of_fileheader_and_data = 0;
 
-    uint32_t nsize;
-    const char *src;
+    uint32_t nsize  = 0;
+    const char *src = NULL;
 
     if (!(local_header = fmap_need_off(map, loff, SIZEOF_LOCAL_HEADER))) {
         cli_dbgmsg("cli_unzip: local header - out of file\n");
@@ -652,7 +652,7 @@ static unsigned int parse_local_file_header(
     }
 
     nsize = (LOCAL_HEADER_flen >= sizeof(name)) ? sizeof(name) - 1 : LOCAL_HEADER_flen;
-    src = fmap_need_ptr_once(map, zip, nsize);
+    src   = fmap_need_ptr_once(map, zip, nsize);
     if (nsize && (NULL != src)) {
         memcpy(name, zip, nsize);
         name[nsize] = '\0';

--- a/libclamav/unzip.c
+++ b/libclamav/unzip.c
@@ -624,6 +624,9 @@ static unsigned int parse_local_file_header(
     uint32_t csize, usize;
     unsigned int size_of_fileheader_and_data = 0;
 
+    uint32_t nsize;
+    const char *src;
+
     if (!(local_header = fmap_need_off(map, loff, SIZEOF_LOCAL_HEADER))) {
         cli_dbgmsg("cli_unzip: local header - out of file\n");
         goto done;
@@ -647,18 +650,19 @@ static unsigned int parse_local_file_header(
         fmap_unneed_off(map, loff, SIZEOF_LOCAL_HEADER);
         goto done;
     }
-    if (ctx->engine->cdb || cli_debug_flag || ctx->engine->keeptmp || ctx->options->general & CL_SCAN_GENERAL_COLLECT_METADATA) {
-        uint32_t nsize = (LOCAL_HEADER_flen >= sizeof(name)) ? sizeof(name) - 1 : LOCAL_HEADER_flen;
-        const char *src;
-        if (nsize && (src = fmap_need_ptr_once(map, zip, nsize))) {
-            memcpy(name, zip, nsize);
-            name[nsize] = '\0';
-            if (CL_SUCCESS != cli_basename(name, nsize, &original_filename)) {
-                original_filename = NULL;
-            }
-        } else
-            name[0] = '\0';
+
+    nsize = (LOCAL_HEADER_flen >= sizeof(name)) ? sizeof(name) - 1 : LOCAL_HEADER_flen;
+    src = fmap_need_ptr_once(map, zip, nsize);
+    if (nsize && (NULL != src)) {
+        memcpy(name, zip, nsize);
+        name[nsize] = '\0';
+        if (CL_SUCCESS != cli_basename(name, nsize, &original_filename)) {
+            original_filename = NULL;
+        }
+    } else {
+        name[0] = '\0';
     }
+
     zip += LOCAL_HEADER_flen;
     zsize -= LOCAL_HEADER_flen;
 


### PR DESCRIPTION
- ZIP: Always parse file names

   Having the filename is useful for certain callbacks, and will likely be
   more useful in the future if we can start comparing detected filetypes
   with file extensions.

   E.g. if filetype is just "binary" or "text" we may be able to do better
   by trusting a ".js" extension to determine the type.
   Or else if detected file type is "pe" but the extension is ".png" we may
   want to say it's suspicious.

- Adjust example callback program to disable metadata option

   The CL_SCAN_GENERAL_COLLECT_METADATA is no longer required for the Zip
   parser to record filenames for embedded files, and described in the
   previous commit.

   This program can be used to demonstrate that it is behaving as desired.