### PR TITLE
libclamav: Fix issue scanning with no signatures loaded

### DIFF
--- a/libclamav/scanners.c
+++ b/libclamav/scanners.c
@@ -4608,7 +4608,13 @@ cl_error_t cli_magic_scan(cli_ctx *ctx, cli_file_t type)
         typercg = 0;
     }
 
-    if (ctx->engine->engine_options & ENGINE_OPTIONS_DISABLE_CACHE) {
+    /*
+     * Determine if caching is enabled.
+     * The application may have specifically disabled caching. Also, if the application never loaded any signatures,
+     * then the cache will be NULL and caching will also be disabled.
+     */
+    if ((ctx->engine->engine_options & ENGINE_OPTIONS_DISABLE_CACHE) ||
+        (ctx->engine->cache == NULL)) {
         cache_enabled = false;
     }
 


### PR DESCRIPTION
If the application never calls `cl_load()`, then the clean-cache is never initialized. That is a legitimate mode to run in when perhaps we just want to extract stuff, record metadata, or for fuzzing.

This commit adds a check if the ctx->engine->cache is NULL. If it is, then we treat it as though caching is disabled.

CLAM-2856