### PR TITLE
CI: Fix recent CI failures

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -56,9 +56,9 @@ jobs:
           - check: "win32/compat"
             exclude: ""
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Run clang-format style check for C/C++ programs.
-        uses: jidicula/clang-format-action@v4.4.1
+        uses: jidicula/clang-format-action@v4.13.0
         with:
           clang-format-version: "16"
           check-path: ${{ matrix.path['check'] }}

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -29,17 +29,17 @@ jobs:
         run: rm /usr/bin/link.exe
         shell: bash
 
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
 
       - name: Install Build Tools
-        uses: crazy-max/ghaction-chocolatey@v1
+        uses: crazy-max/ghaction-chocolatey@v3
         with:
           args: install wixtoolset
 
       - name: Install pytest for easier to read test results
         run: python3 -m pip install pytest
 
-      - uses: lukka/get-cmake@v3.21.2
+      - uses: lukka/get-cmake@v3.30.0
 
       # Restore from cache the previously built ports. If cache-miss, download, build vcpkg ports.
       - name: Restore vcpkg ports from cache or install vcpkg
@@ -91,7 +91,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
 
       - name: Install Build Tools
         run: brew install bison flex pipx
@@ -102,7 +102,7 @@ jobs:
       - name: Install pytest for easier to read test results
         run: pipx install pytest
 
-      - uses: lukka/get-cmake@v3.21.2
+      - uses: lukka/get-cmake@v3.30.0
 
       - name: Create Build Directory
         shell: bash
@@ -142,7 +142,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
 
       - name: Update package listings
         run: sudo apt-get update
@@ -156,7 +156,7 @@ jobs:
       - name: Install pytest for easier to read test results
         run: pipx install pytest
 
-      - uses: lukka/get-cmake@v3.21.2
+      - uses: lukka/get-cmake@v3.30.0
 
       - name: Create Build Directory
         shell: bash

--- a/clamonacc/inotif/inotif.c
+++ b/clamonacc/inotif/inotif.c
@@ -154,7 +154,7 @@ int onas_ddd_init(uint64_t nwatches, size_t ht_size)
     if (ret < 0) return CL_EREAD;
 
     tmp = strtol(nwatch_str, &p, 10);
-    if (tmp < 0 || tmp == LONG_MAX){
+    if (tmp < 0 || tmp == LONG_MAX) {
         /*Seems like a sane value (also the value on my ubuntu system)*/
         nwatches = 0x10000;
     } else {

--- a/cmake/FindRust.cmake
+++ b/cmake/FindRust.cmake
@@ -430,6 +430,8 @@ foreach(LINE ${LINE_LIST})
     string(REPLACE "native-static-libs: " "" LINE "${LINE}")
     string(REGEX REPLACE "  " "" LINE "${LINE}")
     string(REGEX REPLACE " " ";" LINE "${LINE}")
+    # remove linker flags
+    list(FILTER LINE EXCLUDE REGEX "/.*")
 
     if(LINE)
         message(STATUS "Rust's native static libs: ${LINE}")


### PR DESCRIPTION
This pull request fixes the recent CI failures with `clang-format,` and Rust builds on Windows.