### PR TITLE
Fix possible undefined behavior in inflate64 module

### DIFF
--- a/libclamav/inflate64.c
+++ b/libclamav/inflate64.c
@@ -857,7 +857,7 @@ unsigned short FAR *work;
     code FAR *next;             /* next available space in table */
     const unsigned short FAR *base;     /* base value table to use */
     const unsigned short FAR *extra;    /* extra bits table to use */
-    int end;                    /* use base and extra for symbol > end */
+    unsigned match;             /* use base and extra for symbol >= match */
     unsigned short count[MAXBITS+1];    /* number of codes of each length */
     unsigned short offs[MAXBITS+1];     /* offsets in table for each length */
     static const unsigned short lbase[31] = { /* Length codes 257..285 base */
@@ -987,19 +987,17 @@ unsigned short FAR *work;
     switch (type) {
     case CODES:
         base = extra = work;    /* dummy value--not used */
-        end = 19;
+        match = 20;
         break;
     case LENS:
         base = lbase;
-        base -= 257;
         extra = lext;
-        extra -= 257;
-        end = 256;
+        match = 257;
         break;
     default:            /* DISTS */
         base = dbase;
         extra = dext;
-        end = -1;
+        match = 0;
     }
 
     /* initialize state for loop */
@@ -1021,13 +1019,13 @@ unsigned short FAR *work;
     for (;;) {
         /* create table entry */
         this.bits = (unsigned char)(len - drop);
-        if ((int)(work[sym]) < end) {
+        if (work[sym] + 1U < match) {
             this.op = (unsigned char)0;
             this.val = work[sym];
         }
-        else if ((int)(work[sym]) > end) {
-            this.op = (unsigned char)(extra[work[sym]]);
-            this.val = base[work[sym]];
+        else if (work[sym] >= match) {
+            this.op = (unsigned char)(extra[work[sym] - match]);
+            this.val = base[work[sym] - match];
         }
         else {
             this.op = (unsigned char)(32 + 64);         /* end of block */


### PR DESCRIPTION
The ClamAV inflate64 module is based on zlib 1.2.3 source code with significant changes to support extracting zip64 and some addressing code quality issues.

This commit adds a zlib v1.2.9 fix for possible undefined behavior: https://github.com/madler/zlib/commit/6a043145ca6e9c55184013841a67b2fef87e44c0

Thank you to TITAN Team for reporting this issue.