### PR TITLE
Fix alert-exceeds-max feature for files > 2GB and < max-filesize

### DIFF
--- a/libclamav/scanners.c
+++ b/libclamav/scanners.c
@@ -5497,21 +5497,6 @@ static cl_error_t scan_common(cl_fmap_t *map, const char *filepath, const char *
     cli_logg_setup(&ctx);
     logg_initalized = true;
 
-    /* We have a limit of around 2GB (INT_MAX - 2). Enforce it here. */
-    /* TODO: Large file support is large-ly untested. Remove this restriction
-     * and test with a large set of large files of various types. libclamav's
-     * integer type safety has come a long way since 2014, so it's possible
-     * we could lift this restriction, but at least one of the parsers is
-     * bound to behave badly with large files. */
-    if (map->len > INT_MAX - 2) {
-        if (scanoptions->heuristic & CL_SCAN_HEURISTIC_EXCEEDS_MAX) {
-            status = cli_append_potentially_unwanted(&ctx, "Heuristics.Limits.Exceeded.MaxFileSize");
-        } else {
-            status = CL_CLEAN;
-        }
-        goto done;
-    }
-
     status = cli_magic_scan(&ctx, CL_TYPE_ANY);
 
 #if HAVE_JSON


### PR DESCRIPTION
The --alert-exceeds-max feature should alert for all files larger than 2GB because 2GB is the internal limit for individual files. This isn't working correctly because the `goto done;` exit condition after recording the exceeds-max heuristic skips over the logic that reports the alert.

This fix moves the ">2GB" check up to the location where the max-filesize engine option is set by clamd or clamscan. If max-filesize > 2GB - 1 is requested, then max-filesize is set to 2GB - 1.

Additionally, a warning is printed if max-filesize > 2GB is requested (with an exception for when it's maxed out by setting --max-filesize=0).

Resolves: https://github.com/Cisco-Talos/clamav/issues/1030