### PR TITLE
Some fixes for GNU/Hurd

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,8 @@ elseif(APPLE OR CMAKE_SYSTEM_NAME MATCHES "BSD")
     set(C_BSD 1)
 elseif(CMAKE_SYSTEM_NAME MATCHES "AIX")
     set(AIX TRUE)
+elseif(CMAKE_SYSTEM_NAME STREQUAL "GNU")
+    set(C_GNU_HURD 1)
 endif()
 
 # Git optionally used to add commit info into build to differentiate in bug reports.
@@ -196,7 +198,7 @@ else()
   set(USING_CLANG OFF)
 endif()
 
-if(C_LINUX)
+if(C_LINUX OR C_GNU_HURD)
     if(CMAKE_COMPILER_IS_GNUCXX OR USING_CLANG)
         # Set _GNU_SOURCE for O_LARGEFILE, O_CLOEXEC, O_DIRECTORY, O_NOFOLLOW, etc flags on older systems
         # (pre POSIX.1-2008: glibc 2.11 and earlier). #4042

--- a/clamconf/clamconf.c
+++ b/clamconf/clamconf.c
@@ -228,7 +228,7 @@ static void print_platform(struct cli_environment *env)
 
     printf("OS: " TARGET_OS_TYPE ", ARCH: " TARGET_ARCH_TYPE ", CPU: " TARGET_CPU_TYPE "\n");
 
-#ifdef C_LINUX
+#if defined(C_LINUX) || defined(C_GNU_HURD)
     if (!access("/usr/bin/lsb_release", X_OK)) {
         fputs("Full OS version: ", stdout);
         fflush(stdout);

--- a/clamd/clamd.c
+++ b/clamd/clamd.c
@@ -51,7 +51,7 @@
 #include <syslog.h>
 #endif
 
-#ifdef C_LINUX
+#if defined(C_LINUX) || defined(__GLIBC__)
 #include <sys/resource.h>
 #endif
 
@@ -150,7 +150,7 @@ int main(int argc, char **argv)
     struct sigaction sa;
     int dropPrivRet = 0;
 #endif
-#if defined(C_LINUX) || (defined(RLIMIT_DATA) && defined(C_BSD))
+#if defined(C_LINUX) || defined(__GLIBC__) || (defined(RLIMIT_DATA) && defined(C_BSD))
     struct rlimit rlim;
 #endif
     time_t currtime;
@@ -201,7 +201,7 @@ int main(int argc, char **argv)
     }
 
     if (optget(opts, "debug")->enabled) {
-#if defined(C_LINUX)
+#if defined(C_LINUX) || defined(__GLIBC__)
         /* njh@bandsman.co.uk: create a dump if needed */
         rlim.rlim_cur = rlim.rlim_max = RLIM_INFINITY;
         if (setrlimit(RLIMIT_CORE, &rlim) < 0)


### PR DESCRIPTION
This PR provides some fixes needed to help making clamav build again on GNU/Hurd, like it used to in the past:
- improve the build system for detecting GNU/Hurd, and tweak build flags
- run `lsb_release` as diagnostic
- use POSIX rlimits

There are a couple more fixes needed; this is a good part of the changes needed.