### PR TITLE
Adding clamav cargo vcs info for each rust component as used by ClamAV at build time

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -89,7 +89,7 @@ pipeline {
 
                 dir(path: 'docs/html') {
                     sh """# Move the clamav-documentation here.
-                        cp -r ../../clamav_documentation/ .
+                        cp -r ../../clamav_documentation/* .
                         # Clean-up
                         rm -rf ../../clamav_documentation
                         rm -rf .git .nojekyll CNAME Placeholder || true
@@ -122,6 +122,13 @@ pipeline {
                         cpack --config CPackSourceConfig.cmake
                     """
                     archiveArtifacts(artifacts: "clamav-${params.VERSION}*.tar.gz", onlyIfSuccessful: true)
+
+                    sh """
+                        jq -s 'map(. + {package_version: input_filename | split("/") | .[-2]})' $HOME/.cargo/registry/src/*/*/.cargo_vcs_info.json > clamav_cargo_vcs_info.json
+                    """
+
+                    archiveArtifacts(artifacts: "clamav_cargo_vcs_info.json", onlyIfSuccessful: true)
+
                 }
                 cleanWs()
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -124,7 +124,7 @@ pipeline {
                     archiveArtifacts(artifacts: "clamav-${params.VERSION}*.tar.gz", onlyIfSuccessful: true)
 
                     sh """
-                        jq -s 'map(. + {package_version: input_filename | split("/") | .[-2]})' $HOME/.cargo/registry/src/*/*/.cargo_vcs_info.json > clamav_cargo_vcs_info.json
+                        jq -n '[ inputs | .package_version = (input_filename | split("/") | .[-2])]' $HOME/.cargo/registry/src/*/*/.cargo_vcs_info.json > clamav_cargo_vcs_info.json
                     """
 
                     archiveArtifacts(artifacts: "clamav_cargo_vcs_info.json", onlyIfSuccessful: true)


### PR DESCRIPTION
This file can be used to get the source code for each rust component used while building ClamAV.

Here "**package_version**" is the new key added to specify the "git" sha1 of individual rust package. File is derived from .cargo_vcs_info.json file build time.

Sample Value for a component.

`  {
    "git": {
      "sha1": "6aa1d2eb8d9d82f09772a665ffe4f689a90f0a9c"
    },
    "path_in_vcs": "derive",
    "package_version": "zune-inflate-0.2.54"
  }
`