### PR TITLE
Tests: remove dead code

### DIFF
--- a/unit_tests/check_bytecode.c
+++ b/unit_tests/check_bytecode.c
@@ -501,17 +501,13 @@ END_TEST
 
 static void runload(const char *dbname, struct cl_engine *engine, unsigned signoexp)
 {
-    const char *srcdir = getenv("srcdir");
     char *str;
     unsigned signo = 0;
     int rc;
-    if (!srcdir) {
-        /* when run from automake srcdir is set, but if run manually then not */
-        srcdir = SRCDIR;
-    }
-    str = malloc(strlen(srcdir) + 1 + strlen(dbname) + 1);
+
+    str = malloc(strlen(SRCDIR) + 1 + strlen(dbname) + 1);
     ck_assert_msg(!!str, "malloc");
-    sprintf(str, "%s" PATHSEP "%s", srcdir, dbname);
+    sprintf(str, "%s" PATHSEP "%s", SRCDIR, dbname);
 
     rc = cl_load(str, engine, &signo, CL_DB_STDOPT);
     ck_assert_msg(rc == CL_SUCCESS, "failed to load %s: %s\n",

--- a/unit_tests/check_clamav.c
+++ b/unit_tests/check_clamav.c
@@ -538,11 +538,6 @@ static unsigned skip_files(void)
     unsigned skipped = 0;
 
     /* skip .rar files if unrar is disabled */
-    const char *s = getenv("unrar_disabled");
-    if (s && !strcmp(s, "1")) {
-        skipped += 2;
-    }
-
 #if HAVE_UNRAR
 #else
     skipped += 2;
@@ -1899,17 +1894,11 @@ void errmsg_expected(void)
 int open_testfile(const char *name, int flags)
 {
     int fd;
-    const char *srcdir = getenv("srcdir");
     char *str;
 
-    if (!srcdir) {
-        /* when run from automake srcdir is set, but if run manually then not */
-        srcdir = SRCDIR;
-    }
-
-    str = malloc(strlen(name) + strlen(srcdir) + 2);
+    str = malloc(strlen(name) + strlen(SRCDIR) + 2);
     ck_assert_msg(!!str, "malloc");
-    sprintf(str, "%s" PATHSEP "%s", srcdir, name);
+    sprintf(str, "%s" PATHSEP "%s", SRCDIR, name);
 
     fd = open(str, flags);
     ck_assert_msg(fd >= 0, "open() failed: %s", str);


### PR DESCRIPTION
Remove check for 'unrar_disabled' only used by legacy Automake tooling.

Resolves: https://github.com/Cisco-Talos/clamav/issues/1447