### PR TITLE
Fix CVD dsig verification when hash starts with zeros

### DIFF
--- a/libclamav/dsig.c
+++ b/libclamav/dsig.c
@@ -88,7 +88,7 @@ static unsigned char *cli_decodesig(const char *sig, unsigned int plen, BIGNUM *
     BIGNUM *r = NULL, *p = NULL, *c = NULL;
     BN_CTX *bn_ctx = NULL;
     unsigned int bn_bytes;
-    ;
+    unsigned char *plain_offset = NULL;
 
     r = BN_new();
     if (!r) {
@@ -144,9 +144,12 @@ static unsigned char *cli_decodesig(const char *sig, unsigned int plen, BIGNUM *
         cli_errmsg("cli_decodesig: Can't allocate memory for 'plain'\n");
         goto done;
     }
-    if (!BN_bn2bin(p, plain)) {
-        goto done;
-    }
+
+    // If bn_bytes is smaller than plen, we need to offset the plain buffer.
+    // If we didn't, then a hash that should start with 00 would end with 00 instead.
+    plain_offset = plain + plen - bn_bytes;
+
+    BN_bn2bin(p, plain_offset);
 
     ret_sig = plain;
     plain   = NULL;


### PR DESCRIPTION
Occasionally the MD5 hash for RSA-based digital signature verification begins with zeros. A bug in how we convert the RSA decoded plain text from a big number back to a hex string causes it to write the number to the far left of the plain text buffer. If the number is smaller than a hash, then zero-padding ends up on the right when it should've been on the left.