### PR TITLE
Import clamav-sys

### DIFF
--- a/clamav-sys/.gitignore
+++ b/clamav-sys/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/clamav-sys/Cargo.toml
+++ b/clamav-sys/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+authors = [
+    "Jonas Zaddach <jzaddach@cisco.com>",
+    "Scott Hutton <schutton@cisco.com>",
+]
+categories = ["external-ffi-bindings"]
+description = "ClamAV low level bindings for Rust"
+edition = "2021"
+homepage = "https://github.com/Cisco-Talos/clamav-sys/"
+license = "GPL-2.0"
+name = "clamav-sys"
+repository = "https://github.com/Cisco-Talos/clamav-sys/"
+version = "1.0.0"
+
+[build-dependencies]
+bindgen = "0.64.0"
+
+[target.'cfg(unix)'.build-dependencies]
+pkg-config = "0.3"
+
+[target.'cfg(windows)'.build-dependencies]
+vcpkg = "0.2.10"

--- a/clamav-sys/LICENSE
+++ b/clamav-sys/LICENSE
@@ -1,0 +1,339 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/clamav-sys/README.md
+++ b/clamav-sys/README.md
@@ -1,0 +1,64 @@
+# clamav-sys
+
+clamav-sys is a minimal Rust interface around [libclamav](https://www.clamav.net).
+This package is not supposed to be used stand-alone, but only through its safe wrapper,
+clamav-rs.
+
+
+## Building
+
+### Unix (anything but Windows)
+You should have the `clamav-dev` package of your distribution installed (ClamAV
+with headers). The headers and library should be picked up automatically via
+pkg-config.
+
+### Windows
+#### vcpkg
+The preferred way of handling dependencies is `vcpkg`.
+Point `$env:VCPKG_ROOT` to your `vcpkg` installation, and set
+`$env:VCPKGRS_DYNAMIC=1` to use dynamic linking (the default method of linking will
+likely not work, as `pdcurses` doesn't support the `x64-windows-static-md` triplet).
+
+See the [vcpkg crate's documentation](https://docs.rs/vcpkg) for more details. 
+
+Gotchas:
+- Windows has its own version of a zlib dll that is incompatbile with vcpkg. If
+  you get a message such as "The procedure entry point gzdirect could not be
+  located in the dynamic link library", you'll want to make sure that the vcpkg
+  dynamic libraries in your PATH variable are preceding the Windows one.
+  ```
+  $env:PATH="$env:VCPKG_ROOT\installed\x64-windows\bin\;$env:PATH"
+  ```
+  This error is especially hard to diagnose in PowerShell, as the process will
+  just hang without any output. In cmd.exe you'll get the aforementioned dialog
+  box telling you about the error.
+
+
+#### Manual
+If `vcpkg` is not available or cannot be found on your system, the build defaults
+to a manual specification of dependencies.
+You will need to define the following environment variables:
+- `CLAMAV_SOURCE`: Points to the directory where the ClamAV source is located.
+- `CLAMAV_BUILD`: Points to the ClamAV build directory.
+- `OPENSSL_INCLUDE`: Points to the include directory containing `openssl/ssl.h`.
+
+### MacOS
+Install the development dependencies via `homebrew`:
+```
+brew install clamav openssl@1.1
+```
+
+OpenSSL is not included in the environment to avoid shadowing Apple's one, so
+you need to tell the build script where it is located:
+```
+export OPENSSL_ROOT_DIR=/usr/local/Cellar/openssl@1.1/1.1.1i/
+```
+
+## Versioning
+The version number of `libclamav-sys` tracks ClamAV's version number. That is,
+you'll require at least ClamAV 1.0.0 to build `libclamav-sys` 1.0.0. As ClamAV
+usually doesn't do breaking API changes, you'll be able to use `libclamav-sys`
+with newer ClamAV versions.
+
+No attempt at preserving downward compatibility (using a `libclamav-sys` with
+a version number greater than ClamAV's) is made.

--- a/clamav-sys/build.rs
+++ b/clamav-sys/build.rs
@@ -1,0 +1,226 @@
+// Copyright (C) 2020-2023 Cisco Systems, Inc. and/or its affiliates. All rights reserved.
+//
+// Authors: Jonas Zaddach, Scott Hutton
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 2 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+// MA 02110-1301, USA.
+
+use std::env;
+use std::path::PathBuf;
+
+// Generate bindings for these functions:
+const BINDGEN_FUNCTIONS: &[&str] = &[
+    "cl_cleanup_crypto",
+    "cl_cvdfree",
+    "cl_cvdparse",
+    "cl_debug",
+    "cl_engine_addref",
+    "cl_engine_compile",
+    "cl_engine_free",
+    "cl_engine_get_num",
+    "cl_engine_get_str",
+    "cl_engine_new",
+    "cl_engine_set_clcb_engine_compile_progress",
+    "cl_engine_set_clcb_engine_free_progress",
+    "cl_engine_set_clcb_file_inspection",
+    "cl_engine_set_clcb_file_props",
+    "cl_engine_set_clcb_hash",
+    "cl_engine_set_clcb_meta",
+    "cl_engine_set_clcb_post_scan",
+    "cl_engine_set_clcb_pre_cache",
+    "cl_engine_set_clcb_pre_scan",
+    "cl_engine_set_clcb_sigload",
+    "cl_engine_set_clcb_sigload_progress",
+    "cl_engine_set_clcb_stats_add_sample",
+    "cl_engine_set_clcb_stats_decrement_count",
+    "cl_engine_set_clcb_stats_flush",
+    "cl_engine_set_clcb_stats_get_hostid",
+    "cl_engine_set_clcb_stats_get_num",
+    "cl_engine_set_clcb_stats_get_size",
+    "cl_engine_set_clcb_stats_remove_sample",
+    "cl_engine_set_clcb_stats_submit",
+    "cl_engine_set_clcb_virus_found",
+    "cl_engine_set_num",
+    "cl_engine_set_stats_set_cbdata",
+    "cl_engine_set_str",
+    "cl_engine_settings_apply",
+    "cl_engine_settings_copy",
+    "cl_engine_settings_free",
+    "cl_engine_stats_enable",
+    "cl_fmap_close",
+    "cl_fmap_open_handle",
+    "cl_fmap_open_memory",
+    "cl_init",
+    "cl_initialize_crypto",
+    "cl_load",
+    "cl_retdbdir",
+    "cl_retflevel",
+    "cl_retver",
+    "cl_scandesc",
+    "cl_scandesc_callback",
+    "cl_scanfile",
+    "cl_scanfile_callback",
+    "cl_scanmap_callback",
+    "cl_set_clcb_msg",
+    "cl_strerror",
+    "cli_append_virus",
+    "cli_ctx",
+    "cli_dbgmsg_no_inline",
+    "cli_errmsg",
+    "cli_get_debug_flag",
+    "cli_getdsig",
+    "cli_infomsg_simple",
+    "cli_versig2",
+    "cli_warnmsg",
+    "lsig_increment_subsig_match",
+];
+
+// Generate bindings for these types (structs, prototypes, etc.):
+const BINDGEN_TYPES: &[&str] = &[
+    "cl_cvd",
+    "clcb_file_props",
+    "clcb_meta",
+    "clcb_post_scan",
+    "clcb_pre_scan",
+    "cli_ac_data",
+    "cli_ac_result",
+    "cli_matcher",
+    "time_t",
+];
+
+// Generate "newtype" enums for these C enums
+const BINDGEN_ENUMS: &[&str] = &["cl_engine_field", "cl_error_t", "cl_msg"];
+
+const BINDGEN_CONSTANTS: &[&str] = &[
+    "CL_DB_.*",
+    "CL_INIT_DEFAULT",
+    "CL_SCAN_.*",
+    "ENGINE_OPTIONS_.*",
+    "LAYER_ATTRIBUTES_.*",
+];
+
+const CLAMAV_LIBRARY_NAME: &str = "clamav";
+
+fn generate_bindings(customize_bindings: &dyn Fn(bindgen::Builder) -> bindgen::Builder) {
+    let mut bindings = bindgen::Builder::default();
+    for function in BINDGEN_FUNCTIONS {
+        bindings = bindings.allowlist_function(function);
+    }
+
+    for typename in BINDGEN_TYPES {
+        bindings = bindings.allowlist_type(typename);
+    }
+
+    for typename in BINDGEN_ENUMS {
+        bindings = bindings.newtype_enum(typename);
+    }
+
+    for constant in BINDGEN_CONSTANTS {
+        bindings = bindings.allowlist_var(constant);
+    }
+
+    bindings = bindings
+        .header("wrapper.h")
+        // Tell cargo to invalidate the built crate whenever any of the
+        // included header files changed.
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks));
+
+    bindings = customize_bindings(bindings);
+
+    // Write the bindings to the $OUT_DIR/bindings.rs file.
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+
+    bindings
+        // Finish the builder and generate the bindings.
+        .generate()
+        // Unwrap the Result and panic on failure.
+        .expect("Unable to generate bindings")
+        .write_to_file(out_path.join("bindings.rs"))
+        .expect("Couldn't write bindings!");
+}
+
+fn cargo_common() {
+    println!("cargo:rustc-link-lib=dylib={}", CLAMAV_LIBRARY_NAME);
+
+    // Tell cargo to invalidate the built crate whenever the wrapper changes
+    println!("cargo:rerun-if-changed=wrapper.h");
+}
+
+#[cfg(windows)]
+fn main() {
+    let include_paths = match vcpkg::find_package("clamav") {
+        Ok(pkg) => pkg.include_paths,
+        Err(err) => {
+            println!(
+                "cargo:warning=Either vcpkg is not installed, or an error occurred in vcpkg: {}",
+                err
+            );
+            let clamav_source = PathBuf::from(env::var("CLAMAV_SOURCE").expect("CLAMAV_SOURCE environment variable must be set and point to ClamAV's source directory"));
+            let clamav_build = PathBuf::from(env::var("CLAMAV_BUILD").expect("CLAMAV_BUILD environment variable must be set and point to ClamAV's build directory"));
+            let openssl_include = PathBuf::from(env::var("OPENSSL_INCLUDE").expect("OPENSSL_INCLUDE environment variable must be set and point to openssl's include directory"));
+            let profile = env::var("PROFILE").unwrap();
+
+            let library_path = match profile.as_str() {
+                "debug" => std::path::Path::new(&clamav_build).join("libclamav/Debug"),
+                "release" => std::path::Path::new(&clamav_build).join("libclamav/Release"),
+                _ => panic!("Unexpected build profile"),
+            };
+
+            println!(
+                "cargo:rustc-link-search=native={}",
+                library_path.to_str().unwrap()
+            );
+
+            vec![
+                clamav_source.join("libclamav"),
+                clamav_build,
+                openssl_include,
+            ]
+        }
+    };
+
+    cargo_common();
+    generate_bindings(&|x: bindgen::Builder| -> bindgen::Builder {
+        let mut x = x;
+        for include_path in &include_paths {
+            x = x.clang_arg("-I").clang_arg(include_path.to_str().unwrap());
+        }
+        x
+    });
+}
+
+#[cfg(unix)]
+fn main() {
+    let libclamav = pkg_config::Config::new()
+        .atleast_version("0.103")
+        .probe("libclamav")
+        .unwrap();
+
+    let mut include_paths = libclamav.include_paths;
+
+    if let Some(val) = std::env::var_os("OPENSSL_ROOT_DIR") {
+        let mut openssl_include_dir = PathBuf::from(val);
+        openssl_include_dir.push("include");
+        include_paths.push(openssl_include_dir);
+    }
+
+    cargo_common();
+    generate_bindings(&|x: bindgen::Builder| -> bindgen::Builder {
+        let mut x = x;
+        for include_path in &include_paths {
+            x = x.clang_arg("-I").clang_arg(include_path.to_str().unwrap());
+        }
+        x
+    });
+}

--- a/clamav-sys/src/lib.rs
+++ b/clamav-sys/src/lib.rs
@@ -1,0 +1,178 @@
+// Copyright (C) 2020-2023 Cisco Systems, Inc. and/or its affiliates. All rights reserved.
+//
+// Authors: Jonas Zaddach, Scott Hutton
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 2 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+// MA 02110-1301, USA.
+
+#![warn(clippy::all, clippy::pedantic)]
+#![allow(
+    non_camel_case_types,
+    non_upper_case_globals,
+    clippy::unreadable_literal
+)]
+
+use std::ffi::CStr;
+
+include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+
+impl Default for cl_scan_options {
+    fn default() -> Self {
+        cl_scan_options {
+            general: 0,
+            parse: CL_SCAN_PARSE_ARCHIVE
+                | CL_SCAN_PARSE_MAIL
+                | CL_SCAN_PARSE_OLE2
+                | CL_SCAN_PARSE_PDF
+                | CL_SCAN_PARSE_HTML
+                | CL_SCAN_PARSE_SWF
+                | CL_SCAN_PARSE_PE
+                | CL_SCAN_PARSE_ELF
+                | CL_SCAN_PARSE_SWF
+                | CL_SCAN_PARSE_XMLDOCS,
+            heuristic: 0,
+            mail: 0,
+            dev: 0,
+        }
+    }
+}
+
+impl PartialEq for cl_scan_options {
+    fn eq(&self, other: &Self) -> bool {
+        self.general == other.general
+            && self.parse == other.parse
+            && self.heuristic == other.heuristic
+            && self.mail == other.mail
+            && self.dev == other.dev
+    }
+}
+
+/// We need this for Windows, MSVC will use an `i32` as underlying enum type instead of `u32` like
+/// gcc and clang.
+impl From<i32> for cl_error_t {
+    fn from(val: i32) -> cl_error_t {
+        unsafe { cl_error_t(std::mem::transmute(val)) }
+    }
+}
+
+impl From<u32> for cl_error_t {
+    fn from(val: u32) -> cl_error_t {
+        cl_error_t(val)
+    }
+}
+
+impl From<cl_error_t> for i32 {
+    fn from(val: cl_error_t) -> i32 {
+        unsafe { std::mem::transmute(val.0) }
+    }
+}
+
+impl From<cl_error_t> for u32 {
+    fn from(val: cl_error_t) -> u32 {
+        val.0
+    }
+}
+
+impl std::fmt::Display for cl_error_t {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        unsafe {
+            let msg = CStr::from_ptr(cl_strerror(*self));
+            f.write_str(msg.to_str().unwrap_or("<unknown ClamAV error>"))
+        }
+    }
+}
+
+/// We need this for Windows, MSVC will use an `i32` as underlying enum type instead of `u32` like
+/// gcc and clang.
+impl From<i32> for cl_engine_field {
+    fn from(val: i32) -> cl_engine_field {
+        unsafe { cl_engine_field(std::mem::transmute(val)) }
+    }
+}
+
+impl From<u32> for cl_engine_field {
+    fn from(val: u32) -> cl_engine_field {
+        cl_engine_field(val)
+    }
+}
+
+impl From<cl_engine_field> for i32 {
+    fn from(val: cl_engine_field) -> i32 {
+        unsafe { std::mem::transmute(val.0) }
+    }
+}
+
+impl From<cl_engine_field> for u32 {
+    fn from(val: cl_engine_field) -> u32 {
+        val.0
+    }
+}
+
+impl std::fmt::Display for cl_engine_field {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(&self.0, f)
+    }
+}
+
+/// We need this for Windows, MSVC will use an `i32` as underlying enum type instead of `u32` like
+/// gcc and clang.
+impl From<i32> for cl_msg {
+    fn from(val: i32) -> cl_msg {
+        unsafe { cl_msg(std::mem::transmute(val)) }
+    }
+}
+
+impl From<u32> for cl_msg {
+    fn from(val: u32) -> cl_msg {
+        cl_msg(val)
+    }
+}
+
+impl From<cl_msg> for i32 {
+    fn from(val: cl_msg) -> i32 {
+        unsafe { std::mem::transmute(val.0) }
+    }
+}
+
+impl From<cl_msg> for u32 {
+    fn from(val: cl_msg) -> u32 {
+        val.0
+    }
+}
+
+impl std::fmt::Display for cl_msg {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(&self.0, f)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::cl_msg;
+
+    #[test]
+    fn msg_levels_exist() {
+        // Just a compilation check that the message levels are there. We don't
+        // check their values since those are defined in the C header file.
+        assert!(cl_msg::CL_MSG_WARN != cl_msg(0));
+        assert!(cl_msg::CL_MSG_ERROR != cl_msg(0));
+        assert!(cl_msg::CL_MSG_INFO_VERBOSE != cl_msg(0));
+    }
+
+    #[test]
+    fn test_cl_error_t_to_string() {
+        let err = super::cl_error_t::CL_EMEM;
+        assert_eq!(err.to_string(), "Can't allocate memory".to_string());
+    }
+}

--- a/clamav-sys/wrapper.h
+++ b/clamav-sys/wrapper.h
@@ -1,0 +1,1 @@
+#include <clamav.h>


### PR DESCRIPTION
This is a bare import of the `clamav-sys` tree into `clamav`, as well as including it in the workspace `Cargo.toml`.

This is a precursor to being fully integrated, but as this brings in history from a foreign repository, this merge is being done separate of that work, and shouldn't impact the `clamav` build.