### PR TITLE
INSTALL.md: change LLVM description

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -642,7 +642,7 @@ Options for a custom LLVM install path, or to select a specific version if you
 have multiple LLVM installations:
 ```sh
   -D LLVM_ROOT_DIR="_path to llvm install root_"
-  -D LLVM_FIND_VERSION="3.6.0"
+  -D LLVM_FIND_VERSION="8.0.1"
 ```
 
 ### `libcurl`
@@ -688,8 +688,7 @@ ClamAV has two bytecode runtimes:
    execution should be faster. Not all scans will run bytecode signatures, so
    performance testing will depend heavily depending on what files are tested.
 
-   We ran out of time in 0.104 development to update to support newer versions
-   of LLVM. LLVM 3.6.2 is the newest version supported in ClamAV 0.104.
+   We can work with LLVM 8.0 to 13.x. 
 
 #### Interpreter Bytecode Runtime
 
@@ -704,7 +703,7 @@ cmake .. -D BYTECODE_RUNTIME="interpreter"
 
 If you wish to build using LLVM JIT for the bytecode runtime instead of the
 bytecode interpreter, you will need to install the LLVM development libraries.
-ClamAV currently supports LLVM versions 8.0 through 12.0.
+ClamAV currently supports LLVM versions 8.0 through 13.x.
 
 To build with LLVM for the bytecode runtime, build with this option:
 ```sh


### PR DESCRIPTION
Somehow the changes from #692 did not come with a doc update. The cap at version 13 is given from #574. I did not try to build it with LLVM 14, so I don't know whether it truly doesn't compile or simply fails due to the CMake thing.