### PR TITLE
Add Haiku (BeOS-like) support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -612,7 +612,7 @@ endforeach()
 
 # Always use '-fPIC'/'-fPIE' option if OS is not Haiku.
 if(NOT HAIKU)
-       set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+    set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 endif()
 
 # Checks for header files.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -610,8 +610,10 @@ foreach(_cxx1x_flag -std=c++14 -std=c++11)
     endif()
 endforeach()
 
-# Always use '-fPIC'/'-fPIE' option.
-set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+# Always use '-fPIC'/'-fPIE' option if OS is not Haiku.
+if(NOT HAIKU)
+       set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+endif()
 
 # Checks for header files.
 include(CheckIncludeFile)

--- a/libfreshclam/CMakeLists.txt
+++ b/libfreshclam/CMakeLists.txt
@@ -48,6 +48,10 @@ if(ENABLE_SHARED_LIB)
                 resolv
                 ${APPLE_CORE_FOUNDATION}
                 ${APPLE_SECURITY} )
+    elseif(HAIKU)
+        target_link_libraries( freshclam
+            PUBLIC
+                network )
     elseif(UNIX)
         if(HAVE_RESOLV_H AND NOT C_BSD) # BSD appears to have libresolv inside libc
             target_link_libraries( freshclam
@@ -128,6 +132,10 @@ if(ENABLE_STATIC_LIB)
                 resolv
                 ${APPLE_CORE_FOUNDATION}
                 ${APPLE_SECURITY} )
+    elseif(HAIKU)
+        target_link_libraries( freshclam_static
+            PUBLIC
+                network )
     elseif(UNIX)
         if(HAVE_RESOLV_H AND NOT C_BSD) # BSD appears to have libresolv inside libc
             target_link_libraries( freshclam_static


### PR DESCRIPTION
Hello,
recently I ported ClamAV (and all its modules except MILTER) to Haiku (a BeOS-like operating system).
I tried to do things in the cleanest way possible and to keeps patches at a minimum, in the hope to upstream these changes.
All three proposed changes are wrapped in if/elseif statements to avoid the possibility of introducing regressions.

I really hope that this PR will be accepted, so future ClamAV versions can be compiled without patches.

Thank you very much,
Luca