### PR TITLE
Docs: Clarify help text about --fdpass option

### DIFF
--- a/docs/man/clamdscan.1.in
+++ b/docs/man/clamdscan.1.in
@@ -70,7 +70,7 @@ Continue scanning within file after finding a match.
 Only print infected files
 .TP
 \fB\-\-fdpass\fR
-Pass the file descriptor permissions to clamd. This is useful if clamd is running as a different user as it is faster than streaming the file to clamd.
+Open the file and pass the opened file descriptor to clamd. This is useful if clamd is running as a different user or if clamd sees a different file system tree. This is faster than streaming the file to clamd.
 Only available if connected to clamd via local(unix) socket.
 .TP
 \fB\-\-stream\fR


### PR DESCRIPTION
My shot at a better help text for `--fdpass` as mentioned here: https://github.com/Cisco-Talos/clamav/issues/1138. I am happy to receive further suggestions on how to rephrase.

Thanks!