### PR TITLE
ZIP: Fix possible leak

### DIFF
--- a/libclamav/unzip.c
+++ b/libclamav/unzip.c
@@ -1154,11 +1154,15 @@ cl_error_t index_the_central_directory(
                     cli_dbgmsg("    current file start: %u\n", curr_record->local_header_offset);
 
                     if (ZIP_MAX_NUM_OVERLAPPING_FILES < num_overlapping_files) {
+                        status = CL_EFORMAT;
+
                         if (SCAN_HEURISTICS) {
-                            status = cli_append_potentially_unwanted(ctx, "Heuristics.Zip.OverlappingFiles");
-                        } else {
-                            status = CL_EFORMAT;
+                            ret = cli_append_potentially_unwanted(ctx, "Heuristics.Zip.OverlappingFiles");
+                            if (CL_SUCCESS != ret) {
+                                status = ret;
+                            }
                         }
+
                         goto done;
                     }
                 }


### PR DESCRIPTION
Fix a possible memory leak in the overlapping files detecting logic. The issue is because cleanup for the zip catalogue allocated by this function only happens if the status is no CL_SUCCESS.

My fix uses a better pattern to ensure we don't override a format error with a "clean" result when adding the heuristic alert.

Fixes: https://issues.oss-fuzz.com/issues/376723678

CLAM-2857