### PR TITLE
Fix lzma-sdk xz bug

### DIFF
--- a/libclamav/7z/XzDec.c
+++ b/libclamav/7z/XzDec.c
@@ -343,8 +343,10 @@ void MixCoder_Free(CMixCoder *p)
   for (i = 0; i < p->numCoders; i++)
   {
     IStateCoder *sc = &p->coders[i];
-    if (p->alloc && sc->p)
+    if (p->alloc && sc->p) {
       sc->Free(sc->p, p->alloc);
+      sc->p = NULL;
+    }
   }
   p->numCoders = 0;
   if (p->buf)


### PR DESCRIPTION
A use-after-free read is possible in the Xz decoder cleanup.

The fix is to set a pointer to NULL so it doesn't try to dereference it and free a second time.

Fixes https://issues.oss-fuzz.com/issues/384549094

This fix is also present in lzma-sdk version 18.01. Ref: https://github.com/welovegit/LZMA-SDK/blame/main/C/XzDec.c#L508

Note: This was also fixed in ClamAV 1.4.3 and 1.0.9.