### PR TITLE
Windows: fix build issue with newer version of Rust

### DIFF
--- a/cmake/FindRust.cmake
+++ b/cmake/FindRust.cmake
@@ -428,6 +428,10 @@ foreach(LINE ${LINE_LIST})
     endif()
 
     string(REPLACE "native-static-libs: " "" LINE "${LINE}")
+
+    # Some Rust versions have a defaultlib:msvcrt; in the output, which we don't want.
+    string(REGEX REPLACE " /defaultlib:msvcrt" "" LINE "${LINE}")
+
     string(REGEX REPLACE "  " "" LINE "${LINE}")
     string(REGEX REPLACE " " ";" LINE "${LINE}")
 


### PR DESCRIPTION
Newer versions of Rust appear to include '/defaultlib:msvcrt' in the list of native static libs when you run '--print=native-static-libs'.

MSVC doesn't know what to do with this when passed as a linker dependency.

Since msvcrt.lib is ALSO listed, the solution seems to be to strip this item from the list.