### PR TITLE
CMake/Rust openssl detection fix

### DIFF
--- a/libclamav_rust/CMakeLists.txt
+++ b/libclamav_rust/CMakeLists.txt
@@ -8,29 +8,25 @@
 get_filename_component(OPENSSL_DIR "${OPENSSL_INCLUDE_DIR}" DIRECTORY)
 
 set(OPENSSL_LIBS "")
-foreach(LIB IN LISTS OPENSSL_LIBRARIES)
-    # Skip any libraries starting with `-l` (e.g. -lpthread).
-    # These are system libraries and won't be found in the OPENSSL_LIB_DIR.
-    if (NOT LIB MATCHES "^-l")
-        # Remove path and extension
-        get_filename_component(LIBNAME "${LIB}" NAME_WLE)
 
-        # Remove "lib" prefix, if present
-        string(REGEX REPLACE "^lib" "" LIBNAME "${LIBNAME}")
+# Get the libcrypto library.
+# Remove path and extension.
+get_filename_component(LIBNAME "${OPENSSL_CRYPTO_LIBRARY}" NAME_WLE)
+# Remove "lib" prefix, if present.
+string(REGEX REPLACE "^lib" "" LIBNAME "${LIBNAME}")
+# Add libcrypto.
+set(OPENSSL_LIBS "${LIBNAME}")
 
-        if (NOT OPENSSL_LIBS)
-            # Add first openssl lib.
-            set(OPENSSL_LIBS "${LIBNAME}")
+# Get the libssl library.
+# Remove path and extension.
+get_filename_component(LIBNAME "${OPENSSL_SSL_LIBRARY}" NAME_WLE)
+# Remove "lib" prefix, if present.
+string(REGEX REPLACE "^lib" "" LIBNAME "${LIBNAME}")
+# Add libssl.
+set(OPENSSL_LIBS "${OPENSSL_LIBS}:${LIBNAME}")
 
-            # While we're at it... get directory of the first library to use for the OPENSSL_LIB_DIR.
-            # Note: This assumes that all libs are in the same directory.
-            get_filename_component(OPENSSL_LIB_DIR "${LIB}" DIRECTORY)
-        else()
-            # Add additional openssl libs.
-            set(OPENSSL_LIBS "${OPENSSL_LIBS}:${LIBNAME}")
-        endif()
-    endif()
-endforeach()
+# Get directory of the first library to use for the OPENSSL_LIB_DIR.
+get_filename_component(OPENSSL_LIB_DIR "${OPENSSL_CRYPTO_LIBRARY}" DIRECTORY)
 
 set(ENVIRONMENT "")
 list(APPEND ENVIRONMENT "OPENSSL_DIR=${OPENSSL_DIR}")

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -303,29 +303,25 @@ set(ENVIRONMENT
 get_filename_component(OPENSSL_DIR "${OPENSSL_INCLUDE_DIR}" DIRECTORY)
 
 set(OPENSSL_LIBS "")
-foreach(LIB IN LISTS OPENSSL_LIBRARIES)
-    # Skip any libraries starting with `-l` (e.g. -lpthread).
-    # These are system libraries and won't be found in the OPENSSL_LIB_DIR.
-    if (NOT LIB MATCHES "^-l")
-        # Remove path and extension
-        get_filename_component(LIBNAME "${LIB}" NAME_WLE)
 
-        # Remove "lib" prefix, if present
-        string(REGEX REPLACE "^lib" "" LIBNAME "${LIBNAME}")
+# Get the libcrypto library.
+# Remove path and extension.
+get_filename_component(LIBNAME "${OPENSSL_CRYPTO_LIBRARY}" NAME_WLE)
+# Remove "lib" prefix, if present.
+string(REGEX REPLACE "^lib" "" LIBNAME "${LIBNAME}")
+# Add libcrypto.
+set(OPENSSL_LIBS "${LIBNAME}")
 
-        if (NOT OPENSSL_LIBS)
-            # Add first openssl lib.
-            set(OPENSSL_LIBS "${LIBNAME}")
+# Get the libssl library.
+# Remove path and extension.
+get_filename_component(LIBNAME "${OPENSSL_SSL_LIBRARY}" NAME_WLE)
+# Remove "lib" prefix, if present.
+string(REGEX REPLACE "^lib" "" LIBNAME "${LIBNAME}")
+# Add libssl.
+set(OPENSSL_LIBS "${OPENSSL_LIBS}:${LIBNAME}")
 
-            # While we're at it... get directory of the first library to use for the OPENSSL_LIB_DIR.
-            # Note: This assumes that all libs are in the same directory.
-            get_filename_component(OPENSSL_LIB_DIR "${LIB}" DIRECTORY)
-        else()
-            # Add additional openssl libs.
-            set(OPENSSL_LIBS "${OPENSSL_LIBS}:${LIBNAME}")
-        endif()
-    endif()
-endforeach()
+# Get directory of the first library to use for the OPENSSL_LIB_DIR.
+get_filename_component(OPENSSL_LIB_DIR "${OPENSSL_CRYPTO_LIBRARY}" DIRECTORY)
 
 list(APPEND ENVIRONMENT "OPENSSL_DIR=${OPENSSL_DIR}")
 list(APPEND ENVIRONMENT "OPENSSL_INCLUDE_DIR=${OPENSSL_INCLUDE_DIR}")

--- a/unit_tests/clamd_test.py
+++ b/unit_tests/clamd_test.py
@@ -48,7 +48,7 @@ class TC(testcase.TestCase):
         TC.clamd_socket =   'clamd-test.socket'             # <-- A relative path here and in check_clamd to avoid-
                                                             # test failures caused by (invalid) long socket filepaths.
                                                             # The max length for a socket file path is _really_ short.
-        TC.clamd_port_num = 3319                            # <-- This is hard-coded into the `check_clamd` program
+        TC.clamd_port_num = 3319                            # <-- This is hard-coded into the `check_clamd` program on Windows.
         TC.path_db = TC.path_tmp / 'database'
         TC.path_db.mkdir(parents=True)
         shutil.copy(
@@ -96,9 +96,7 @@ class TC(testcase.TestCase):
             # Use LocalSocket for Posix, because that's what check_clamd expects.
             config += '''
                 LocalSocket {localsocket}
-                TCPSocket {tcpsocket}
-                TCPAddr localhost
-                '''.format(localsocket=TC.clamd_socket, tcpsocket=TC.clamd_port_num)
+                '''.format(localsocket=TC.clamd_socket)
 
         TC.clamd_config = TC.path_tmp / 'clamd-test.conf'
         TC.clamd_config.write_text(config)
@@ -616,9 +614,7 @@ class TC(testcase.TestCase):
             # Use LocalSocket for Posix, because that's what check_clamd expects.
             config += '''
                 LocalSocket {localsocket}
-                TCPSocket {tcpsocket}
-                TCPAddr localhost
-                '''.format(localsocket=TC.clamd_socket, tcpsocket=TC.clamd_port_num)
+                '''.format(localsocket=TC.clamd_socket)
 
         clamd_config = TC.path_tmp / 'clamd-test.conf'
         clamd_config.write_text(config)
@@ -692,9 +688,7 @@ class TC(testcase.TestCase):
             # Use LocalSocket for Posix, because that's what check_clamd expects.
             config += '''
                 LocalSocket {localsocket}
-                TCPSocket {tcpsocket}
-                TCPAddr localhost
-                '''.format(localsocket=TC.clamd_socket, tcpsocket=TC.clamd_port_num)
+                '''.format(localsocket=TC.clamd_socket)
 
         clamd_config = TC.path_tmp / 'clamd-test.conf'
         clamd_config.write_text(config)
@@ -776,9 +770,7 @@ class TC(testcase.TestCase):
             # Use LocalSocket for Posix, because that's what check_clamd expects.
             config += '''
                 LocalSocket {localsocket}
-                TCPSocket {tcpsocket}
-                TCPAddr localhost
-                '''.format(localsocket=TC.clamd_socket, tcpsocket=TC.clamd_port_num)
+                '''.format(localsocket=TC.clamd_socket)
 
         clamd_config = TC.path_tmp / 'clamd-test.conf'
         clamd_config.write_text(config)


### PR DESCRIPTION
We observed build failures on Ubuntu 20.04 ARM64 because the Rust code saw extra OpenSSL dependencies in the OPENSSL_LIBS environment variable and was confused.

This change switches from using OPENSSL_LIBRARIES, which may have extra dependencies for libcrypto/libssl, to only use OPENSSL_CRYPTO_LIBRARY and OPENSSL_SSL_LIBRARY.