### PR TITLE
Fix PDF double-free bug

### DIFF
--- a/libclamav/pdf.c
+++ b/libclamav/pdf.c
@@ -1677,15 +1677,12 @@ cl_error_t pdf_extract_obj(struct pdf_struct *pdf, struct pdf_obj *obj, uint32_t
                     goto done;
                 }
 
-                objstm = malloc(sizeof(struct objstm_struct));
-                if (!objstm) {
-                    cli_warnmsg("pdf_extract_obj: out of memory parsing object stream (%u)\n", pdf->nobjstms);
-                    status = CL_EMEM;
-                    goto done;
-                }
-                pdf->objstms[pdf->nobjstms - 1] = objstm;
+                CLI_CALLOC_OR_GOTO_DONE(
+                    objstm, 1, sizeof(struct objstm_struct),
+                    cli_warnmsg("pdf_extract_obj: out of memory parsing object stream (%u)\n", pdf->nobjstms),
+                    status = CL_EMEM);
 
-                memset(objstm, 0, sizeof(*objstm));
+                pdf->objstms[pdf->nobjstms - 1] = objstm;
 
                 objstm->first        = (size_t)objstm_first;
                 objstm->current      = (size_t)objstm_first;

--- a/libclamav/udf.c
+++ b/libclamav/udf.c
@@ -648,7 +648,7 @@ static cl_error_t initPointerList(PointerList *pl)
 
     freePointerList(pl);
     CLI_CALLOC_OR_GOTO_DONE(pl->idxs, capacity, sizeof(uint8_t *),
-                            cli_errmsg("initPointerList: Can't allocate memory\n");
+                            cli_errmsg("initPointerList: Can't allocate memory\n"),
                             ret = CL_EMEM);
 
     pl->capacity = capacity;


### PR DESCRIPTION
It's possible that the `token->content` variable may get freed and set to an uninitialized value from the `decoded` variable. This results in both
 "Conditional jump or move depends on uninitialised value"
and
 "Invalid free() / delete / delete[] / realloc()"

This bug appears to have been introduced during 1.5 development and does not occur in prior versions.

To fix it, I'm initializing the `decoded` variable and adding some callocs elsewhere to initialize a couple other things that looked iffy, and I'm making it so it won't try to `free(token->content)` and use `decoded` if decompression results in an empty buffer and the status code is set to CL_BREAK.

Fixes: https://issues.oss-fuzz.com/issues/429489013

CLAM-2854