### PR TITLE
fix: Attempt to create log file if it does not exist.

### DIFF
--- a/common/output.c
+++ b/common/output.c
@@ -55,6 +55,7 @@
 #include "clamav.h"
 #include "others.h"
 #include "str.h"
+
 #include "output.h"
 
 #ifdef CL_THREAD_SAFE

--- a/common/output.c
+++ b/common/output.c
@@ -56,9 +56,6 @@
 #include "others.h"
 #include "str.h"
 #include "output.h"
-#include "optparser.h"
-#include <pwd.h>
-#include "output.h"
 
 #ifdef CL_THREAD_SAFE
 #include <pthread.h>
@@ -273,12 +270,10 @@ static int logg_open(void)
 
     if (logg_file)
         if (logg_size > 0)
-            if (CLAMSTAT(logg_file, &sb) != -1) {
+            if (CLAMSTAT(logg_file, &sb) != -1)
                 if (sb.st_size > logg_size)
                     if (rename_logg(&sb))
                         return -1;
-            } else
-                return -1;
 
     return 0;
 }
@@ -338,6 +333,7 @@ int logg(loglevel_t loglevel, const char *str, ...)
 #ifdef CL_THREAD_SAFE
     pthread_mutex_lock(&logg_mutex);
 #endif
+
     logg_open();
 
     if (!logg_fp && logg_file) {

--- a/common/output.c
+++ b/common/output.c
@@ -350,6 +350,9 @@ int logg(loglevel_t loglevel, const char *str, ...)
             current_dir = (char*)realloc(current_dir, strlen(current_dir) + strlen(token) + 2);
             strcat(current_dir, token);
             token = strtok(NULL, "/");
+            if(token == NULL) {
+                break;
+            }
             if(LSTAT(current_dir, &sb) == -1) {
                 if(mkdir(current_dir, 0755) == -1) {
                     printf("ERROR: Failed to create required directory %s. Will continue without writing in %s.\n", current_dir, logg_file);
@@ -360,7 +363,6 @@ int logg(loglevel_t loglevel, const char *str, ...)
             }
             strcat(current_dir, "/");
         }
-        //create file
         if ((logg_fp = fopen(logg_file, "at")) == NULL) {
             printf("ERROR: Can't open %s in append mode (check permissions!).\n", logg_file);
             free(current_dir);

--- a/freshclam/freshclam.c
+++ b/freshclam/freshclam.c
@@ -811,26 +811,6 @@ static fc_error_t initialize(struct optstruct *opts)
 #endif
     }
 
-#ifdef HAVE_PWD_H
-    /* Drop database privileges here if we are not planning on daemonizing.  If
-     * we are, we should wait until after we create the PidFile to drop
-     * privileges.  That way, it is owned by root (or whoever started freshclam),
-     * and no one can change it.  */
-    if (!optget(opts, "daemon")->enabled) {
-        /*
-         * freshclam shouldn't work with root privileges.
-         * Drop privileges to the DatabaseOwner user, if specified.
-         * Pass NULL for the log file name, because it hasn't been created yet.
-         */
-        ret = drop_privileges(optget(opts, "DatabaseOwner")->strarg, NULL);
-        if (ret) {
-            logg(LOGG_ERROR, "Failed to switch to %s user.\n", optget(opts, "DatabaseOwner")->strarg);
-            status = FC_ECONFIG;
-            goto done;
-        }
-    }
-#endif /* HAVE_PWD_H */
-
     /*
      * Initialize libclamav.
      */
@@ -982,6 +962,7 @@ static fc_error_t initialize(struct optstruct *opts)
     fcConfig.requestTimeout = optget(opts, "ReceiveTimeout")->numarg;
 
     fcConfig.bCompressLocalDatabase = optget(opts, "CompressLocalDatabase")->enabled;
+    fcConfig.dbOwner                = optget(opts, "DatabaseOwner")->strarg;
 
     /*
      * Initialize libfreshclam.
@@ -991,6 +972,27 @@ static fc_error_t initialize(struct optstruct *opts)
         status = ret;
         goto done;
     }
+
+#ifdef HAVE_PWD_H
+    /* Drop database privileges here (cause of log file creation in /var/log) if we are not planning on daemonizing.  If
+     * we are, we should wait until after we create the PidFile to drop
+     * privileges.  That way, it is owned by root (or whoever started freshclam),
+     * and no one can change it. */
+    if (!optget(opts, "daemon")->enabled) {
+        /*
+         * freshclam shouldn't work with root privileges.
+         * Drop privileges to the DatabaseOwner user, if specified.
+         * Pass NULL for the log file name, because it hasn't been created yet.
+         */
+        ret = drop_privileges(optget(opts, "DatabaseOwner")->strarg, NULL);
+        if (ret) {
+            logg(LOGG_ERROR, "Failed to switch to %s user.\n", optget(opts, "DatabaseOwner")->strarg);
+            status = FC_ECONFIG;
+            goto done;
+        }
+    }
+#endif /* HAVE_PWD_H */
+
 
     /*
      * Set libfreshclam callback functions.

--- a/libfreshclam/libfreshclam.h
+++ b/libfreshclam/libfreshclam.h
@@ -60,6 +60,7 @@ typedef struct fc_config_ {
     const char *proxyPassword;       /**< (optional) Password for proxy server authentication. */
     const char *databaseDirectory;   /**< Filepath of database directory. */
     const char *tempDirectory;       /**< Filepath to store temp files. */
+    const char *dbOwner;             /**< Owner of DB, used when creating log file/folder. */
 } fc_config;
 
 typedef enum fc_error_tag {


### PR DESCRIPTION
Fixes: #1155 
It might seem a bit messy but the gist of the PR is that.

* We introduce `fc_upsert_logg_file` method, which attempts to create the directories & log file as required.
* We move the `drop_privileges` case/branch later during the execution. If we do this before we `fc_upsert_logg_file` our log file, then we can't use `root` privileges even if `freshclam` is started as `root`.
* In order to `chown` the directories (and file, overkill?) we introduce the field `dbOwner` in the `fc_config` structure.

Seems this has been handled in documentation as a [step of the setup](https://docs.clamav.net/manual/Usage/Configuration.html?highlight=log%20file#freshclamconf).