### PR TITLE
Stop parsing yara files when a syntax error s found.

### DIFF
--- a/libclamav/yara_grammar.c
+++ b/libclamav/yara_grammar.c
@@ -3649,6 +3649,8 @@ yyerrlab:
       }
 # undef YYSYNTAX_ERROR
 #endif
+      /*Exit out, no reason to continue parsing, since we have already found errors.*/
+      goto yyreturn;
     }
 
 


### PR DESCRIPTION
The yara parser can potentially overwrite heap buffers parsing invalid yara files. Exit on error to avoid this.  These overwrites are only observed when running with address sanitization and mpool disabled.