### PR TITLE
libclamav: Fix crash on some platforms with optimization enabled.

### DIFF
--- a/libclamav/pdf.c
+++ b/libclamav/pdf.c
@@ -2022,12 +2022,10 @@ static void handle_pdfname(struct pdf_struct *pdf, struct pdf_obj *obj, const ch
         pdfname = "URI";
     }
 
-    if (!act) {
-        for (j = 0; j < sizeof(pdfname_actions) / sizeof(pdfname_actions[0]); j++) {
-            if (!strcmp(pdfname, pdfname_actions[j].pdfname)) {
-                act = &pdfname_actions[j];
-                break;
-            }
+    for (j = 0; j < sizeof(pdfname_actions) / sizeof(pdfname_actions[0]); j++) {
+        if (!strcmp(pdfname, pdfname_actions[j].pdfname)) {
+            act = &pdfname_actions[j];
+            break;
         }
     }
 


### PR DESCRIPTION
Some compilers were packing the pdfname_action structure with difference sizes in memory with optimization enabled while assigning a pointer to a member of an array of these structures, resulting in the line calling the callback from said structure accessing invalid memory. This fix changes the logic so that rather than assign the pointer to the struct containing the callback, the string that would result in the pointer assignment later on is changed to result in the same assignment. This fixes the issue on all tested platforms.

https://github.com/Cisco-Talos/clamav/issues/1566
CLAM-2859