### PR TITLE
Tests: remove unused Python modules from freshclam tests

### DIFF
--- a/unit_tests/freshclam_test.py
+++ b/unit_tests/freshclam_test.py
@@ -10,14 +10,10 @@ import os
 from pathlib import Path
 import platform
 import shutil
-import subprocess
-import sys
-import time
 import unittest
 from functools import partial
 
 from http.server import HTTPServer, BaseHTTPRequestHandler
-import cgi
 
 import testcase
 


### PR DESCRIPTION
The 'cgi' module is deprecrated and will be removed in Python 3.13. We weren't using it anyways.