### PR TITLE
Add regex support for OnAccessExcludePath

### DIFF
--- a/clamonacc/inotif/hash.c
+++ b/clamonacc/inotif/hash.c
@@ -142,6 +142,8 @@ int onas_ht_init(struct onas_ht **ht, uint32_t size)
     **ht = (struct onas_ht){
         .htable = NULL,
         .size   = size,
+        .head   = NULL,
+        .tail   = NULL,
         .nbckts = 0,
     };
 
@@ -260,6 +262,19 @@ int onas_ht_insert(struct onas_ht *ht, struct onas_element *elem)
         bckt            = ht->htable[idx];
     }
 
+    /* Init activated buckets */
+    if (ht->nbckts == 0) {
+        ht->head   = bckt;
+        ht->tail   = bckt;
+        bckt->prev = NULL;
+        bckt->next = NULL;
+    } else {
+        struct onas_bucket *ht_tail = ht->tail;
+        ht_tail->next               = bckt;
+        bckt->prev                  = ht_tail;
+        bckt->next                  = NULL;
+        ht->tail                    = bckt;
+    }
     bsize = bckt->size;
     ret   = onas_bucket_insert(bckt, elem);
 

--- a/clamonacc/inotif/hash.h
+++ b/clamonacc/inotif/hash.h
@@ -45,11 +45,15 @@ struct onas_bucket {
 
     struct onas_element *head;
     struct onas_element *tail;
+    struct onas_bucket *next; /* Next activated bucket */
+    struct onas_bucket *prev; /* Prev activated bucket */
 };
 
 struct onas_ht {
 
     struct onas_bucket **htable;
+    struct onas_bucket *head; /* Activated buckets head */
+    struct onas_bucket *tail; /* Activated buckets tail */
 
     /* Must be a sufficiently high power of two--will not grow. */
     uint32_t size;


### PR DESCRIPTION
Fix https://github.com/Cisco-Talos/clamav/issues/1074

To efficiently iterate over all watching files, I've introduced a linked list within `struct onas_ht` to keep track of all active buckets. Would this approach be effective for our purposes? @micahsnyder

