### PR TITLE
Sigtool: fix --html-normalise crash

### DIFF
--- a/sigtool/sigtool.c
+++ b/sigtool/sigtool.c
@@ -587,9 +587,9 @@ static int htmlnorm(const struct optstruct *opts)
 
     if (NULL != (ctx = convenience_ctx(fd, optget(opts, "html-normalise")->strarg))) {
         html_normalise_map(ctx, ctx->fmap, ".", NULL, NULL);
-        fmap_free(ctx->fmap);
-    } else
+    } else {
         mprintf(LOGG_ERROR, "fmap failed\n");
+    }
 
     close(fd);
 


### PR DESCRIPTION
Sigtool crashes when you use the `--html-normalise` option, every time.

Simple double free bug only affecting that specific sigtool command. Does not affect clamscan scans (thank goodness).

Fixes: https://github.com/Cisco-Talos/clamav/issues/1483

CLAM-2835