### PR TITLE
Defer or avoid file MD5 calculation when cache is disabled

### DIFF
--- a/libclamav/cache.c
+++ b/libclamav/cache.c
@@ -752,11 +752,6 @@ cl_error_t clean_cache_check(unsigned char *md5, size_t size, cli_ctx *ctx)
         return CL_VIRUS;
     }
 
-    if (ctx->engine->engine_options & ENGINE_OPTIONS_DISABLE_CACHE) {
-        cli_dbgmsg("clean_cache_check: Caching disabled. Returning CL_VIRUS.\n");
-        return CL_VIRUS;
-    }
-
     ret = cache_lookup_hash(md5, size, ctx->engine->cache, ctx->recursion_level);
     cli_dbgmsg("clean_cache_check: %02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x is %s\n", md5[0], md5[1], md5[2], md5[3], md5[4], md5[5], md5[6], md5[7], md5[8], md5[9], md5[10], md5[11], md5[12], md5[13], md5[14], md5[15], (ret == CL_VIRUS) ? "negative" : "positive");
     return ret;

--- a/libclamav/scanners.c
+++ b/libclamav/scanners.c
@@ -4241,7 +4241,8 @@ done:
 cl_error_t cli_magic_scan(cli_ctx *ctx, cli_file_t type)
 {
     cl_error_t ret = CL_CLEAN;
-    cl_error_t cache_check_result;
+    cl_error_t cache_check_result = CL_VIRUS;
+    bool cache_enabled = true;
     cl_error_t verdict_at_this_level;
     cli_file_t dettype              = 0;
     uint8_t typercg                 = 1;
@@ -4325,6 +4326,10 @@ cl_error_t cli_magic_scan(cli_ctx *ctx, cli_file_t type)
 
     if (type == CL_TYPE_PART_ANY) {
         typercg = 0;
+    }
+
+    if (ctx->engine->engine_options & ENGINE_OPTIONS_DISABLE_CACHE) {
+        cache_enabled = false;
     }
 
     /*
@@ -4432,17 +4437,19 @@ cl_error_t cli_magic_scan(cli_ctx *ctx, cli_file_t type)
     }
 
     /*
-     * Get the maphash
+     * Get the maphash, if necessary
      */
-    if (CL_SUCCESS != fmap_get_hash(ctx->fmap, &hash, CLI_HASH_MD5)) {
-        cli_dbgmsg("cli_magic_scan: Failed to get a hash for the current fmap.\n");
+    if (cache_enabled || (SCAN_COLLECT_METADATA)) {
+        if (CL_SUCCESS != fmap_get_hash(ctx->fmap, &hash, CLI_HASH_MD5)) {
+            cli_dbgmsg("cli_magic_scan: Failed to get a hash for the current fmap.\n");
 
-        // It may be that the file was truncated between the time we started the scan and the time we got the hash.
-        // Not a reason to print an error message.
-        ret = CL_SUCCESS;
-        goto done;
+            // It may be that the file was truncated between the time we started the scan and the time we got the hash.
+            // Not a reason to print an error message.
+            ret = CL_SUCCESS;
+            goto done;
+        }
+        hashed_size = ctx->fmap->len;
     }
-    hashed_size = ctx->fmap->len;
 
     ret = dispatch_file_inspection_callback(ctx->engine->cb_file_inspection, ctx, filetype);
     if (CL_CLEAN != ret) {
@@ -4457,9 +4464,11 @@ cl_error_t cli_magic_scan(cli_ctx *ctx, cli_file_t type)
     /*
      * Check if we've already scanned this file before.
      */
-    perf_start(ctx, PERFT_CACHE);
-    cache_check_result = clean_cache_check(hash, hashed_size, ctx);
-    perf_stop(ctx, PERFT_CACHE);
+    if (cache_enabled) {
+        perf_start(ctx, PERFT_CACHE);
+        cache_check_result = clean_cache_check(hash, hashed_size, ctx);
+        perf_stop(ctx, PERFT_CACHE);
+    }
 
 #if HAVE_JSON
     if (SCAN_COLLECT_METADATA) {
@@ -4479,7 +4488,7 @@ cl_error_t cli_magic_scan(cli_ctx *ctx, cli_file_t type)
     }
 #endif
 
-    if (cache_check_result != CL_VIRUS) {
+    if (cache_enabled && (cache_check_result != CL_VIRUS)) {
         cli_dbgmsg("cli_magic_scan: returning %d %s (no post, no cache)\n", ret, __AT__);
         ret = CL_SUCCESS;
         goto early_ret;


### PR DESCRIPTION
If the clean cache is not used (`CL_ENGINE_DISABLE_CACHE=1`), it is not necessary to calculate the file's MD5 checksum in preparation for cache lookup. This change modifies `cli_magic_scan` to skips the MD5 calculation if the cache is disabled.      