### PR TITLE
PDF: Fix 1-byte overread

### DIFF
--- a/libclamav/pdfng.c
+++ b/libclamav/pdfng.c
@@ -240,16 +240,23 @@ static char *pdf_decrypt_string(struct pdf_struct *pdf, struct pdf_obj *obj, con
     if (pdf->flags & (1 << DECRYPTABLE_PDF)) {
         int hex2str_ret;
         bool hex_encoded_binary = false;
+        const char *start       = NULL;
+        const char *end         = NULL;
 
         enc = get_enc_method(pdf, obj);
 
+        if (*length < 2) {
+            cli_dbgmsg("pdf_decrypt_string: length < 2\n");
+            return NULL;
+        }
+
         // Strip off the leading `<` and trailing `>`
-        const char *start = in;
+        start = in;
         if (start[0] == '<') {
             start++;
             hex_encoded_binary = true;
         }
-        const char *end = in + *length;
+        end = in + *length;
         if (end[-1] == '>') {
             end--;
         }


### PR DESCRIPTION
An overread may occur if attempting to decrypt an empty string. Issue introduced during 1.3 development.

Fixes: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=66281


Not a vulnerability, but should be fixed asap before 1.3.0 release since it was introduced during 1.3 development.