### PR TITLE
Fix a possible crash when loading a malformed logical signature

### DIFF
--- a/libclamav_rust/src/evidence.rs
+++ b/libclamav_rust/src/evidence.rs
@@ -209,7 +209,7 @@ pub unsafe extern "C" fn _evidence_add_indicator(
     indicator_type: IndicatorType,
     err: *mut *mut FFIError,
 ) -> bool {
-    let name_str = validate_str_param!(name);
+    let name_str = validate_str_param!(name, err = err);
 
     let mut evidence = ManuallyDrop::new(Box::from_raw(evidence as *mut Evidence));
 

--- a/libclamav_rust/src/fuzzy_hash.rs
+++ b/libclamav_rust/src/fuzzy_hash.rs
@@ -181,7 +181,7 @@ pub unsafe extern "C" fn _fuzzy_hash_load_subsignature(
     subsig_id: u32,
     err: *mut *mut FFIError,
 ) -> bool {
-    let hexsig = validate_str_param!(hexsig);
+    let hexsig = validate_str_param!(hexsig, err=err);
 
     let mut hashmap = ManuallyDrop::new(Box::from_raw(fuzzy_hashmap as *mut FuzzyHashMap));
 


### PR DESCRIPTION
If the 'hexsig' for an image fuzzy hash subsignature has invalid unicode it may cause a crash. The problem is we fail to allocate an error message in this instance, so when it tries to print that message it gets a NULL dereference.

This is not a security issue.

Fixes: https://issues.oss-fuzz.com/issues/376331488