### PR TITLE
CMake+Rust: Fix offline builds w. vendored git repos

### DIFF
--- a/cmake/FindRust.cmake
+++ b/cmake/FindRust.cmake
@@ -209,6 +209,11 @@ function(cargo_vendor)
 [source.crates-io]
 replace-with = \"vendored-sources\"
 
+[source.\"git+https://github.com/Cisco-Talos/onenote.rs.git?branch=CLAM-2329-new-from-slice\"]
+git = \"hhttps://github.com/Cisco-Talos/onenote.rs.git\"
+branch = \"CLAM-2329-new-from-slice\"
+replace-with = \"vendored-sources\"
+
 [source.vendored-sources]
 directory = \".cargo/vendor\"
 "


### PR DESCRIPTION
Some builds using the tarball with the vendored Rust dependencies are failing.

The onenote-rs dependency is presently tied to a git branch from github rather than using a release from crates.io. This is the differing factor though I'm unsure why it is causing the build to try to update the repo rather than just building the vendored source.

This commit adds a `--offline` parameter to the build options if the vendored source is detected, in an attempt to force Cargo to use what it has and stay offline.