### PR TITLE
Update clamav-clamonacc.service.in

### DIFF
--- a/clamonacc/clamav-clamonacc.service.in
+++ b/clamonacc/clamav-clamonacc.service.in
@@ -12,6 +12,7 @@ Type=simple
 User=root
 ExecStartPre=/bin/bash -c "while [ ! -S /run/clamav/clamd.ctl ]; do sleep 1; done"
 ExecStart=@prefix@/sbin/clamonacc -F --log=/var/log/clamav/clamonacc.log --move=/root/quarantine
+ExecStop=/bin/kill -SIGKILL $MAINPID
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Allowing the service to shutdown instead of ignoring SIGTERM and waiting for 1m30s, which is extremely irritating and blocking the shutdown of the machine
Fixing part of issue #834.
