### PR TITLE
Fix link error with LLD 17 (1.0.4)

### DIFF
--- a/libclamav/libclamav.map
+++ b/libclamav/libclamav.map
@@ -80,7 +80,6 @@ CLAMAV_PRIVATE {
     cli_strlcat;
     cli_strlcpy;
     cli_strntoul;
-    cli_cvdunpack;
     cli_regcomp;
     cli_regexec;
     cli_regfree;
@@ -97,7 +96,6 @@ CLAMAV_PRIVATE {
     cli_ole2_extract;
     cli_errmsg;
     cli_debug_flag;
-    cli_dbgmsg_internal;
     cli_vba_readdir;
     cli_vba_inflate;
     cli_ppt_vba_read;
@@ -146,8 +144,6 @@ CLAMAV_PRIVATE {
     regex_list_match;
     cli_hashset_destroy;
     phishing_init;
-    init_domainlist;
-    init_whitelist;
     phishing_done;
     blobCreate;
     blobAddData;
@@ -169,7 +165,6 @@ CLAMAV_PRIVATE {
     cli_ac_free;
     cli_ac_chklsig;
     cli_sigopts_handler;
-    cli_parse_add;
     cli_bm_init;
     cli_bm_scanbuff;
     cli_bm_free;
@@ -209,7 +204,7 @@ CLAMAV_PRIVATE {
     cli_bytecode_context_setparam_ptr;
     cli_bytecode_context_setfile;
     cli_bytecode_context_getresult_int;
-    cli_bytecode_context_clear;
+
     cli_bytecode_init;
     cli_bytecode_done;
     cli_bytecode_debug;


### PR DESCRIPTION
Backport of https://github.com/Cisco-Talos/clamav/pull/1051

---

Developers of FreeBSD base system are currently working to upgrade its LLVM/Clang/LLDB/LLD to 17. As a part of it they tried building all ports in FreeBSD ports collections to check if build of them succeeds with LLVM/Clang/LLD 17. As a result there are some ports that fail to be built with it and unfortunately `security/clamav` is one of them. The build of it fails with link error as following.

```
  ld: error: version script assignment of 'CLAMAV_PRIVATE' to symbol 'cli_cvdunpack' failed: symbol not defined
  ld: error: version script assignment of 'CLAMAV_PRIVATE' to symbol 'cli_dbgmsg_internal' failed: symbol not defined
  ld: error: version script assignment of 'CLAMAV_PRIVATE' to symbol 'init_domainlist' failed: symbol not defined
  ld: error: version script assignment of 'CLAMAV_PRIVATE' to symbol 'init_whitelist' failed: symbol not defined
  ld: error: version script assignment of 'CLAMAV_PRIVATE' to symbol 'cli_parse_add' failed: symbol not defined
  ld: error: version script assignment of 'CLAMAV_PRIVATE' to symbol 'cli_bytecode_context_clear' failed: symbol not defined
  cc: error: linker command failed with exit code 1 (use -v to see invocation)
```

According to the investigation of ClamAV's source code, `cli_cvdunpack` is a static function so it isn't visible to external consumers. And other mentioned symbols aren't found anywhere. So fix link error by removing all of them from linker version script.