### PR TITLE
Improve handling of malformed ZIP files

### DIFF
--- a/libclamav/7z/XzDec.c
+++ b/libclamav/7z/XzDec.c
@@ -343,8 +343,10 @@ void MixCoder_Free(CMixCoder *p)
   for (i = 0; i < p->numCoders; i++)
   {
     IStateCoder *sc = &p->coders[i];
-    if (p->alloc && sc->p)
+    if (p->alloc && sc->p) {
       sc->Free(sc->p, p->alloc);
+      sc->p = NULL;
+    }
   }
   p->numCoders = 0;
   if (p->buf)

--- a/libclamav/unzip.c
+++ b/libclamav/unzip.c
@@ -660,8 +660,10 @@ static unsigned int parse_local_file_header(
     zip += LOCAL_HEADER_flen;
     zsize -= LOCAL_HEADER_flen;
 
-        cli_dbgmsg("cli_unzip: local header - ZMDNAME:%d:%.255s:%u:%u:%x:%u:%u:%u\n",
-               ((LOCAL_HEADER_flags & F_ENCR) != 0), name, LOCAL_HEADER_usize, LOCAL_HEADER_csize, LOCAL_HEADER_crc32, LOCAL_HEADER_method, file_count, ctx->recursion_level);
+    cli_dbgmsg("cli_unzip: local header - ZMDNAME:%d:%.255s:%u:%u:" /*%x:%u:*/ "%u:%u\n",
+               ((LOCAL_HEADER_flags & F_ENCR) != 0), name, usize, csize, file_count, ctx->recursion_level);
+    /* ZMDfmt virname:encrypted(0-1):filename(exact|*):usize(exact|*):csize(exact|*):crc32(exact|*):method(exact|*):fileno(exact|*):maxdepth(exact|*) */
+
     /* Scan file header metadata. */
     if (cli_matchmeta(ctx, name, LOCAL_HEADER_csize, LOCAL_HEADER_usize, (LOCAL_HEADER_flags & F_ENCR) != 0, file_count, LOCAL_HEADER_crc32) == CL_VIRUS) {
         *ret = CL_VIRUS;

--- a/libclamav/unzip.c
+++ b/libclamav/unzip.c
@@ -776,6 +776,11 @@ done:
         free(original_filename);
     }
 
+    if (size_of_fileheader_and_data == 0) {
+        size_of_fileheader_and_data = zip - local_header;
+        *ret = CL_EPARSE;
+    }
+
     return size_of_fileheader_and_data;
 }
 

--- a/libclamav/unzip.c
+++ b/libclamav/unzip.c
@@ -625,6 +625,8 @@ static unsigned int parse_local_file_header(
     uint32_t nsize  = 0;
     const char *src = NULL;
 
+    zip = local_header + SIZEOF_LOCAL_HEADER;
+
     if (!(local_header = fmap_need_off(map, loff, SIZEOF_LOCAL_HEADER))) {
         cli_dbgmsg("cli_unzip: local header - out of file\n");
         goto done;
@@ -638,7 +640,6 @@ static unsigned int parse_local_file_header(
         goto done;
     }
 
-    zip = local_header + SIZEOF_LOCAL_HEADER;
     zsize -= SIZEOF_LOCAL_HEADER;
 
     if (zsize <= LOCAL_HEADER_flen) {
@@ -775,6 +776,7 @@ done:
     if (NULL != original_filename) {
         free(original_filename);
     }
+
 
     if (size_of_fileheader_and_data == 0) {
         size_of_fileheader_and_data = zip - local_header;
@@ -1250,8 +1252,7 @@ cl_error_t index_local_file_headers_within_bounds(
         if (!(ptr = fmap_need_off_once(map, coff, 4)))
             continue;
         if (cli_readint32(ptr) == ZIP_MAGIC_LOCAL_FILE_HEADER) {
-            // increment coff by the size of the found local file header + file data
-            coff += parse_local_file_header(
+            size_t file_record_size = parse_local_file_header(
                 map,
                 coff,
                 fsize - coff,
@@ -1264,15 +1265,18 @@ cl_error_t index_local_file_headers_within_bounds(
                 1,
                 NULL,
                 &(zip_catalogue[index]));
-            // decrement coff by 1 to account for the increment at the end of the loop
-            coff -= 1;
 
-            if (CL_EPARSE != ret) {
-                // Found a record.
-                index++;
-                total_file_count++;
-            }
+        if (file_record_size != 0 && CL_EPARSE != ret) { 
+            // Found a record.
+            cli_dbgmsg("cli_unzip: Found a record\n");
+            index++;
+            total_file_count++;
 
+            // increment coff by the size of the found local file header + file data
+            // but decrement by 1 to account for the increment at the end of the loop
+            coff += file_record_size - 1;
+        }
+            
             if (ret == CL_VIRUS) {
                 status = CL_VIRUS;
                 goto done;

--- a/libclamav/unzip.c
+++ b/libclamav/unzip.c
@@ -616,10 +616,10 @@ static unsigned int parse_local_file_header(
     zip_cb zcb,
     struct zip_record *record)
 {
-    const uint8_t *local_header, *zip;
-    char name[256];
+    const uint8_t *local_header = NULL, *zip = NULL;
+    char name[256] = {0};
     char *original_filename = NULL;
-    uint32_t csize, usize;
+    uint32_t csize = 0, usize = 0;
     unsigned int size_of_fileheader_and_data = 0;
 
     uint32_t nsize  = 0;
@@ -641,30 +641,26 @@ static unsigned int parse_local_file_header(
     zip = local_header + SIZEOF_LOCAL_HEADER;
     zsize -= SIZEOF_LOCAL_HEADER;
 
-    memset(name, '\0', 256);
-
     if (zsize <= LOCAL_HEADER_flen) {
         cli_dbgmsg("cli_unzip: local header - fname out of file\n");
         fmap_unneed_off(map, loff, SIZEOF_LOCAL_HEADER);
         goto done;
     }
 
-    nsize = (LOCAL_HEADER_flen >= sizeof(name)) ? sizeof(name) - 1 : LOCAL_HEADER_flen;
+    nsize = LOCAL_HEADER_flen >= (sizeof(name) - 1) ? sizeof(name) - 1 : LOCAL_HEADER_flen;
+    cli_dbgmsg("cli_unzip: nsize %u\n", nsize);
     src   = fmap_need_ptr_once(map, zip, nsize);
     if (nsize && (NULL != src)) {
         memcpy(name, zip, nsize);
-        name[nsize] = '\0';
         if (CL_SUCCESS != cli_basename(name, nsize, &original_filename)) {
             original_filename = NULL;
         }
-    } else {
-        name[0] = '\0';
     }
 
     zip += LOCAL_HEADER_flen;
     zsize -= LOCAL_HEADER_flen;
 
-    cli_dbgmsg("cli_unzip: local header - ZMDNAME:%d:%s:%u:%u:%x:%u:%u:%u\n",
+    cli_dbgmsg("cli_unzip: local header - ZMDNAME:%d:%.255s:%u:%u:%x:%u:%u:%u\n",
                ((LOCAL_HEADER_flags & F_ENCR) != 0), name, LOCAL_HEADER_usize, LOCAL_HEADER_csize, LOCAL_HEADER_crc32, LOCAL_HEADER_method, file_count, ctx->recursion_level);
     /* ZMDfmt virname:encrypted(0-1):filename(exact|*):usize(exact|*):csize(exact|*):crc32(exact|*):method(exact|*):fileno(exact|*):maxdepth(exact|*) */
 

--- a/libclamav/unzip.c
+++ b/libclamav/unzip.c
@@ -760,7 +760,7 @@ static unsigned int parse_local_file_header(
         }
         zsize -= 12;
         if (fmap_need_ptr_once(map, zip, 4)) {
-            if (cli_readint32(zip) == ZIP_MAGIC_FILE_BEGIN_SPLIT_OR_SPANNED) {
+            if (zip && cli_readint32(zip) == ZIP_MAGIC_FILE_BEGIN_SPLIT_OR_SPANNED) {
                 if (zsize < 4) {
                     cli_dbgmsg("cli_unzip: local header - data desc out of file\n");
                     *ret = CL_EPARSE;
@@ -786,7 +786,7 @@ done:
             size_of_fileheader_and_data = zip - local_header;
         } else {
             // Shouldn't happen, but best to log if it does due to changes
-            cli_dbgmsg("cli_unzip: zip %u local_header %u\n", zip, local_header);
+            cli_dbgmsg("cli_unzip: zip %p local_header %p\n", zip, local_header);
         }
     }
 


### PR DESCRIPTION
This addresses https://github.com/Cisco-Talos/clamav/issues/1534 and makes some minor improvements for maintainability when handling NULL terminated strings.

Solves loops when unzipping ZIP64 as well but only due to an overlapping cause.