### PR TITLE
On Windows, use CP_UTF8 over CP_OEMCP for output

### DIFF
--- a/clambc/bcrun.c
+++ b/clambc/bcrun.c
@@ -262,6 +262,10 @@ int main(int argc, char *argv[])
     int fd = -1;
     unsigned tracelevel;
 
+#ifdef _WIN32
+    SetConsoleOutputCP(CP_UTF8);
+#endif
+
     if (check_flevel())
         exit(1);
 

--- a/clamd/clamd.c
+++ b/clamd/clamd.c
@@ -177,7 +177,9 @@ int main(int argc, char **argv)
     if (check_flevel())
         exit(1);
 
-#ifndef _WIN32
+#ifdef _WIN32
+    SetConsoleOutputCP(CP_UTF8);
+#else /* !_WIN32 */
     memset(&sa, 0, sizeof(sa));
     sa.sa_handler = SIG_IGN;
     sigaction(SIGHUP, &sa, NULL);

--- a/clamdscan/clamdscan.c
+++ b/clamdscan/clamdscan.c
@@ -68,7 +68,9 @@ int main(int argc, char **argv)
     struct optstruct *opts;
     const struct optstruct *opt;
     char buffer[26];
-#ifndef _WIN32
+#ifdef _WIN32
+    SetConsoleOutputCP(CP_UTF8);
+#else /* !_WIN32 */
     struct sigaction sigact;
 #endif
 

--- a/clamdtop/clamdtop.c
+++ b/clamdtop/clamdtop.c
@@ -1577,6 +1577,10 @@ int main(int argc, char *argv[])
     struct timeval tv_last, tv;
     unsigned i;
 
+#ifdef _WIN32
+    SetConsoleOutputCP(CP_UTF8);
+#endif
+
     atexit(cleanup);
     setup_connections(argc, argv);
     init_ncurses(global.num_clamd, default_colors);

--- a/clamscan/clamscan.c
+++ b/clamscan/clamscan.c
@@ -68,7 +68,9 @@ int main(int argc, char **argv)
     time_t date_start, date_end;
 
     char buffer[26];
-#ifndef _WIN32
+#ifdef _WIN32
+    SetConsoleOutputCP(CP_UTF8);
+#else /* !_WIN32 */
     sigset_t sigset;
 #endif
     struct optstruct *opts;

--- a/clamsubmit/clamsubmit.c
+++ b/clamsubmit/clamsubmit.c
@@ -204,6 +204,10 @@ int main(int argc, char *argv[])
     char *url_for_auth_token;
     char *url_for_presigned_cookie;
 
+#ifdef _WIN32
+    SetConsoleOutputCP(CP_UTF8);
+#endif
+
     curl_global_init(CURL_GLOBAL_ALL);
 
     clam_curl = curl_easy_init();

--- a/common/output.c
+++ b/common/output.c
@@ -505,35 +505,6 @@ void mprintf(loglevel_t loglevel, const char *str, ...)
     va_end(args);
     buff[len - 1] = 0;
 
-#ifdef _WIN32
-    do {
-        int tmplen    = len + 1;
-        wchar_t *tmpw = malloc(tmplen * sizeof(wchar_t));
-        char *nubuff;
-        if (!tmpw)
-            break;
-        if (!MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, buff, -1, tmpw, tmplen)) {
-            free(tmpw);
-            break;
-        }
-        /* FIXME CHECK IT'S REALLY UTF8 */
-        nubuff = (char *)malloc(tmplen);
-        if (!nubuff) {
-            free(tmpw);
-            break;
-        }
-        if (!WideCharToMultiByte(CP_OEMCP, 0, tmpw, -1, nubuff, tmplen, NULL, NULL)) {
-            free(nubuff);
-            free(tmpw);
-            break;
-        }
-        free(tmpw);
-        if (len > sizeof(buffer))
-            free(abuffer);
-        abuffer = buff = nubuff;
-        len            = sizeof(buffer) + 1;
-    } while (0);
-#endif
     if (loglevel == LOGG_ERROR) {
         if (!mprintf_stdout)
             fd = stderr;

--- a/sigtool/sigtool.c
+++ b/sigtool/sigtool.c
@@ -4132,6 +4132,10 @@ int main(int argc, char **argv)
     const char *cvdcertsdir = NULL;
     STATBUF statbuf;
 
+#ifdef _WIN32
+    SetConsoleOutputCP(CP_UTF8);
+#endif
+
     if (check_flevel())
         exit(1);
 


### PR DESCRIPTION
CP_ACP makes more sense than CP_OEMCP. It is more common that applications use ACP over OEM.

Tested by inputting a file with unicode characters in its name. Now it is presented in the ACP. Also ran `ctest -C RelWithDebInfo` but I'm not sure if it tests those kinds of things.

An alternative would be to encode it as UTF-8. Then all unicode characters could be represented.