### PR TITLE
clamd: Fix bug reporting memory stats, used by clamdtop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -778,6 +778,8 @@ include(CheckFTS)
 include(CheckUnamePosix)
 # Check support for file descriptor passing
 include(CheckFDPassing)
+# Check support for mallinfo memory stats
+include(CheckMallinfo)
 
 # Check if big-endian
 include(TestBigEndian)

--- a/cmake/CheckMallinfo.c
+++ b/cmake/CheckMallinfo.c
@@ -1,0 +1,8 @@
+#include <malloc.h>
+
+int main()
+{
+    struct mallinfo mi;
+    mi = mallinfo();
+    return 0;
+}

--- a/cmake/CheckMallinfo.cmake
+++ b/cmake/CheckMallinfo.cmake
@@ -1,0 +1,26 @@
+#
+# Check for mallinfo(3) sys call.
+#
+
+GET_FILENAME_COMPONENT(_selfdir_CheckMallinfo
+    "${CMAKE_CURRENT_LIST_FILE}" PATH)
+
+# Check that the POSIX compliant uname(2) call works properly (HAVE_UNAME_SYSCALL)
+try_run(
+    # Name of variable to store the run result (process exit status; number) in:
+    test_run_result
+    # Name of variable to store the compile result (TRUE or FALSE) in:
+    test_compile_result
+    # Binary directory:
+    ${CMAKE_CURRENT_BINARY_DIR}
+    # Source file to be compiled:
+    ${_selfdir_CheckMallinfo}/CheckMallinfo.c
+    # Where to store the output produced during compilation:
+    COMPILE_OUTPUT_VARIABLE test_compile_output
+    # Where to store the output produced by running the compiled executable:
+    RUN_OUTPUT_VARIABLE test_run_output )
+
+# Did compilation succeed and process return 0 (success)?
+if("${test_compile_result}" AND ("${test_run_result}" EQUAL 0))
+    set(HAVE_MALLINFO 1)
+endif()


### PR DESCRIPTION
ClamD's STATS API reports process memory stats on systems that
provide the `mallinfo()` system call.
This feature is used by ClamDTOP to show process memory usage.
When we switched to the CMake build system, we neglected to add the
check for the `mallinfo()` system call and so broke ClamD memory
usage reporting.

This commit adds the CMake check for `mallinfo()` and sets
HAVE_MALLINFO, if found.

Fixes: https://github.com/Cisco-Talos/clamav/issues/706

Jira: CLAM-2742