### PR TITLE
Update libclamav.map with missing symbols

### DIFF
--- a/libclamav/libclamav.map
+++ b/libclamav/libclamav.map
@@ -202,10 +202,17 @@ CLAMAV_PRIVATE {
     cli_writen;
     cli_url_canon;
     cli_strerror;
+    cli_ftname;
+    cli_ftcode;
     decodeLine;
     messageCreate;
     messageDestroy;
     base64Flush;
+    cli_unrar_open;
+    cli_unrar_peek_file_header;
+    cli_unrar_extract_file;
+    cli_unrar_skip_file;
+    cli_unrar_close;
     have_rar;
     have_clamjit;
     cli_bytecode_load;


### PR DESCRIPTION
Linker errors when supplying local unrar interface
```
[2024-01-25T17:38:36.469Z] : && g++   clamshell/clamshell_unpriv/CMakeFiles/clamshell-bin.dir/main.cpp.o clamshell/clamshell_unpriv/CMakeFiles/clamshell-bin.dir/crash_handler_crashpad.cpp.o -o clamshell/clamshell_unpriv/clamshell -L/home/jenkins/workspace/Cloud_ampcx_PR-7032/ampcx/build/debug/export/lib -Wl,-rpath,/home/jenkins/workspace/Cloud_ampcx_PR-7032/ampcx/build/debug/export/lib::::::::  src/libclamshell_unpriv.a  -lclamav  -lclamunrar_iface  -lclamunrar  -lclammspack  -Wl,-Bstatic  -lpcre2-8  -lssl  -lcrypto  -lxml2  -Wl,-Bdynamic  -lcrashpad_handler_lib  -lcrashpad_client  -lcrashpad_common  -lcrashpad_minidump  -lcrashpad_snapshot  -lcrashpad_common  -lcrashpad_context  -lcrashpad_net  -lcrashpad_util  -lcrashpad_base  -lz  -lrt  -lpthread  -lm  -ldl  -lbz2  -lstdc++  -lcrashpad_minidump  -lcrashpad_snapshot  -lcrashpad_context  -lcrashpad_net  -lcrashpad_util  -lcrashpad_base  -lz  -lrt  -lpthread  -lm  -ldl  -lbz2  -lstdc++ && :

[2024-01-25T17:38:36.469Z] /usr/bin/ld: src/libclamshell_unpriv.a(clamshell_unrar.c.o): in function `cs_unrar_enable':
[2024-01-25T17:38:36.469Z] clamshell_unrar.c:(.text+0x7): undefined reference to `cli_unrar_open'
[2024-01-25T17:38:36.469Z] /usr/bin/ld: clamshell_unrar.c:(.text+0x18): undefined reference to `cli_unrar_peek_file_header'
[2024-01-25T17:38:36.469Z] /usr/bin/ld: clamshell_unrar.c:(.text+0x29): undefined reference to `cli_unrar_extract_file'
[2024-01-25T17:38:36.469Z] /usr/bin/ld: clamshell_unrar.c:(.text+0x3a): undefined reference to `cli_unrar_skip_file'
[2024-01-25T17:38:36.469Z] /usr/bin/ld: clamshell_unrar.c:(.text+0x4b): undefined reference to `cli_unrar_close'
```
