### PR TITLE
CMake: Fix Windows build issue w/ conflicting libraries

### DIFF
--- a/clamdtop/CMakeLists.txt
+++ b/clamdtop/CMakeLists.txt
@@ -47,6 +47,8 @@ if(WIN32)
             UNRESOLVED_DEPENDENCIES_VAR _u_deps
             DIRECTORIES
                 $<TARGET_FILE_DIR:Curses::curses>
+            POST_EXCLUDE_REGEXES
+                "[cC]:[\\/][wW][iI][nN][dD][oO][wW][sS]"
         )
         foreach(_file ${_r_deps})
             string(TOLOWER ${_file} _file_lower)

--- a/clamsubmit/CMakeLists.txt
+++ b/clamsubmit/CMakeLists.txt
@@ -57,6 +57,8 @@ if(WIN32)
             DIRECTORIES
                 $<TARGET_FILE_DIR:CURL::libcurl>
                 $<TARGET_FILE_DIR:JSONC::jsonc>
+            POST_EXCLUDE_REGEXES
+                "[cC]:[\\/][wW][iI][nN][dD][oO][wW][sS]"
         )
         foreach(_file ${_r_deps})
             string(TOLOWER ${_file} _file_lower)

--- a/libclamav/CMakeLists.txt
+++ b/libclamav/CMakeLists.txt
@@ -495,6 +495,8 @@ if(ENABLE_SHARED_LIB)
                     $<TARGET_FILE_DIR:PCRE2::pcre2>
                     $<TARGET_FILE_DIR:LibXml2::LibXml2>
                     $<TARGET_FILE_DIR:JSONC::jsonc>
+                POST_EXCLUDE_REGEXES
+                    "[cC]:[\\/][wW][iI][nN][dD][oO][wW][sS]"
             )
             foreach(_file ${_r_deps})
                 string(TOLOWER ${_file} _file_lower)

--- a/libfreshclam/CMakeLists.txt
+++ b/libfreshclam/CMakeLists.txt
@@ -83,6 +83,8 @@ if(ENABLE_SHARED_LIB)
                     $<TARGET_FILE_DIR:CURL::libcurl>
                     $<TARGET_FILE_DIR:OpenSSL::SSL>
                     $<TARGET_FILE_DIR:OpenSSL::Crypto>
+                POST_EXCLUDE_REGEXES
+                   "[cC]:[\\/][wW][iI][nN][dD][oO][wW][sS]"
             )
             foreach(_file ${_r_deps})
                 string(TOLOWER ${_file} _file_lower)

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -441,6 +441,8 @@ if(WIN32)
                         $<TARGET_FILE_DIR:LibXml2::LibXml2>
                         $<TARGET_FILE_DIR:CURL::libcurl>
                         $<TARGET_FILE_DIR:JSONC::jsonc>
+                    POST_EXCLUDE_REGEXES
+                        "[cC]:[\\/][wW][iI][nN][dD][oO][wW][sS]"
                     CONFLICTING_DEPENDENCIES_PREFIX CTEST_CONFLICTING_DEPENDENCIES
                 )
                 foreach(_file ${_r_deps})
@@ -496,6 +498,8 @@ if(WIN32)
                         $<TARGET_FILE_DIR:PCRE2::pcre2>
                         $<TARGET_FILE_DIR:LibXml2::LibXml2>
                         $<TARGET_FILE_DIR:JSONC::jsonc>
+                    POST_EXCLUDE_REGEXES
+                        "[cC]:[\\/][wW][iI][nN][dD][oO][wW][sS]"
                     CONFLICTING_DEPENDENCIES_PREFIX CTEST_CONFLICTING_DEPENDENCIES
                 )
                 foreach(_file ${_r_deps})


### PR DESCRIPTION
At install, the CMake build may fail if it detects the same library dependency in two locations. This happened for us with the following error:
```
  CMake Error at libfreshclam/cmake_install.cmake:157 (file):
    file Multiple conflicting paths found for libcrypto-3-x64.dll:

      C:/Users/clamav_jenkins_svc.TALOS/clam_dependencies/x64/lib/libcrypto-3-x64.dll
      C:/WINDOWS/system32/libcrypto-3-x64.dll
      C:\WINDOWS\system32/libcrypto-3-x64.dll
  Call Stack (most recent call first):
    cmake_install.cmake:96 (include)
```
This happens when system provided DLL names match exactly with the ones we provide. ClamAV woudld't prefer that DLL at load time, because it looks in the EXE directory first. But it does confuse the `file()` command used to locate build dependencies.

The fix in this commit uses a regex to exclude all libraries found under C:\Windows