### PR TITLE
When loading a CVD, skip .info file DSIG check if used .sign file

### DIFF
--- a/fuzz/clamav_dbload_fuzzer.cpp
+++ b/fuzz/clamav_dbload_fuzzer.cpp
@@ -80,7 +80,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 
     dboptions =
         CL_DB_PHISHING | CL_DB_PHISHING_URLS |
-        CL_DB_BYTECODE | CL_DB_PUA | CL_DB_ENHANCED;
+        CL_DB_BYTECODE | CL_DB_PUA;
 
 #if defined(CLAMAV_FUZZ_CDB)
     snprintf(tmp_file_name, sizeof(tmp_file_name), "tmp.dbload.%d.cdb", pid);

--- a/libclamav/cvd.c
+++ b/libclamav/cvd.c
@@ -520,6 +520,9 @@ cl_error_t cli_cvdload(
             status = CL_EVERIFY;
             goto done;
         }
+
+        // Set enhanced flag to indicate it was verified using an external .sign digital signature.
+        options |= CL_DB_ENHANCED;
     }
 
     /* For .cvd files, check if there is a .cld of the same name.

--- a/libfreshclam/libfreshclam.c
+++ b/libfreshclam/libfreshclam.c
@@ -485,7 +485,7 @@ fc_error_t fc_test_database(const char *dbFilename, int bBytecodeEnabled)
 
     cl_engine_set_clcb_stats_submit(engine, NULL);
 
-    dboptions = CL_DB_PHISHING | CL_DB_PHISHING_URLS | CL_DB_BYTECODE | CL_DB_PUA | CL_DB_ENHANCED;
+    dboptions = CL_DB_PHISHING | CL_DB_PHISHING_URLS | CL_DB_BYTECODE | CL_DB_PUA;
     if (g_bFipsLimits) {
         dboptions |= CL_DB_FIPS_LIMITS;
     }


### PR DESCRIPTION
If a CVD was verified using a `.sign` file, there's no need to verify the legacy SHA2-256-based RSA DSIG when loading the `.info` file.

In this commit, I've reused the old `CL_DB_ENHANCED` flag to indicate if a CVD was verified using the `.sign` file. This differentiates from using the `CL_DB_SIGNED` flag, which is used for the weaker MD5-based RSA DSIG that would be found within a CVD header.

This gets ClamAV away from requiring the legacy CVD DSIG capability so that in the future we might publish CVD's which *only* have the more modern external `.sign` digital signatures.

CLAM-2851