### PR TITLE
CLAM-2216-ClamOnAccLoop Applied the fix that was not included in 0.103 version

### DIFF
--- a/clamonacc/inotif/inotif.c
+++ b/clamonacc/inotif/inotif.c
@@ -585,8 +585,8 @@ void *onas_ddd_th(void *arg)
                         }
                     }
                 }
-                pt = (struct optstruct *)pt->nextarg;
             }
+            pt = (struct optstruct *)pt->nextarg;
         }
     }
 


### PR DESCRIPTION
Applied the fix that was already done here: https://github.com/Cisco-Talos/clamav/pull/1047

This fix was originally aimed to fix the issue where a wrong configuration would lead to clamonacc process just running in a infinite loop and using 100% of the available cpu time that was allocated to the process.

Example of the incorrect configuration that triggers this bug:
´OnAccessIncludePath /var/lib/this_path_does_not_exist´

After this is changed to a correct path, clamonacc will not be stuck in the loop and will work as intended.

Sorry if I did not follow good practises when creating this PR. This is my first time creating a PR to a public project.

I did not test this as this was already accepted in the original PR.

