### PR TITLE
Windows: code quality improvement for --move and --remove options

### DIFF
--- a/common/actions.c
+++ b/common/actions.c
@@ -344,7 +344,7 @@ static int traverse_to(const char *directory, bool want_directory_handle, HANDLE
                 /* Change createfile options for our target file instead of an intermediate directory. */
                 desiredAccess  = FILE_GENERIC_READ | DELETE;
                 fileAttributes = FILE_ATTRIBUTE_NORMAL;
-                createOptions  = FILE_NON_DIRECTORY_FILE;
+                createOptions  = FILE_NON_DIRECTORY_FILE | FILE_OPEN_REPARSE_POINT;
                 shareAccess    = FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE;
             }
         }


### PR DESCRIPTION
When the --move or --remove options are used, ClamAV carefully traverses the file path one layer at a time so as to avoid following a directory that is a symlink or reparse point.
We do this for directories, but could also do it for files. Only an admin should be able to create a reparse point for a file, but it is better to be consistent.

Thank you to Maxim Suhanov for reporting this issue.