### PR TITLE
Jenkins: Remove GitGuardian stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -64,19 +64,6 @@ pipeline {
 
     stages {
 
-        stage('GitGuardian Scan') {
-            environment {
-                GITGUARDIAN_API_KEY = credentials('gitguardian-token')
-                GITGUARDIAN_API_URL = 'https://gitguardian.cisco.com/'
-            }
-            agent { label "docker" }
-            steps {
-                withDockerContainer(args: "-i --entrypoint=''", image: 'gitguardian/ggshield:latest') {
-                    sh 'ggshield secret scan ci'
-                }
-            }
-        }
-
         stage('Generate Tarball') {
             steps {
                 cleanWs()


### PR DESCRIPTION
We have GitHub Advanced Security (GHAS) enabled.
GitGuardian is no longer used.

CLAM-2836