### PR TITLE
Clam 2507 rc2 prep

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ cmake_policy(SET CMP0087 NEW) # support generator expressions in install(CODE) a
 #  For release candidate:     set(VERSION_SUFFIX "-rc")
 #  For release:               set(VERSION_SUFFIX "")
 string(TIMESTAMP TODAY "%Y%m%d")
-set(VERSION_SUFFIX "-rc")
+set(VERSION_SUFFIX "-rc2")
 
 project( ClamAV
          VERSION "1.3.0"

--- a/NEWS.md
+++ b/NEWS.md
@@ -52,6 +52,9 @@ ClamAV 1.3.0 includes the following improvements and changes:
   "CL_TYPE_PYTHON_COMPILED" instead of "CL_TYPE_BINARY_DATA".
   - [GitHub pull request](https://github.com/Cisco-Talos/clamav/pull/1111)
 
+- Improved support for decrypting PDF's with empty passwords.
+  - [GitHub pull request](https://github.com/Cisco-Talos/clamav/pull/1141)
+
 - Assorted minor improvements and typo fixes.
 
 ### Bug fixes
@@ -65,9 +68,23 @@ ClamAV 1.3.0 includes the following improvements and changes:
 - ClamOnAcc: Fixed an infinite loop when a watched directory does not exist.
   - [GitHub pull request](https://github.com/Cisco-Talos/clamav/pull/1047)
 
+- ClamOnAcc: Fixed an infinite loop when a file has been deleted before a scan.
+  Patch courtesy of gsuehiro.
+  - [GitHub pull request](https://github.com/Cisco-Talos/clamav/pull/1150)
+
 - Fixed a possible crash when processing VBA files on HP-UX/IA 64bit.
   Patch courtesy of Albert Chin-A-Young.
   - [GitHub pull request](https://github.com/Cisco-Talos/clamav/pull/526)
+
+- ClamConf: Fixed an issue printing `MaxScanSize` introduced with the change
+  to allow a MaxScanSize greater than 4 GiB.
+  Fix courtesy of teoberi.
+  - [GitHub pull request](https://github.com/Cisco-Talos/clamav/pull/1121)
+
+- Fixed an issue building a ClamAV RPM in some configurations.
+  The issue was caused by faulty CMake logic that intended to create an
+  empty database directory during the install.
+  - [GitHub pull request](https://github.com/Cisco-Talos/clamav/pull/1144)
 
 ### Acknowledgments
 
@@ -75,8 +92,10 @@ Special thanks to the following people for code contributions and bug reports:
 - Albert Chin-A-Young
 - Andrew Kiggins
 - driverxdw
+- gsuehiro
 - Luca D'Amico
 - RainRat
+- teoberi
 
 ## 1.2.1
 

--- a/cmake/FindRust.cmake
+++ b/cmake/FindRust.cmake
@@ -210,7 +210,7 @@ function(cargo_vendor)
 replace-with = \"vendored-sources\"
 
 [source.\"git+https://github.com/Cisco-Talos/onenote.rs.git?branch=CLAM-2329-new-from-slice\"]
-git = \"hhttps://github.com/Cisco-Talos/onenote.rs.git\"
+git = \"https://github.com/Cisco-Talos/onenote.rs.git\"
 branch = \"CLAM-2329-new-from-slice\"
 replace-with = \"vendored-sources\"
 


### PR DESCRIPTION
Set the 1.3.0-rc2 version suffix
Rust: Update pinned dependency versions in Cargo.lock file
News: Update release notes for 1.3.0-rc2
