### PR TITLE
Wait for the mockup server process to exit before moving on

### DIFF
--- a/unit_tests/freshclam_test.py
+++ b/unit_tests/freshclam_test.py
@@ -50,6 +50,7 @@ class TC(testcase.TestCase):
     def tearDown(self):
         if TC.mock_mirror != None:
             TC.mock_mirror.terminate()
+            TC.mock_mirror.join()
             TC.mock_mirror = None
 
         # Clear the database directory


### PR DESCRIPTION
This fixes #1512, a race condition that triggers when the next server starts quicker than the previous one exits after signalling it asynchronously.