### PR TITLE
Windows: json-c 0.17 compatibility with ssize_t type definition (0.103.11)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -349,13 +349,13 @@ check_type_size("ssize_t" SIZEOF_SSIZE_T)
 if(SIZEOF_SSIZE_T STREQUAL "")
     # ssize_t is a signed type in POSIX storing at least -1.
     # Set it to "int" to match the behavior of AC_TYPE_SSIZE_T (autotools).
-    set(ssize_t int)
+    set(SSIZE_T_DEF "typedef int ssize_t;")
 endif()
 check_type_size("off_t" SIZEOF_OFF_T)
 if(SIZEOF_OFF_T STREQUAL "")
     # off_t is a signed type in POSIX no narrower than int.
     # Set it to "long int" to match the behavior of AC_TYPE_OFF_T (autotools).
-    set(off_t long int)
+    set(OFF_T_DEF "typedef long int off_t;")
 endif()
 
 check_type_size("int" SIZEOF_INT)

--- a/clamav-config.h.cmake.in
+++ b/clamav-config.h.cmake.in
@@ -581,11 +581,22 @@
 #define inline @INLINE_KEYWORD@
 #endif
 
-/* Define to `long int' if <sys/types.h> does not define. */
-#cmakedefine off_t @off_t@
-
 /* Define to `int' if <sys/types.h> does not define. */
-#cmakedefine ssize_t @ssize_t@
+#ifndef SSIZE_T_DEFINED
+   #if defined(_MSC_VER)
+      #include <BaseTsd.h>
+      typedef SSIZE_T ssize_t;
+   #else
+      @SSIZE_T_DEF@
+   #endif
+   # define SSIZE_T_DEFINED
+#endif
+
+/* Define to `long int' if <sys/types.h> does not define. */
+#ifndef OFF_T_DEFINED
+   @OFF_T_DEF@
+   #define OFF_T_DEFINED
+#endif
 
 /* Define to the equivalent of the C99 'restrict' keyword, or to
    nothing if this is not supported.  Do not define if restrict is

--- a/win32/clamav-config.h
+++ b/win32/clamav-config.h
@@ -573,7 +573,8 @@
 /* #undef off_t */
 
 /* Define to `int' */
-typedef int ssize_t;
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
 
 /* Define to the equivalent of the C99 'restrict' keyword, or to
    nothing if this is not supported.  Do not define if restrict is

--- a/win32/compat/net.h
+++ b/win32/compat/net.h
@@ -24,8 +24,14 @@
 
 /* Don't include clamav-config.h, because that brings in platform.h
    and platform.h will make these functions recursive ;-). */
-#ifndef ssize_t
+#ifndef SSIZE_T_DEFINED
+#if defined(_MSC_VER)
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+#else
 typedef int ssize_t;
+#endif
+#define SSIZE_T_DEFINED
 #endif
 
 #define F_GETFL 1

--- a/win32/llvmbuild/include/llvm/System/DataTypes.h
+++ b/win32/llvmbuild/include/llvm/System/DataTypes.h
@@ -109,7 +109,8 @@ typedef short int16_t;
 typedef unsigned short uint16_t;
 typedef signed char int8_t;
 typedef unsigned char uint8_t;
-typedef signed int ssize_t;
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
 /* Certain compatibility updates to VC++ introduce the `cstdint'
 * header, which defines the INT*_C macros. On default installs they
 * are absent. */


### PR DESCRIPTION
Backport of https://github.com/Cisco-Talos/clamav/pull/1002

Note: this one has an extra commit with the same changes to some files that weren't generated back in 0.103 days when using Visual Studio. 

---

json-c 0.17 defines the ssize_t type using a typedef on Windows. We have been setting ssize_t for Windows to a different type using a #define instead of a typedef.

We should have been using a typedef since it is a type. However, we must also match the exact type they're setting it to or else the compiler will baulk because the types are different.

Note: in C11, it's fine to use typedef the same type more than once, so long as you're defining it the same every time.