### PR TITLE
Email Parser: Reduce message multipart json logic complexity

### DIFF
--- a/libclamav/json_api.c
+++ b/libclamav/json_api.c
@@ -352,45 +352,6 @@ json_object *cli_jsonobj(json_object *obj, const char *key)
     return newobj;
 }
 
-/* adding an object does NOT increment reference count */
-cl_error_t cli_json_addowner(json_object *owner, json_object *child, const char *key, int idx)
-{
-    json_type objty;
-    if (NULL == owner) {
-        cli_dbgmsg("json: no owner object specified to cli_json_addowner\n");
-        return CL_ENULLARG;
-    }
-
-    if (NULL == child) {
-        cli_dbgmsg("json: no child object specified to cli_json_addowner\n");
-        return CL_ENULLARG;
-    }
-    objty = json_object_get_type(owner);
-
-    if (objty == json_type_object) {
-        if (NULL == key) {
-            cli_dbgmsg("json: null string specified as key to cli_addowner\n");
-            return CL_ENULLARG;
-        }
-        json_object_object_add(owner, key, child);
-    } else if (objty == json_type_array) {
-        if (idx < 0 || NULL == json_object_array_get_idx(owner, idx))
-            json_object_array_add(owner, child);
-        else if (0 != json_object_array_put_idx(owner, idx, child)) {
-            /* this shouldn't be possible */
-            cli_dbgmsg("json: cannot delete idx %d of owner array\n", idx);
-            return CL_BREAK;
-        }
-    } else {
-        cli_dbgmsg("json: no owner object cannot hold ownership\n");
-        return CL_EARG;
-    }
-
-    /* increment reference count */
-    json_object_get(child);
-    return CL_SUCCESS;
-}
-
 /* deleting an object DOES decrement reference count */
 cl_error_t cli_json_delowner(json_object *owner, const char *key, int idx)
 {

--- a/libclamav/json_api.h
+++ b/libclamav/json_api.h
@@ -47,7 +47,6 @@ cl_error_t cli_jsondouble(json_object *obj, const char *key, double d);
 json_object *cli_jsonarray(json_object *obj, const char *key);
 cl_error_t cli_jsonint_array(json_object *obj, int32_t val);
 json_object *cli_jsonobj(json_object *obj, const char *key);
-cl_error_t cli_json_addowner(json_object *owner, json_object *child, const char *key, int idx);
 cl_error_t cli_json_delowner(json_object *owner, const char *key, int idx);
 #define cli_json_delobj(obj) json_object_put(obj)
 

--- a/libclamav/mbox.c
+++ b/libclamav/mbox.c
@@ -4228,10 +4228,10 @@ do_multipart(message *mainMessage, message **messages, int i, mbox_status *rc, m
         json_object *multiobj = cli_jsonarray(mctx->wrkobj, "Multipart");
         if (multiobj == NULL) {
             cli_errmsg("Cannot get multipart preclass array\n");
-        } else if (NULL == (thisobj = messageGetJObj(aMessage))) {
-            cli_dbgmsg("Cannot get message preclass object\n");
-        } else if (CL_SUCCESS != cli_json_addowner(multiobj, thisobj, NULL, -1)) {
-            cli_errmsg("Cannot assign message preclass object to multipart preclass array\n");
+        } else if (NULL == (thisobj = cli_jsonobj(NULL, NULL))) {
+            cli_dbgmsg("Cannot allocate new json object for message part.\n");
+        } else {
+            json_object_array_add(multiobj, thisobj);
         }
     }
 

--- a/libclamav/message.c
+++ b/libclamav/message.c
@@ -194,9 +194,6 @@ void messageReset(message *m)
         free(m->encodingTypes);
     }
 
-    if (m->jobj)
-        cli_json_delobj(m->jobj);
-
     memset(m, '\0', sizeof(message));
     m->mimeType = NOMIME;
 }
@@ -2666,16 +2663,4 @@ int isuuencodebegin(const char *line)
     return (strncasecmp(line, "begin ", 6) == 0) &&
            isdigit(line[6]) && isdigit(line[7]) &&
            isdigit(line[8]) && (line[9] == ' ');
-}
-
-json_object *messageGetJObj(message *m)
-{
-    if (m == NULL) {
-        return NULL;
-    }
-
-    if (m->jobj == NULL)
-        m->jobj = cli_jsonobj(NULL, NULL);
-
-    return m->jobj;
 }

--- a/libclamav/message.h
+++ b/libclamav/message.h
@@ -50,8 +50,6 @@ typedef struct message {
     char base64_1, base64_2, base64_3;
     unsigned int isInfected : 1;
     unsigned int isTruncated : 1;
-
-    json_object *jobj;
 } message;
 
 message *messageCreate(void);
@@ -87,6 +85,5 @@ int isuuencodebegin(const char *line);
 void messageSetCTX(message *m, cli_ctx *ctx);
 int messageContainsVirus(const message *m);
 int messageSavePartial(message *m, const char *dir, const char *id, unsigned part);
-json_object *messageGetJObj(message *m);
 
 #endif /*_MESSAGE_H*/


### PR DESCRIPTION
Simplify JSON object handling in mbox scanning, eliminate a number of single use functions, and reduce the places the JSON object is exposed.