### PR TITLE
Fix: TNEF dump hanging

### DIFF
--- a/libclamav/tnef.c
+++ b/libclamav/tnef.c
@@ -171,7 +171,7 @@ int cli_tnef(const char *dir, cli_ctx *ctx)
                         cli_warnmsg("Saving dump to %s:  refer to https://docs.clamav.net/manual/Installing.html\n", filename);
 
                         pos = 0;
-                        while ((count = fmap_readn(ctx->fmap, buffer, pos, sizeof(buffer))) != (size_t)-1) {
+                        while ((count = fmap_readn(ctx->fmap, buffer, pos, sizeof(buffer))) != (size_t)-1 && count != 0) {
                             pos += count;
                             cli_writen(fout, buffer, count);
                         }


### PR DESCRIPTION
Hello, while running clamav in debug mode, we found a file that was hanging the process.

After investigation, it turns out it is an eml with a winmail.data attachment > 8kb

So, in order to dump, it loops over the file with BUFSIZ chunks using fmap_readn

fmap_readn can return either -1 or 0 (https://github.com/Cisco-Talos/clamav/blob/86a38352182aef4b63fcbd69fade4ac11b66bea2/libclamav/fmap.h#L301) but in the dump code only the -1 case is handled

It is hard to add a test, we can't share the original file and I found no way to create a similar file