### PR TITLE
Reduce C-Rust FFI complexity for HTML CSS image extraction logic (1.3.1)

### DIFF
--- a/libclamav/htmlnorm.h
+++ b/libclamav/htmlnorm.h
@@ -45,9 +45,6 @@ typedef struct m_area_tag {
     fmap_t *map;
 } m_area_t;
 
-typedef void *css_image_extractor_t;
-typedef void *css_image_handle_t;
-
 bool html_normalise_mem(cli_ctx *ctx, unsigned char *in_buff, off_t in_size, const char *dirname, tag_arguments_t *hrefs, const struct cli_dconf *dconf);
 bool html_normalise_map(cli_ctx *ctx, fmap_t *map, const char *dirname, tag_arguments_t *hrefs, const struct cli_dconf *dconf);
 void html_tag_arg_free(tag_arguments_t *tags);

--- a/libclamav_rust/build.rs
+++ b/libclamav_rust/build.rs
@@ -60,8 +60,6 @@ const BINDGEN_TYPES: &[&str] = &[
     "cli_matcher",
     "cli_ac_data",
     "cli_ac_result",
-    "css_image_extractor_t",
-    "css_image_handle_t",
     "onedump_t",
 ];
 

--- a/libclamav_rust/src/scanners.rs
+++ b/libclamav_rust/src/scanners.rs
@@ -37,7 +37,7 @@ use crate::{
 
 /// Rust wrapper of libclamav's cli_magic_scan_buff() function.
 /// Use magic sigs to identify the file type and then scan it.
-fn magic_scan(ctx: *mut cli_ctx, buf: &[u8], name: Option<String>) -> cl_error_t {
+pub fn magic_scan(ctx: *mut cli_ctx, buf: &[u8], name: Option<String>) -> cl_error_t {
     let ptr = buf.as_ptr();
     let len = buf.len();
 


### PR DESCRIPTION
Backport of https://github.com/Cisco-Talos/clamav/pull/1241

---

The C-Rust FFI code is needlessly complex. Now that we are calling into magic_scan from Rust, we can simply hand off the <style> block contents to Rust code to handle extraction and scanning.