### PR TITLE
tests: fix valgrind FP

### DIFF
--- a/unit_tests/valgrind.supp
+++ b/unit_tests/valgrind.supp
@@ -366,6 +366,12 @@
    ...
 }
 {
+   <statx7-cdiff_apply>
+   Memcheck:Addr8
+   fun:cdiff_apply
+   ...
+}
+{
    <rayon-jpeg-decoder-error>
    Memcheck:Cond
    fun:drop_in_place<core::result::Result<(), std::sync::mpsc::SendError<alloc::vec::Vec<u8, alloc::alloc::Global>>>>


### PR DESCRIPTION
We're seeing an fp from valgrind with this stack trace on ubuntu-18-arm64 plus a warning about an unhandled syscall.

```
11: [INFO]: ==10880== Invalid write of size 8
11: [INFO]: ==10880==    at 0x17BDD0: cdiff_apply (cdiff.rs:576)
11: [INFO]: ==10880==    by 0x17354F: rundiff (sigtool.c:1970)
11: [INFO]: ==10880==    by 0x17354F: main (sigtool.c:3796)
11: [INFO]: ==10880==  Address 0x1ffeffea40 is on thread 1's stack
11: [INFO]: ==10880==  128 bytes below stack pointer
11: [INFO]: ==10880==
11: [INFO]: {
11: [INFO]:    <insert_a_suppression_name_here>
11: [INFO]:    Memcheck:Addr8
11: [INFO]:    fun:cdiff_apply
11: [INFO]:    fun:rundiff
11: [INFO]:    fun:main
11: [INFO]: }
11: [INFO]: --10880-- WARNING: unhandled arm64-linux syscall: 291
11: [INFO]: ==10880==    at 0x573A4D4: syscall (syscall.S:39)
11: [INFO]: ==10880==    by 0x3A8183: statx (weak.rs:176)
11: [INFO]: ==10880==    by 0x3A8183: std::sys::pal::unix::fs::try_statx (fs.rs:196)
11: [INFO]: ==10880==    by 0x386227: file_attr (fs.rs:1189)
11: [INFO]: ==10880==    by 0x386227: std::fs::File::metadata (fs.rs:588)
11: [INFO]: ==10880==    by 0x17BF2B: read_dsig (cdiff.rs:1080)
11: [INFO]: ==10880==    by 0x17BF2B: cdiff_apply (cdiff.rs:619)
11: [INFO]: ==10880==    by 0x17BF2B: cdiff_apply (cdiff.rs:590)
11: [INFO]: ==10880==    by 0x17354F: rundiff (sigtool.c:1970)
11: [INFO]: ==10880==    by 0x17354F: main (sigtool.c:3796)
11: [INFO]: --10880-- You may be able to write your own handler.
11: [INFO]: --10880-- Read the file README_MISSING_SYSCALL_OR_IOCTL.
11: [INFO]: --10880-- Nevertheless we consider this a bug.  Please report
11: [INFO]: --10880-- it at http://valgrind.org/support/bug_reports.html.
```

We already have multiple variants of suppressions to ignore these `statx` false positives.

In this case, for some reason valgrind isn't getting the full call stack and is just blaming `cdiff_apply`.

Add a blanket suppression for `cdiff_apply` to make the tests pass.