### PR TITLE
For RAR load, check LD_LIBRARY_PATH before checking install path

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -94,13 +94,13 @@ jobs:
       - uses: actions/checkout@v1
 
       - name: Install Build Tools
-        run: brew install bison flex
+        run: brew install bison flex pipx
 
       - name: Install Dependencies
-        run: brew install bzip2 check curl-openssl json-c libxml2 ncurses openssl@1.1 pcre2 zlib
+        run: brew install bzip2 check curl json-c libxml2 ncurses openssl@3 pcre2 zlib
 
       - name: Install pytest for easier to read test results
-        run: python3 -m pip install pytest
+        run: pipx install pytest
 
       - uses: lukka/get-cmake@v3.21.2
 
@@ -119,9 +119,9 @@ jobs:
         # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
         run:
           cmake ${{runner.workspace}}/clamav -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }}
-          -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl@1.1/
-          -DOPENSSL_CRYPTO_LIBRARY=/usr/local/opt/openssl@1.1/lib/libcrypto.1.1.dylib
-          -DOPENSSL_SSL_LIBRARY=/usr/local/opt/openssl@1.1/lib/libssl.1.1.dylib
+          -DOPENSSL_ROOT_DIR=/opt/homebrew/include/
+          -DOPENSSL_CRYPTO_LIBRARY=/opt/homebrew/lib/libcrypto.3.dylib
+          -DOPENSSL_SSL_LIBRARY=/opt/homebrew/lib/libssl.3.dylib
           -DENABLE_STATIC_LIB=ON
           -DENABLE_EXAMPLES=ON
 
@@ -148,13 +148,13 @@ jobs:
         run: sudo apt-get update
 
       - name: Install Build Tools
-        run: sudo apt-get install -y bison flex valgrind
+        run: sudo apt-get install -y bison flex valgrind pipx
 
       - name: Install Dependencies
         run: sudo apt-get install -y check libbz2-dev libcurl4-openssl-dev libjson-c-dev libmilter-dev libncurses5-dev libpcre3-dev libssl-dev libxml2-dev zlib1g-dev
 
       - name: Install pytest for easier to read test results
-        run: python3 -m pip install pytest
+        run: pipx install pytest
 
       - uses: lukka/get-cmake@v3.21.2
 

--- a/libclamunrar/CMakeLists.txt
+++ b/libclamunrar/CMakeLists.txt
@@ -1,7 +1,6 @@
 # Copyright (C) 2019-2024 Cisco Systems, Inc. and/or its affiliates. All rights reserved.
 
 add_compile_definitions(RARDLL)
-add_compile_definitions(WARN_DLOPEN_FAIL)
 add_compile_definitions(_FILE_OFFSET_BITS=64)
 
 if(WIN32)


### PR DESCRIPTION
ClamAV initalization's rarload() function tries to load libclamunrar_iface from the install path before checking under LD_LIBRARY_PATH.
This means the unit tests will use the wrong unrar library if testing on a system where ClamAV is already installed.
In the event there is an ABI break between versions, this will cause a bunch of tests to fail.

This commit fixes the issue by checking for libclamunrar_iface under LD_LIBRARY_PATH *first* before checking in the install lib directory.

Note in the previous version we were also checking LD_LIBRARY_PATH on Windows, which is not a thing. I removed this.

Fixes: https://github.com/Cisco-Talos/clamav/issues/1249

Also removed check for WARN_DLOPEN_FAIL define, which was not used, and mistakenly set for the unrar library build target.