### PR TITLE
CMake: improve ncurses detection; separate TINFO_LIBRARY input

### DIFF
--- a/INSTALL-cross-linux-arm64.md
+++ b/INSTALL-cross-linux-arm64.md
@@ -157,12 +157,14 @@ set(CMAKE_SYSROOT           /opt/aarch64-wrs-linux-sysroot)
 #set(PCRE2_INCLUDE_DIR       "/usr/include/")
 #set(PCRE2_LIBRARY           "/usr/lib64/libpcre2-8.so")
 
-#set(CURSES_INCLUDE_DIR      "/usr/include/")
-#set(CURSES_LIBRARY          "/usr/lib/aarch64-linux-gnu/libncurses.a;/usr/lib/aarch64-linux-gnu/libtinfo.a")
-# Tip: You may not need to also link with libtinfo.a, depending on what your distribution provides:
-#set(CURSES_LIBRARY          "/usr/lib/aarch64-linux-gnu/libncurses.a")
-# Tip: Alternatively, you could link with the shared library:
+set(NCURSES_INCLUDE_DIR      "/usr/include/")
+set(CURSES_LIBRARY          "/usr/lib/aarch64-linux-gnu/libncurses.a")
+set(TINFO_LIBRARY           "/usr/lib/aarch64-linux-gnu/libtinfo.a")
+# Tip: You may not need to also link with libtinfo.a, depending on what your distribution provides.
+
+# Tip 2: Alternatively, you could link with the shared libraries:
 #set(CURSES_LIBRARY          "/usr/lib/aarch64-linux-gnu/libncurses.so")
+#set(TINFO_LIBRARY          "/usr/lib/aarch64-linux-gnu/libtinfo.so")
 
 #set(ZLIB_INCLUDE_DIR        "/usr/include/")
 #set(ZLIB_LIBRARY            "/usr/lib64/libz.so")
@@ -225,12 +227,14 @@ set(LIBXML2_LIBRARY         "/usr/lib/aarch64-linux-gnu/libxml2.so")
 set(PCRE2_INCLUDE_DIR       "/usr/include/")
 set(PCRE2_LIBRARY           "/usr/lib/aarch64-linux-gnu/libpcre2-8.so")
 
-set(CURSES_INCLUDE_DIR      "/usr/include/")
-set(CURSES_LIBRARY          "/usr/lib/aarch64-linux-gnu/libncurses.a;/usr/lib/aarch64-linux-gnu/libtinfo.a")
-# Tip: You may not need to also link with libtinfo.a, depending on what your distribution provides:
-#set(CURSES_LIBRARY          "/usr/lib/aarch64-linux-gnu/libncurses.a")
-# Tip: Alternatively, you could link with the shared library:
+set(NCURSES_INCLUDE_DIR      "/usr/include/")
+set(CURSES_LIBRARY          "/usr/lib/aarch64-linux-gnu/libncurses.a")
+set(TINFO_LIBRARY           "/usr/lib/aarch64-linux-gnu/libtinfo.a")
+# Tip: You may not need to also link with libtinfo.a, depending on what your distribution provides.
+
+# Tip 2: Alternatively, you could link with the shared libraries:
 #set(CURSES_LIBRARY          "/usr/lib/aarch64-linux-gnu/libncurses.so")
+#set(TINFO_LIBRARY          "/usr/lib/aarch64-linux-gnu/libtinfo.so")
 
 set(ZLIB_INCLUDE_DIR        "/usr/include/")
 set(ZLIB_LIBRARY            "/usr/lib/aarch64-linux-gnu/libz.so")

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -668,6 +668,11 @@ and:
   -D CURSES_LIBRARY="_filepath of curses library_"
 ```
 
+and, if tinfo is separate from ncurses:
+```sh
+  -D TINFO_LIBRARY="_filepath of tinfo library_"
+```
+
 ### Bytecode Runtime
 
 Bytecode signatures are a type of executable plugin that provide extra
@@ -688,7 +693,7 @@ ClamAV has two bytecode runtimes:
    execution should be faster. Not all scans will run bytecode signatures, so
    performance testing will depend heavily depending on what files are tested.
 
-   We can work with LLVM 8.0 to 13.x. 
+   We can work with LLVM 8.0 to 13.x.
 
 #### Interpreter Bytecode Runtime
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -91,8 +91,9 @@ node('default') {
                     -D LIBXML2_LIBRARY="$HOME/.mussels/install/host-static/lib/libxml2.a" \
                     -D PCRE2_INCLUDE_DIR="$HOME/.mussels/install/host-static/include" \
                     -D PCRE2_LIBRARY="$HOME/.mussels/install/host-static/lib/libpcre2-8.a" \
-                    -D CURSES_INCLUDE_DIR="$HOME/.mussels/install/host-static/include" \
-                    -D CURSES_LIBRARY="$HOME/.mussels/install/host-static/lib/libncurses.a;$HOME/.mussels/install/host-static/lib/libtinfo.a" \
+                    -D NCURSES_INCLUDE_DIR="$HOME/.mussels/install/host-static/include" \
+                    -D CURSES_LIBRARY="$HOME/.mussels/install/host-static/lib/libncurses.a" \
+                    -D TINFO_LIBRARY="$HOME/.mussels/install/host-static/lib/libtinfo.a" \
                     -D ZLIB_INCLUDE_DIR="$HOME/.mussels/install/host-static/include" \
                     -D ZLIB_LIBRARY="$HOME/.mussels/install/host-static/lib/libz.a" \
                     -D LIBCHECK_INCLUDE_DIR="$HOME/.mussels/install/host-static/include" \

--- a/cmake/FindCURSES.cmake
+++ b/cmake/FindCURSES.cmake
@@ -13,7 +13,7 @@ Imported Targets
 This module provides the following imported targets, if found:
 
 ``Curses::curses``
-  The CURSES library
+  The CURSES library and possibly TINFO library
 
 Result Variables
 ^^^^^^^^^^^^^^^^
@@ -34,10 +34,14 @@ Cache Variables
 
 The following cache variables may also be set:
 
-``CURSES_INCLUDE_DIR``
-  The directory containing ``foo.h``.
+``NCURSES_INCLUDE_DIR``
+  The directory containing ``ncurses.h``.
+``PDCURSES_INCLUDE_DIR``
+  The directory containing ``curses.h``.
 ``CURSES_LIBRARY``
   The path to the CURSES library.
+``TINFO_LIBRARY``
+  The path to the TINFO library.
 
 #]=======================================================================]
 
@@ -46,8 +50,8 @@ find_package(PkgConfig QUIET)
 pkg_search_module (PC_NCurses QUIET ncurses ncursesw)
 
 find_path(NCURSES_INCLUDE_DIR
-  NAMES ncurses.h
-  PATHS ${PC_NCurses_INCLUDE_DIRS} ${CURSES_INCLUDE_DIR}
+    NAMES ncurses.h
+    PATHS ${PC_NCurses_INCLUDE_DIRS} ${CURSES_INCLUDE_DIR}
 )
 
 string(FIND ${NCURSES_INCLUDE_DIR} "-NOTFOUND" NCURSES_NOT_FOUND)
@@ -69,82 +73,98 @@ if(NCURSES_NOT_FOUND EQUAL -1)
 
     include(FindPackageHandleStandardArgs)
     find_package_handle_standard_args(CURSES
-      FOUND_VAR CURSES_FOUND
-      REQUIRED_VARS
+        FOUND_VAR CURSES_FOUND
+        REQUIRED_VARS
         CURSES_LIBRARY
         NCURSES_INCLUDE_DIR
-      VERSION_VAR CURSES_VERSION
+        VERSION_VAR CURSES_VERSION
+    )
+
+    include(FindPackageHandleStandardArgs)
+    find_package_handle_standard_args(TINFO
+        FOUND_VAR TINFO_FOUND
+        REQUIRED_VARS
+        TINFO_LIBRARY
+        NCURSES_INCLUDE_DIR
+        VERSION_VAR CURSES_VERSION
     )
 
     set(HAVE_LIBNCURSES 1)
     set(CURSES_INCLUDE "<ncurses.h>")
 
-    set(CURSES_LIBRARIES ${CURSES_LIBRARY})
+    if(NOT TINFO_FOUND)
+        set(CURSES_LIBRARIES "${CURSES_LIBRARY}")
+    else()
+        set(CURSES_LIBRARIES "${CURSES_LIBRARY};${TINFO_LIBRARY}")
+    endif()
+
     set(CURSES_INCLUDE_DIRS ${NCURSES_INCLUDE_DIR})
     set(CURSES_DEFINITIONS ${PC_NCurses_CFLAGS_OTHER})
 
     if (NOT TARGET Curses::curses)
-      add_library(Curses::curses INTERFACE IMPORTED)
-      set_target_properties(Curses::curses PROPERTIES
-        INTERFACE_COMPILE_OPTIONS "${PC_NCurses_CFLAGS_OTHER}"
-        INTERFACE_INCLUDE_DIRECTORIES "${CURSES_INCLUDE_DIRS}"
-        INTERFACE_LINK_LIBRARIES "${CURSES_LIBRARY}"
-      )
+        add_library(Curses::curses INTERFACE IMPORTED)
+        set_target_properties(Curses::curses PROPERTIES
+            INTERFACE_COMPILE_OPTIONS "${PC_NCurses_CFLAGS_OTHER}"
+            INTERFACE_INCLUDE_DIRECTORIES "${CURSES_INCLUDE_DIRS}"
+            INTERFACE_LINK_LIBRARIES "${CURSES_LIBRARIES}"
+        )
     endif()
 else()
-  # Try for PDCurses
-  pkg_check_modules(PC_PDCurses QUIET curses)
+    # Try for PDCurses
+    pkg_check_modules(PC_PDCurses QUIET curses)
 
-  find_path(PDCURSES_INCLUDE_DIR
-    NAMES curses.h
-    PATHS ${PC_PDCurses_INCLUDE_DIRS} ${CURSES_INCLUDE_DIR}
-  )
+    find_path(PDCURSES_INCLUDE_DIR
+        NAMES curses.h
+        PATHS ${PC_PDCurses_INCLUDE_DIRS} ${CURSES_INCLUDE_DIR}
+    )
 
-  string(FIND ${PDCURSES_INCLUDE_DIR} "-NOTFOUND" PDCURSES_NOT_FOUND)
-  if(PDCURSES_NOT_FOUND EQUAL -1)
-      #
-      # pdcurses WAS found!
-      #
-      set(HAVE_LIBPDCURSES 1)
-      set(CURSES_INCLUDE "<curses.h>")
+    string(FIND ${PDCURSES_INCLUDE_DIR} "-NOTFOUND" PDCURSES_NOT_FOUND)
+    if(PDCURSES_NOT_FOUND EQUAL -1)
+        #
+        # pdcurses WAS found!
+        #
+        set(HAVE_LIBPDCURSES 1)
+        set(CURSES_INCLUDE "<curses.h>")
 
-      find_library(CURSES_LIBRARY
-        NAMES curses pdcurses
-        PATHS ${PC_PDCurses_LIBRARY_DIRS}
-      )
-
-      set(CURSES_VERSION ${PC_PDCurses_VERSION})
-
-      include(FindPackageHandleStandardArgs)
-      find_package_handle_standard_args(CURSES
-        FOUND_VAR CURSES_FOUND
-        REQUIRED_VARS
-          CURSES_LIBRARY
-          PDCURSES_INCLUDE_DIR
-        VERSION_VAR CURSES_VERSION
-      )
-
-      set(HAVE_LIBPDCURSES 1)
-      set(CURSES_INCLUDE "<curses.h>")
-
-      set(CURSES_LIBRARIES ${CURSES_LIBRARY})
-      set(CURSES_INCLUDE_DIRS ${PDCURSES_INCLUDE_DIR})
-      set(CURSES_DEFINITIONS ${PC_PDCurses_CFLAGS_OTHER})
-
-      if (NOT TARGET Curses::curses)
-        add_library(Curses::curses UNKNOWN IMPORTED)
-        set_target_properties(Curses::curses PROPERTIES
-          INTERFACE_COMPILE_OPTIONS "${PC_PDCurses_CFLAGS_OTHER}"
-          INTERFACE_INCLUDE_DIRECTORIES "${CURSES_INCLUDE_DIRS}"
-          IMPORTED_LOCATION "${CURSES_LIBRARY}"
+        find_library(CURSES_LIBRARY
+            NAMES curses pdcurses
+            PATHS ${PC_PDCurses_LIBRARY_DIRS}
         )
-      endif()
-  else()
-      message(FATAL_ERROR "Unable to find ncurses or pdcurses")
-  endif()
+
+        set(CURSES_VERSION ${PC_PDCurses_VERSION})
+
+        include(FindPackageHandleStandardArgs)
+        find_package_handle_standard_args(CURSES
+            FOUND_VAR CURSES_FOUND
+            REQUIRED_VARS
+            CURSES_LIBRARY
+            PDCURSES_INCLUDE_DIR
+            VERSION_VAR CURSES_VERSION
+        )
+
+        set(HAVE_LIBPDCURSES 1)
+        set(CURSES_INCLUDE "<curses.h>")
+
+        set(CURSES_LIBRARIES ${CURSES_LIBRARY})
+        set(CURSES_INCLUDE_DIRS ${PDCURSES_INCLUDE_DIR})
+        set(CURSES_DEFINITIONS ${PC_PDCurses_CFLAGS_OTHER})
+
+        if (NOT TARGET Curses::curses)
+            add_library(Curses::curses UNKNOWN IMPORTED)
+            set_target_properties(Curses::curses PROPERTIES
+                INTERFACE_COMPILE_OPTIONS "${PC_PDCurses_CFLAGS_OTHER}"
+                INTERFACE_INCLUDE_DIRECTORIES "${CURSES_INCLUDE_DIRS}"
+                IMPORTED_LOCATION "${CURSES_LIBRARIES}"
+            )
+        endif()
+    else()
+        message(FATAL_ERROR "Unable to find ncurses or pdcurses")
+    endif()
 endif()
 
 mark_as_advanced(
-  CURSES_INCLUDE_DIR
-  CURSES_LIBRARY
+    NCURSES_INCLUDE_DIR
+    PDCURSES_INCLUDE_DIR
+    CURSES_LIBRARY
+    TINFO_LIBRARY
 )


### PR DESCRIPTION
I found that on macOS, setting the libncurses.a and libtinfo.a into the same CURSES_LIBRARY variable does not find or link with libtinfo.a.

To fix this, this commit adds a separate TINFO_LIBRARY variable. In the end, CURSES_LIBRARIES and the Curses::curses CMake TARGET will still have both libraries set, if both are provided.

This fix is necessary if the ncurses was built with `--with-terminfo`. I think we got away without it on Linux because of pkg-config.