### PR TITLE
Fix bounds check in OLE2 decryption

### DIFF
--- a/libclamav/ole2_extract.c
+++ b/libclamav/ole2_extract.c
@@ -2130,7 +2130,7 @@ static cl_error_t handler_otf_encrypted(ole2_header_t *hdr, property_t *prop, co
             }
             bytesRead += blockSize;
 
-            for (; writeIdx <= (leftover + bytesToWrite) - 16; writeIdx += 16, decryptDstIdx += 16) {
+            for (; writeIdx + 16 <= leftover + bytesToWrite; writeIdx += 16, decryptDstIdx += 16) {
                 rijndaelDecrypt(rk, nrounds, &(buff[writeIdx]), &(decryptDst[decryptDstIdx]));
             }
 


### PR DESCRIPTION
The bounds check for the loop iterating an OLE2 block during decryption may have an integer underflow if the `leftover + bytesToWrite` is less than 16. That results in a significant buffer over read and a segfault.

The fix is simply to do addition on the left side of the check instead of subtraction on the right.

Fixes https://issues.oss-fuzz.com/issues/372544101

Note: This is the fix from 1.4.2 and 1.0.8 (e.g. a copy of https://github.com/Cisco-Talos/clamav/commit/935b2fe3a715c08fa5e63d5f01772a32df7ef385) for main / 1.5.