### PR TITLE
Fix unit tests srcdir var - env vars are case sensitive

### DIFF
--- a/unit_tests/check_bytecode.c
+++ b/unit_tests/check_bytecode.c
@@ -501,7 +501,7 @@ END_TEST
 
 static void runload(const char *dbname, struct cl_engine *engine, unsigned signoexp)
 {
-    const char *srcdir = getenv("srcdir");
+    const char *srcdir = getenv("SRCDIR");
     char *str;
     unsigned signo = 0;
     int rc;

--- a/unit_tests/check_clamav.c
+++ b/unit_tests/check_clamav.c
@@ -1899,7 +1899,7 @@ void errmsg_expected(void)
 int open_testfile(const char *name, int flags)
 {
     int fd;
-    const char *srcdir = getenv("srcdir");
+    const char *srcdir = getenv("SRCDIR");
     char *str;
 
     if (!srcdir) {


### PR DESCRIPTION
In unit tests has been used `getenv("srcdir")` but the set variable is called `SRCDIR`.  
So on platforms where env vars are case sensitive, the unit tests failed 1.4.2 and master at least.