### PR TITLE
Fix usage for --datadir option

### DIFF
--- a/docs/man/freshclam.1.in
+++ b/docs/man/freshclam.1.in
@@ -61,7 +61,7 @@ This option forces old non\-DNS verification method (without a TTL delay).
 Check #n times per day for a new database. #n must be between 1 and 50.
 .TP
 \fB\-\-datadir=DIRECTORY\fR
-Install new database in DIRECTORY. The directory must be writable for the '@CLAMAV_USER@' user or unprivileged user running freshclam.
+Install new database in DIRECTORY. The directory must be writable for the '@CLAMAV_USER@' user or unprivileged user running freshclam, already exist, and be an absolute path.
 .TP
 \fB\-\-daemon\-notify=/path/to/clamd.conf\fR
 Notify the daemon about the new database. By default it reads a hardcoded config file but you can use a different one. Both local and TCP sockets are supported.

--- a/docs/man/freshclam.conf.5.in
+++ b/docs/man/freshclam.conf.5.in
@@ -62,7 +62,7 @@ Write the daemon's pid to the specified file.
 Default: disabled
 .TP
 \fBDatabaseDirectory STRING\fR
-Path to a directory containing database files.
+Path to a directory containing database files.  This directory must already exist, be an absolute path, be writeable by freshclam and readable by clamd/clamscan.
 .br
 Default: @DATADIR@
 .TP

--- a/etc/freshclam.conf.sample
+++ b/etc/freshclam.conf.sample
@@ -9,6 +9,8 @@ Example
 
 # Path to the database directory.
 # WARNING: It must match clamd.conf's directive!
+# WARNING: It must already exist, be an absolute path, be writeable by
+# freshclam, and be readable by clamd/clamscan.
 # Default: hardcoded (depends on installation options)
 #DatabaseDirectory /var/lib/clamav
 

--- a/freshclam/freshclam.c
+++ b/freshclam/freshclam.c
@@ -191,6 +191,8 @@ static void help(void)
     printf("    --no-dns                             Force old non-DNS verification method\n");
     printf("    --checks=#n          -c #n           Number of checks per day, 1 <= n <= 50\n");
     printf("    --datadir=DIRECTORY                  Download new databases into DIRECTORY\n");
+    printf("                                         NOTE: DIRECTORY must already exist, be an absolute path, and");
+    printf("                                         be writeable by freshclam and readable by clamd/clamscan.");
     printf("    --daemon-notify[=/path/clamd.conf]   Send RELOAD command to clamd\n");
     printf("    --local-address=IP   -a IP           Bind to IP for HTTP downloads\n");
     printf("    --on-update-execute=COMMAND          Execute COMMAND after successful update.\n");

--- a/win32/conf_examples/freshclam.conf.sample
+++ b/win32/conf_examples/freshclam.conf.sample
@@ -9,6 +9,8 @@ Example
 
 # Path to the database directory.
 # WARNING: It must match clamd.conf's directive!
+# WARNING: It must already exist, be an absolute path, be writeable by
+# freshclam, and be readable by clamd/clamscan.
 # Default: hardcoded (depends on installation options)
 #DatabaseDirectory "C:\Program Files\ClamAV\database"
 


### PR DESCRIPTION
Make the usage clear to the user that the option specified by '--datadir' must be an absolute path to a directory that already exists, and is writeable by freshclam and readable by clamscan/clamd.

Resolves: https://github.com/Cisco-Talos/clamav/issues/1190