### PR TITLE
cmake/FindRust.cmake: inherit RUSTFLAGS from the environment

### DIFF
--- a/cmake/FindRust.cmake
+++ b/cmake/FindRust.cmake
@@ -488,7 +488,7 @@ elseif(${CMAKE_BUILD_TYPE} STREQUAL "RelWithDebInfo")
 else()
     set(CARGO_BUILD_TYPE "debug")
 endif()
-string(STRIP "${RUSTFLAGS}" RUSTFLAGS)
+string(STRIP "${RUSTFLAGS} $ENV{RUSTFLAGS}" RUSTFLAGS)
 
 find_package_handle_standard_args(Rust
     REQUIRED_VARS cargo_EXECUTABLE


### PR DESCRIPTION
This pull request changes the `FindRust.cmake` script so the `RUSTFLAGS` set from the environment won't be overridden.

This is needed because some downstream distributors (e.g. Linux distros) will need to append several Rust flags to get reproducible builds and/or make the project build on certain architectures.