### PR TITLE
Windows: update DLL names for openssl and pthreads to support new versions

### DIFF
--- a/win32/ClamAV-Installer.iss
+++ b/win32/ClamAV-Installer.iss
@@ -51,14 +51,14 @@ Source: "x64\Release\libmspack.dll"; DestDir: "{app}"; DestName: "libmspack.dll"
 Source: "x64\Release\sigtool.exe"; DestDir: "{app}"; DestName: "sigtool.exe"; Check: Is64BitInstallMode
 Source: "C:\clam_dependencies\x64\lib\json-c.dll"; DestDir: "{app}"; DestName: "json-c.dll"; Check: Is64BitInstallMode
 Source: "C:\clam_dependencies\x64\lib\libbz2.dll"; DestDir: "{app}"; DestName: "libbz2.dll"; Check: Is64BitInstallMode
-Source: "C:\clam_dependencies\x64\lib\libcrypto-1_1-x64.dll"; DestDir: "{app}"; DestName: "libcrypto-1_1-x64.dll"; Check: Is64BitInstallMode
-Source: "C:\clam_dependencies\x64\lib\libssl-1_1-x64.dll"; DestDir: "{app}"; DestName: "libssl-1_1-x64.dll"; Check: Is64BitInstallMode
+Source: "C:\clam_dependencies\x64\lib\libcrypto-3-x64.dll"; DestDir: "{app}"; DestName: "libcrypto-3-x64.dll"; Check: Is64BitInstallMode
+Source: "C:\clam_dependencies\x64\lib\libssl-3-x64.dll"; DestDir: "{app}"; DestName: "libssl-3-x64.dll"; Check: Is64BitInstallMode
 Source: "C:\clam_dependencies\x64\lib\libcurl.dll"; DestDir: "{app}"; DestName: "libcurl.dll"; Check: Is64BitInstallMode
 Source: "C:\clam_dependencies\x64\lib\libssh2.dll"; DestDir: "{app}"; DestName: "libssh2.dll"; Check: Is64BitInstallMode
 Source: "C:\clam_dependencies\x64\lib\libxml2.dll"; DestDir: "{app}"; DestName: "libxml2.dll"; Check: Is64BitInstallMode
 Source: "C:\clam_dependencies\x64\lib\nghttp2.dll"; DestDir: "{app}"; DestName: "nghttp2.dll"; Check: Is64BitInstallMode
 Source: "C:\clam_dependencies\x64\lib\pcre2-8.dll"; DestDir: "{app}"; DestName: "pcre2-8.dll"; Check: Is64BitInstallMode
-Source: "C:\clam_dependencies\x64\lib\pthreadVC2.dll"; DestDir: "{app}"; DestName: "pthreadVC2.dll"; Check: Is64BitInstallMode
+Source: "C:\clam_dependencies\x64\lib\pthreadVC3.dll"; DestDir: "{app}"; DestName: "pthreadVC3.dll"; Check: Is64BitInstallMode
 Source: "C:\clam_dependencies\x64\lib\pdcurses.dll"; DestDir: "{app}"; DestName: "pdcurses.dll"; Check: Is64BitInstallMode
 Source: "C:\clam_dependencies\vcredist\vc_redist.x64.exe"; DestDir: "{tmp}"; Flags: deleteafterinstall; Check: Is64BitInstallMode
 
@@ -79,14 +79,14 @@ Source: "Win32\Release\libmspack.dll"; DestDir: "{app}"; DestName: "libmspack.dl
 Source: "Win32\Release\sigtool.exe"; DestDir: "{app}"; DestName: "sigtool.exe"; Check: not Is64BitInstallMode
 Source: "C:\clam_dependencies\Win32\lib\json-c.dll"; DestDir: "{app}"; DestName: "json-c.dll"; Check: not Is64BitInstallMode
 Source: "C:\clam_dependencies\Win32\lib\libbz2.dll"; DestDir: "{app}"; DestName: "libbz2.dll"; Check: not Is64BitInstallMode
-Source: "C:\clam_dependencies\Win32\lib\libcrypto-1_1.dll"; DestDir: "{app}"; DestName: "libcrypto-1_1.dll"; Check: not Is64BitInstallMode
-Source: "C:\clam_dependencies\Win32\lib\libssl-1_1.dll"; DestDir: "{app}"; DestName: "libssl-1_1.dll"; Check: not Is64BitInstallMode
+Source: "C:\clam_dependencies\Win32\lib\libcrypto-3.dll"; DestDir: "{app}"; DestName: "libcrypto-3.dll"; Check: not Is64BitInstallMode
+Source: "C:\clam_dependencies\Win32\lib\libssl-3.dll"; DestDir: "{app}"; DestName: "libssl-3.dll"; Check: not Is64BitInstallMode
 Source: "C:\clam_dependencies\Win32\lib\libcurl.dll"; DestDir: "{app}"; DestName: "libcurl.dll"; Check: not Is64BitInstallMode
 Source: "C:\clam_dependencies\Win32\lib\libssh2.dll"; DestDir: "{app}"; DestName: "libssh2.dll"; Check: not Is64BitInstallMode
 Source: "C:\clam_dependencies\Win32\lib\libxml2.dll"; DestDir: "{app}"; DestName: "libxml2.dll"; Check: not Is64BitInstallMode
 Source: "C:\clam_dependencies\Win32\lib\nghttp2.dll"; DestDir: "{app}"; DestName: "nghttp2.dll"; Check: not Is64BitInstallMode
 Source: "C:\clam_dependencies\Win32\lib\pcre2-8.dll"; DestDir: "{app}"; DestName: "pcre2-8.dll"; Check: not Is64BitInstallMode
-Source: "C:\clam_dependencies\Win32\lib\pthreadVC2.dll"; DestDir: "{app}"; DestName: "pthreadVC2.dll"; Check: not Is64BitInstallMode
+Source: "C:\clam_dependencies\Win32\lib\pthreadVC3.dll"; DestDir: "{app}"; DestName: "pthreadVC3.dll"; Check: not Is64BitInstallMode
 Source: "C:\clam_dependencies\Win32\lib\pdcurses.dll"; DestDir: "{app}"; DestName: "pdcurses.dll"; Check: not Is64BitInstallMode
 Source: "C:\clam_dependencies\vcredist\vc_redist.x86.exe"; DestDir: "{tmp}"; Flags: deleteafterinstall; Check: not Is64BitInstallMode
 

--- a/win32/libclamav.vcxproj
+++ b/win32/libclamav.vcxproj
@@ -96,7 +96,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>libmspack.lib;win32_compat.lib;ws2_32.lib;json-c.lib;libbz2.lib;libcrypto.lib;libcurl_imp.lib;libssh2.lib;libssl.lib;libxml2.lib;nghttp2.lib;pcre2-8.lib;pthreadVC2.lib;zlibstatic.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>libmspack.lib;win32_compat.lib;ws2_32.lib;json-c.lib;libbz2.lib;libcrypto.lib;libcurl_imp.lib;libssh2.lib;libssl.lib;libxml2.lib;nghttp2.lib;pcre2-8.lib;pthreadVC3.lib;zlibstatic.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>$(SolutionDir)libclamav.def</ModuleDefinitionFile>
       <AdditionalLibraryDirectories>$(SolutionDir)$(PlatformName)\$(Configuration);$(CLAM_DEPENDENCIES)\$(PlatformName)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
@@ -114,7 +114,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>libmspack.lib;win32_compat.lib;ws2_32.lib;json-c.lib;libbz2.lib;libcrypto.lib;libcurl_imp.lib;libssh2.lib;libssl.lib;libxml2.lib;nghttp2.lib;pcre2-8.lib;pthreadVC2.lib;zlibstatic.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>libmspack.lib;win32_compat.lib;ws2_32.lib;json-c.lib;libbz2.lib;libcrypto.lib;libcurl_imp.lib;libssh2.lib;libssl.lib;libxml2.lib;nghttp2.lib;pcre2-8.lib;pthreadVC3.lib;zlibstatic.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>$(SolutionDir)libclamav.def</ModuleDefinitionFile>
       <AdditionalLibraryDirectories>$(SolutionDir)$(PlatformName)\$(Configuration);$(CLAM_DEPENDENCIES)\$(PlatformName)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
@@ -136,7 +136,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>libmspack.lib;win32_compat.lib;ws2_32.lib;json-c.lib;libbz2.lib;libcrypto.lib;libcurl_imp.lib;libssh2.lib;libssl.lib;libxml2.lib;nghttp2.lib;pcre2-8.lib;pthreadVC2.lib;zlibstatic.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>libmspack.lib;win32_compat.lib;ws2_32.lib;json-c.lib;libbz2.lib;libcrypto.lib;libcurl_imp.lib;libssh2.lib;libssl.lib;libxml2.lib;nghttp2.lib;pcre2-8.lib;pthreadVC3.lib;zlibstatic.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>$(SolutionDir)libclamav.def</ModuleDefinitionFile>
       <AdditionalLibraryDirectories>$(SolutionDir)$(PlatformName)\$(Configuration);$(CLAM_DEPENDENCIES)\$(PlatformName)\lib</AdditionalLibraryDirectories>
     </Link>
@@ -158,7 +158,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>libmspack.lib;win32_compat.lib;ws2_32.lib;json-c.lib;libbz2.lib;libcrypto.lib;libcurl_imp.lib;libssh2.lib;libssl.lib;libxml2.lib;nghttp2.lib;pcre2-8.lib;pthreadVC2.lib;zlibstatic.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>libmspack.lib;win32_compat.lib;ws2_32.lib;json-c.lib;libbz2.lib;libcrypto.lib;libcurl_imp.lib;libssh2.lib;libssl.lib;libxml2.lib;nghttp2.lib;pcre2-8.lib;pthreadVC3.lib;zlibstatic.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>$(SolutionDir)libclamav.def</ModuleDefinitionFile>
       <AdditionalLibraryDirectories>$(SolutionDir)$(PlatformName)\$(Configuration);$(CLAM_DEPENDENCIES)\$(PlatformName)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>

--- a/win32/libfreshclam.vcxproj
+++ b/win32/libfreshclam.vcxproj
@@ -101,7 +101,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>shared.lib;ws2_32.lib;pthreadVC2.lib;json-c.lib;libcrypto.lib;libcurl_imp.lib;libssh2.lib;libssl.lib;nghttp2.lib;zlibstatic.lib;libclamav.lib;Dnsapi.lib;Crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>shared.lib;ws2_32.lib;pthreadVC3.lib;json-c.lib;libcrypto.lib;libcurl_imp.lib;libssh2.lib;libssl.lib;nghttp2.lib;zlibstatic.lib;libclamav.lib;Dnsapi.lib;Crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(SolutionDir)$(PlatformName)\$(Configuration);$(CLAM_DEPENDENCIES)\$(PlatformName)\lib</AdditionalLibraryDirectories>
       <ModuleDefinitionFile>$(SolutionDir)libfreshclam.def</ModuleDefinitionFile>
     </Link>
@@ -118,7 +118,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>shared.lib;ws2_32.lib;pthreadVC2.lib;json-c.lib;libcrypto.lib;libcurl_imp.lib;libssh2.lib;libssl.lib;nghttp2.lib;zlibstatic.lib;libclamav.lib;Dnsapi.lib;Crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>shared.lib;ws2_32.lib;pthreadVC3.lib;json-c.lib;libcrypto.lib;libcurl_imp.lib;libssh2.lib;libssl.lib;nghttp2.lib;zlibstatic.lib;libclamav.lib;Dnsapi.lib;Crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(SolutionDir)$(PlatformName)\$(Configuration);$(CLAM_DEPENDENCIES)\$(PlatformName)\lib</AdditionalLibraryDirectories>
       <ModuleDefinitionFile>$(SolutionDir)libfreshclam.def</ModuleDefinitionFile>
     </Link>
@@ -140,7 +140,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(SolutionDir)$(PlatformName)\$(Configuration);$(CLAM_DEPENDENCIES)\$(PlatformName)\lib</AdditionalLibraryDirectories>
-      <AdditionalDependencies>shared.lib;ws2_32.lib;pthreadVC2.lib;json-c.lib;libcrypto.lib;libcurl_imp.lib;libssh2.lib;libssl.lib;nghttp2.lib;zlibstatic.lib;libclamav.lib;Dnsapi.lib;Crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>shared.lib;ws2_32.lib;pthreadVC3.lib;json-c.lib;libcrypto.lib;libcurl_imp.lib;libssh2.lib;libssl.lib;nghttp2.lib;zlibstatic.lib;libclamav.lib;Dnsapi.lib;Crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>$(SolutionDir)libfreshclam.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>
@@ -161,7 +161,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(SolutionDir)$(PlatformName)\$(Configuration);$(CLAM_DEPENDENCIES)\$(PlatformName)\lib</AdditionalLibraryDirectories>
-      <AdditionalDependencies>shared.lib;ws2_32.lib;pthreadVC2.lib;json-c.lib;libcrypto.lib;libcurl_imp.lib;libssh2.lib;libssl.lib;nghttp2.lib;zlibstatic.lib;libclamav.lib;Dnsapi.lib;Crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>shared.lib;ws2_32.lib;pthreadVC3.lib;json-c.lib;libcrypto.lib;libcurl_imp.lib;libssh2.lib;libssl.lib;nghttp2.lib;zlibstatic.lib;libclamav.lib;Dnsapi.lib;Crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>$(SolutionDir)libfreshclam.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>


### PR DESCRIPTION
Goal is primarily to switch to openssl 3.x. 