### PR TITLE
 fix: Allow `clamd` to start normally when a whitelist is present.

### DIFF
--- a/clamscan/manager.c
+++ b/clamscan/manager.c
@@ -1251,6 +1251,15 @@ int scanmanager(const struct optstruct *opts)
     if ((opt = optget(opts, "database"))->active) {
         while (opt) {
             if (optget(opts, "fail-if-cvd-older-than")->enabled) {
+                if (LSTAT(opt->strarg, &sb) == -1) {
+                    logg(LOGG_ERROR, "Can't access database directory/file: %s\n", opt->strarg);
+                    ret = 2;
+                    goto done;
+                }
+                if (!S_ISDIR(sb.st_mode) && !CLI_DBEXT_SIGNATURE(opt->strarg)) {
+                    opt = opt->nextarg;
+                    continue;
+                }
                 if (check_if_cvd_outdated(opt->strarg, optget(opts, "fail-if-cvd-older-than")->numarg) != CL_SUCCESS) {
                     ret = 2;
                     goto done;

--- a/libclamav/cvd.c
+++ b/libclamav/cvd.c
@@ -851,7 +851,7 @@ cl_error_t cl_cvdgetage(const char *path, time_t *age_seconds)
         if (!strcmp(dent->d_name, ".") || !strcmp(dent->d_name, ".."))
             continue;
 
-        if (!CLI_DBEXT(dent->d_name))
+        if (!CLI_DBEXT_SIGNATURE(dent->d_name))
             continue;
 
         if (ends_with_sep)

--- a/libclamav/readdb.h
+++ b/libclamav/readdb.h
@@ -81,6 +81,10 @@ struct cli_matcher;
         cli_strbcasestr(ext, ".ign") ||  \
         cli_strbcasestr(ext, ".ign2") || \
         cli_strbcasestr(ext, ".imp"))
+#define CLI_DBEXT_SIGNATURE(ext)         \
+    (                                    \
+        cli_strbcasestr(ext, ".cvd") ||  \
+        cli_strbcasestr(ext, ".cld"))
 #else
 #define CLI_DBEXT(ext)                   \
     (                                    \
@@ -120,6 +124,10 @@ struct cli_matcher;
         cli_strbcasestr(ext, ".ign") ||  \
         cli_strbcasestr(ext, ".ign2") || \
         cli_strbcasestr(ext, ".imp"))
+#define CLI_DBEXT_SIGNATURE(ext)         \
+    (                                    \
+        cli_strbcasestr(ext, ".cvd") ||  \
+        cli_strbcasestr(ext, ".cld"))
 #endif
 
 char *cli_virname(const char *virname, unsigned int official);


### PR DESCRIPTION
This PR is an attempt to fix issue #1174 

The given functionality was introduced in the [following commit](https://github.com/Cisco-Talos/clamav/commit/e4fe6654c1618bacf3bff9ed64c52615c8c53a97) and after taking a look at the [cli_cvdverify](https://github.com/Cisco-Talos/clamav/blob/e4fe6654c1618bacf3bff9ed64c52615c8c53a97/libclamav/cvd.c#L530) function I believe it is meant to verify only CVDs.

That is, it throws an error when encountering a clear text (whitelist, `.ign`,`.ign2`) file. I mimicked the way the allowed extensions in the Database folder were handled, and excluded the 2 clear text extensions mentioned above. This has locally allowed for the normal execution of `clamd`.