### PR TITLE
Silence PNG early end-of-file warning (1.0.6)

### DIFF
--- a/libclamav/png.c
+++ b/libclamav/png.c
@@ -137,7 +137,7 @@ cl_error_t cli_parsepng(cli_ctx *ctx)
         if (chunk_data_length > 0) {
             ptr = (uint8_t *)fmap_need_off_once(map, offset, chunk_data_length);
             if (NULL == ptr) {
-                cli_warnmsg("PNG: Unexpected early end-of-file.\n");
+                cli_dbgmsg("PNG: Unexpected early end-of-file.\n");
                 if (SCAN_HEURISTIC_BROKEN_MEDIA) {
                     status = cli_append_potentially_unwanted(ctx, "Heuristics.Broken.Media.PNG.EOFReadingChunk");
                 }


### PR DESCRIPTION
Backported fix from 1.3.0

Resolves: https://github.com/Cisco-Talos/clamav/issues/1208