### PR TITLE
Fix issue installing empty database directory

### DIFF
--- a/freshclam/CMakeLists.txt
+++ b/freshclam/CMakeLists.txt
@@ -46,9 +46,6 @@ else()
     install(TARGETS freshclam-bin DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT programs)
 endif()
 
-# Install an empty database directory
-INSTALL(CODE "FILE(MAKE_DIRECTORY \${ENV}\${CMAKE_INSTALL_PREFIX}/\${DATABASE_DIRECTORY})" COMPONENT programs)
-
 # Now we rename freshclam-bin executable to freshclam using target properties
 set_target_properties( freshclam-bin
         PROPERTIES OUTPUT_NAME freshclam )


### PR DESCRIPTION
The CMake code to install the empty database directory doesn't appear to do anything.  Further, it is causing build issues for some users.

Instead of running code to make the directory, it appears we can just install a directory directly.

Fixes: https://github.com/Cisco-Talos/clamav/issues/1142