### PR TITLE
ZIP: Fix NULL-dereference for OOXML scans

### DIFF
--- a/libclamav/filetypes.c
+++ b/libclamav/filetypes.c
@@ -278,7 +278,7 @@ const struct ooxml_ftcodes {
         }                                                                       \
     } while (0)
 
-cli_file_t cli_determine_fmap_type(fmap_t *map, const struct cl_engine *engine, cli_file_t basetype)
+cli_file_t cli_determine_fmap_type(cli_ctx *ctx, cli_file_t basetype)
 {
     unsigned char buffer[MAGIC_BUFFER_SIZE];
     const unsigned char *buff;
@@ -289,22 +289,22 @@ cli_file_t cli_determine_fmap_type(fmap_t *map, const struct cl_engine *engine, 
     struct cli_matcher *root;
     struct cli_ac_data mdata;
 
-    if (!engine) {
+    if (!ctx || !ctx->engine || !ctx->fmap) {
         cli_errmsg("cli_determine_fmap_type: engine == NULL\n");
         return CL_TYPE_ERROR;
     }
 
     if (basetype == CL_TYPE_PART_ANY) {
-        bread = MIN(map->len, CL_PART_MBUFF_SIZE);
+        bread = MIN(ctx->fmap->len, CL_PART_MBUFF_SIZE);
     } else {
-        bread = MIN(map->len, CL_FILE_MBUFF_SIZE);
+        bread = MIN(ctx->fmap->len, CL_FILE_MBUFF_SIZE);
     }
     if (bread > MAGIC_BUFFER_SIZE) {
         /* Save anyone who tampered with the header */
         bread = MAGIC_BUFFER_SIZE;
     }
 
-    buff = fmap_need_off_once(map, 0, bread);
+    buff = fmap_need_off_once(ctx->fmap, 0, bread);
     if (buff) {
         if (CL_SUCCESS != cli_memcpy(buffer, buff, bread)) {
             cli_errmsg("cli_determine_fmap_type: fileread error!\n");
@@ -315,9 +315,9 @@ cli_file_t cli_determine_fmap_type(fmap_t *map, const struct cl_engine *engine, 
     }
 
     if (basetype == CL_TYPE_PART_ANY) { /* typing a partition */
-        ret = cli_compare_ftm_partition(buff, bread, engine);
+        ret = cli_compare_ftm_partition(buff, bread, ctx->engine);
     } else { /* typing a file */
-        ret = cli_compare_ftm_file(buff, bread, engine);
+        ret = cli_compare_ftm_file(buff, bread, ctx->engine);
 
         if (ret == CL_TYPE_BINARY_DATA) {
             switch (is_tar(buff, bread)) {
@@ -361,7 +361,7 @@ cli_file_t cli_determine_fmap_type(fmap_t *map, const struct cl_engine *engine, 
                             /* if likely, check full archive */
                             if (likely_ooxml) {
                                 cli_dbgmsg("Likely OOXML, checking additional zip headers\n");
-                                if ((ret2 = cli_ooxml_filetype(NULL, map)) != CL_TYPE_ANY) {
+                                if ((ret2 = cli_ooxml_filetype(ctx)) != CL_TYPE_ANY) {
                                     /* either an error or retyping has occurred, return error or just CL_TYPE_ZIP? */
                                     OOXML_FTIDENTIFIED(ret2);
                                     /* falls-through to additional filetyping */
@@ -375,10 +375,10 @@ cli_file_t cli_determine_fmap_type(fmap_t *map, const struct cl_engine *engine, 
                 }
 
                 if (znamep == NULL) {
-                    if (map->len - zoff > SIZEOF_LOCAL_HEADER) {
+                    if (ctx->fmap->len - zoff > SIZEOF_LOCAL_HEADER) {
                         zoff -= SIZEOF_LOCAL_HEADER + OOXML_DETECT_MAXLEN + 1; /* remap for SIZEOF_LOCAL_HEADER+filelen for header overlap map boundary */
-                        zread = MIN(MAGIC_BUFFER_SIZE, map->len - zoff);
-                        zbuff = fmap_need_off_once(map, zoff, zread);
+                        zread = MIN(MAGIC_BUFFER_SIZE, ctx->fmap->len - zoff);
+                        zbuff = fmap_need_off_once(ctx->fmap, zoff, zread);
                         if (zbuff == NULL) {
                             cli_dbgmsg("cli_determine_fmap_type: error mapping data for OOXML check\n");
                             return CL_TYPE_ERROR;
@@ -393,7 +393,7 @@ cli_file_t cli_determine_fmap_type(fmap_t *map, const struct cl_engine *engine, 
             }
         } else if (ret == CL_TYPE_MBR) {
             /* given filetype sig type 0 */
-            int iret = cli_mbr_check(buff, bread, map->len);
+            int iret = cli_mbr_check(buff, bread, ctx->fmap->len);
             if (iret == CL_TYPE_GPT) {
                 cli_dbgmsg("Recognized GUID Partition Table file\n");
                 return CL_TYPE_GPT;
@@ -411,14 +411,14 @@ cli_file_t cli_determine_fmap_type(fmap_t *map, const struct cl_engine *engine, 
         /* HTML files may contain special characters and could be
          * misidentified as BINARY_DATA by cli_compare_ftm_file()
          */
-        root = engine->root[0];
+        root = ctx->engine->root[0];
         if (!root)
             return ret;
 
         if (cli_ac_initdata(&mdata, root->ac_partsigs, root->ac_lsigs, root->ac_reloff_num, CLI_DEFAULT_AC_TRACKLEN))
             return ret;
 
-        scan_ret = (cli_file_t)cli_ac_scanbuff(buff, bread, NULL, NULL, NULL, engine->root[0], &mdata, 0, ret, NULL, AC_SCAN_FT, NULL);
+        scan_ret = (cli_file_t)cli_ac_scanbuff(buff, bread, NULL, NULL, NULL, ctx->engine->root[0], &mdata, 0, ret, NULL, AC_SCAN_FT, NULL);
 
         cli_ac_freedata(&mdata);
 
@@ -437,14 +437,14 @@ cli_file_t cli_determine_fmap_type(fmap_t *map, const struct cl_engine *engine, 
 
             decoded = (unsigned char *)cli_utf16toascii((char *)buff, bread);
             if (decoded) {
-                scan_ret = (cli_file_t)cli_ac_scanbuff(decoded, bread / 2, NULL, NULL, NULL, engine->root[0], &mdata, 0, CL_TYPE_TEXT_ASCII, NULL, AC_SCAN_FT, NULL);
+                scan_ret = (cli_file_t)cli_ac_scanbuff(decoded, bread / 2, NULL, NULL, NULL, ctx->engine->root[0], &mdata, 0, CL_TYPE_TEXT_ASCII, NULL, AC_SCAN_FT, NULL);
                 free(decoded);
                 if (scan_ret == CL_TYPE_HTML)
                     ret = CL_TYPE_HTML_UTF16;
             }
             cli_ac_freedata(&mdata);
 
-            if ((((struct cli_dconf *)engine->dconf)->phishing & PHISHING_CONF_ENTCONV) && ret != CL_TYPE_HTML_UTF16) {
+            if ((((struct cli_dconf *)ctx->engine->dconf)->phishing & PHISHING_CONF_ENTCONV) && ret != CL_TYPE_HTML_UTF16) {
                 const char *encoding;
 
                 /* check if we can autodetect this encoding.
@@ -472,7 +472,7 @@ cli_file_t cli_determine_fmap_type(fmap_t *map, const struct cl_engine *engine, 
                             return ret;
 
                         if (out_area.length > 0) {
-                            scan_ret = (cli_file_t)cli_ac_scanbuff(decodedbuff, out_area.length, NULL, NULL, NULL, engine->root[0], &mdata, 0, 0, NULL, AC_SCAN_FT, NULL); /* FIXME: can we use CL_TYPE_TEXT_ASCII instead of 0? */
+                            scan_ret = (cli_file_t)cli_ac_scanbuff(decodedbuff, out_area.length, NULL, NULL, NULL, ctx->engine->root[0], &mdata, 0, 0, NULL, AC_SCAN_FT, NULL); /* FIXME: can we use CL_TYPE_TEXT_ASCII instead of 0? */
                             if (scan_ret == CL_TYPE_HTML) {
                                 cli_dbgmsg("cli_determine_fmap_type: detected HTML signature in Unicode file\n");
                                 /* htmlnorm is able to handle any unicode now, since it skips null chars */

--- a/libclamav/filetypes.h
+++ b/libclamav/filetypes.h
@@ -25,7 +25,8 @@
 #include <sys/types.h>
 
 #include "clamav.h"
-#include "fmap.h"
+
+typedef struct cli_ctx_tag cli_ctx;
 
 #define CL_FILE_MBUFF_SIZE 1024
 #define CL_PART_MBUFF_SIZE 1028
@@ -153,7 +154,7 @@ const char *cli_ftname(cli_file_t code);
 void cli_ftfree(const struct cl_engine *engine);
 cli_file_t cli_compare_ftm_file(const unsigned char *buf, size_t buflen, const struct cl_engine *engine);
 cli_file_t cli_compare_ftm_partition(const unsigned char *buf, size_t buflen, const struct cl_engine *engine);
-cli_file_t cli_determine_fmap_type(fmap_t *map, const struct cl_engine *engine, cli_file_t basetype);
+cli_file_t cli_determine_fmap_type(cli_ctx *ctx, cli_file_t basetype);
 int cli_addtypesigs(struct cl_engine *engine);
 
 #endif

--- a/libclamav/ooxml.c
+++ b/libclamav/ooxml.c
@@ -380,7 +380,7 @@ static cl_error_t ooxml_hwp_cb(int fd, const char *filepath, cli_ctx *ctx, const
     return ret;
 }
 
-cli_file_t cli_ooxml_filetype(cli_ctx *ctx, fmap_t *map)
+cli_file_t cli_ooxml_filetype(cli_ctx *ctx)
 {
     struct zip_requests requests;
     cl_error_t ret;
@@ -400,7 +400,7 @@ cli_file_t cli_ooxml_filetype(cli_ctx *ctx, fmap_t *map)
         return CL_TYPE_ANY;
     }
 
-    if ((ret = unzip_search(ctx, map, &requests)) == CL_VIRUS) {
+    if ((ret = unzip_search(ctx, &requests)) == CL_VIRUS) {
         switch (requests.found) {
             case 0:
                 return CL_TYPE_OOXML_XL;

--- a/libclamav/ooxml.h
+++ b/libclamav/ooxml.h
@@ -27,7 +27,7 @@
 
 #include "others.h"
 
-cli_file_t cli_ooxml_filetype(cli_ctx *, fmap_t *);
+cli_file_t cli_ooxml_filetype(cli_ctx *);
 cl_error_t cli_process_ooxml(cli_ctx *, int);
 
 #endif

--- a/libclamav/scanners.c
+++ b/libclamav/scanners.c
@@ -4762,7 +4762,7 @@ cl_error_t cli_magic_scan(cli_ctx *ctx, cli_file_t type)
      */
     perf_start(ctx, PERFT_FT);
     if ((type == CL_TYPE_ANY) || type == CL_TYPE_PART_ANY) {
-        type = cli_determine_fmap_type(ctx->fmap, ctx->engine, type);
+        type = cli_determine_fmap_type(ctx, type);
     }
     perf_stop(ctx, PERFT_FT);
     if (type == CL_TYPE_ERROR) {

--- a/libclamav/unzip.h
+++ b/libclamav/unzip.h
@@ -117,7 +117,7 @@ cl_error_t cli_unzip(cli_ctx *ctx);
  * @param local_header_offset   The offset of the local file header in the zip archive.
  * @return cl_error_t           Returns CL_SUCCESS on success, or an error code on failure.
  */
-cl_error_t cli_unzip_single(cli_ctx *ctx, off_t local_header_offset);
+cl_error_t cli_unzip_single(cli_ctx *ctx, size_t local_header_offset);
 
 /**
  * @brief Unzip a single file from a zip archive.
@@ -131,7 +131,7 @@ cl_error_t cli_unzip_single(cli_ctx *ctx, off_t local_header_offset);
  * @param zcb                   The callback function to invoke after extraction. See `zip_scan_cb`.
  * @return cl_error_t           Returns CL_SUCCESS on success, or an error code on failure.
  */
-cl_error_t unzip_single_internal(cli_ctx *ctx, off_t local_header_offset, zip_cb zcb);
+cl_error_t unzip_single_internal(cli_ctx *ctx, size_t local_header_offset, zip_cb zcb);
 
 /**
  * @brief Add a file a bundle of files to search for in a zip archive.
@@ -153,13 +153,12 @@ cl_error_t unzip_search_add(struct zip_requests *requests, const char *name, siz
  *             or the file you're looking for is not listed in the central directory.
  *
  * @param ctx                   The scan context containing the file map and other scan parameters.
- * @param map                   The file map to search in.
  * @param requests              The `zip_requests` structure containing the files to search for.
  * @return cl_error_t           Returns CL_SUCCESS if nothing was found.
  *                              Returns CL_VIRUS if a match was found.
  *                              Returns a CL_E* error code on failure.
  */
-cl_error_t unzip_search(cli_ctx *ctx, fmap_t *map, struct zip_requests *requests);
+cl_error_t unzip_search(cli_ctx *ctx, struct zip_requests *requests);
 
 /**
  * @brief Search for a single file in a zip archive.


### PR DESCRIPTION
I accidentally introduced a NULL-dereference bug when scanning any OOXML file in https://github.com/Cisco-Talos/clamav/pull/1548

I overlooked the test failure out of haste. 😔

The NULL-dereference happens because the `unzip_search()` feature allowed searching some other file than the one that is currently being scanned, which you would do by setting `ctx` to NULL and setting an `fmap` parameter instead.
In practice, the current layer's `fmap` from the `ctx` was always passed in.

This fix makes it so the `unzip_search()` and related functions only take the `ctx` parameter and do not have and `fmap` or `fsize` field (Note: the `fsize` was never needed, because `fmap->len` take care of that).

CLAM-2837