### PR TITLE
Freshclam: fix crash when using DatabaseCustomURL for CVD and other files

### DIFF
--- a/freshclam/freshclam.c
+++ b/freshclam/freshclam.c
@@ -1504,7 +1504,7 @@ fc_error_t perform_database_update(
                 const char *startOfFilename = strrchr(urlDatabaseList[i], '/') + 1;
                 if (NULL != startOfFilename) {
                     // Add the base database name to the do-not-prune list, excluding the '.cvd' extension.
-                    doNotPruneDatabaseList[nDatabases + i] = CLI_STRNDUP(startOfFilename, strlen(startOfFilename) - strlen(".cvd"));
+                    doNotPruneDatabaseList[nDoNotPruneDatabases] = CLI_STRNDUP(startOfFilename, strlen(startOfFilename) - strlen(".cvd"));
                     nDoNotPruneDatabases++;
                 }
             }


### PR DESCRIPTION
Freshclam may crash if using DatabaseCustomURL for a CVD and multiple other files. 
The issue occurs because of a bad index in the "do not prune" list.

Fixes: https://github.com/Cisco-Talos/clamav/issues/1364