### PR TITLE
libclamav: Remove confusing heuristic

### DIFF
--- a/libclamav/scanners.c
+++ b/libclamav/scanners.c
@@ -1377,12 +1377,8 @@ static cl_error_t cli_scanxz(cli_ctx *ctx)
         /* xz decompress a chunk */
         rc = cli_XzDecode(&strm);
         if (XZ_RESULT_OK != rc && XZ_STREAM_END != rc) {
-            if (rc == XZ_DIC_HEURISTIC) {
-                ret = cli_append_potentially_unwanted(ctx, "Heuristics.XZ.DicSizeLimit");
-                goto xz_exit;
-            }
-            cli_errmsg("cli_scanxz: decompress error: %d\n", rc);
-            ret = CL_EFORMAT;
+            cli_dbgmsg("cli_scanxz: decompress error: %d\n", rc);
+            ret = CL_EMEM;
             goto xz_exit;
         }
         // cli_dbgmsg("cli_scanxz: xz decompressed %li of %li available bytes\n",

--- a/libclamav/xz_iface.c
+++ b/libclamav/xz_iface.c
@@ -84,9 +84,6 @@ int cli_XzDecode(struct CLI_XZ *XZ)
     if (XZ->status == CODER_STATUS_NOT_FINISHED && XZ->avail_out == 0)
         return XZ_RESULT_OK;
     if (((inbytes == 0) && (outbytes == 0)) || res != SZ_OK) {
-        if (res == SZ_ERROR_MEM) {
-            return XZ_DIC_HEURISTIC;
-        }
         return XZ_RESULT_DATA_ERROR;
     }
     return XZ_RESULT_OK;

--- a/libclamav/xz_iface.h
+++ b/libclamav/xz_iface.h
@@ -43,8 +43,6 @@ int cli_XzDecode(struct CLI_XZ *);
 #define XZ_RESULT_DATA_ERROR 1
 #define XZ_STREAM_END 2
 
-#define XZ_DIC_HEURISTIC 3
-
 #define CLI_XZ_OBUF_SIZE 1024 * 1024
 #define CLI_XZ_IBUF_SIZE CLI_XZ_OBUF_SIZE >> 2 /* compression ratio 25% */
 


### PR DESCRIPTION
This commit removes the XZ.DicSizeLimit heuristic. The heuristic was triggered whenever CLI_MAX_ALLOCATION was reached or an OOM event happened during one of the allocation wrappers. Due to the heuristic not being indicative of the actual event(s) that lead to its triggering, and that we have not had any valid hits for this heuristic, we are opting to remove it.

CLAM-2834