### PR TITLE
Fix static analysis code quality issues; Fix old libjson-c support

### DIFF
--- a/clamscan/manager.c
+++ b/clamscan/manager.c
@@ -399,7 +399,6 @@ static void scanfile(const char *filename, struct cl_engine *engine, const struc
         if (chain.chains) {
             chain.chains[0] = strdup(filename);
             if (!chain.chains[0]) {
-                free(chain.chains);
                 logg(LOGG_INFO, "Unable to allocate memory in scanfile()\n");
                 info.errors++;
                 goto done;

--- a/common/optparser.c
+++ b/common/optparser.c
@@ -1255,7 +1255,6 @@ struct optstruct *optparse(const char *cfgfile, int argc, char **argv, int verbo
 
         if (NULL != arg) {
             /* Find and remove inline comments. */
-            numarg        = -1;
             inlinecomment = strchr(arg, '#');
             if (inlinecomment != NULL) {
                 /* Found a '#', indicating an inline comment. Strip it off along with any leading spaces or tabs. */
@@ -1266,6 +1265,8 @@ struct optstruct *optparse(const char *cfgfile, int argc, char **argv, int verbo
                 }
             }
         }
+
+        numarg = -1;
 
         switch (optentry->argtype) {
             case CLOPT_TYPE_STRING:

--- a/libclamav/cache.c
+++ b/libclamav/cache.c
@@ -701,7 +701,7 @@ void clean_cache_add(cli_ctx *ctx)
     /* Get the file size */
     size = ctx->fmap->len;
 
-    level = (ctx->fmap && ctx->fmap->dont_cache_flag) ? ctx->recursion_level : 0;
+    level = ctx->fmap->dont_cache_flag ? ctx->recursion_level : 0;
 
     key = getkey(sha2_256, ctx->engine->cache->trees);
     c   = &ctx->engine->cache[key];

--- a/libclamav/json_api.c
+++ b/libclamav/json_api.c
@@ -243,8 +243,15 @@ cl_error_t cli_jsonuint64(json_object *obj, const char *key, uint64_t i)
     } else if (objty != json_type_array) {
         return CL_EARG;
     }
-
+#if JSON_C_MINOR_VERSION >= 14
     fpobj = json_object_new_uint64(i);
+#else
+    if (i > INT64_MAX) {
+        cli_dbgmsg("json: uint64 value too large for json int64 object\n");
+        return CL_EARG;
+    }
+    fpobj = json_object_new_int64(i);
+#endif
     if (NULL == fpobj) {
         cli_errmsg("json: no memory for json int object.\n");
         return CL_EMEM;

--- a/libclamav/readdb.c
+++ b/libclamav/readdb.c
@@ -1564,7 +1564,7 @@ done:
         free(buffer_cpy);
     }
 
-    if (CL_SUCCESS != ret) {
+    if (CL_SUCCESS != ret && NULL != matcher) {
         for (i = 0; i < 3; i++) {
             if (matcher->icons[i]) {
                 uint32_t j;

--- a/libclamav/scanners.c
+++ b/libclamav/scanners.c
@@ -5325,6 +5325,12 @@ cl_error_t cli_magic_scan(cli_ctx *ctx, cli_file_t type)
             break;
     }
 
+    // Evaluate the result from the parsers to see if it end the scan of this layer early,
+    // and to decide if we should propagate an error or not.
+    if (result_should_goto_done(ctx, ret, &status)) {
+        goto done;
+    }
+
 done:
 
     /*
@@ -6482,7 +6488,7 @@ cl_error_t cl_scanmap_ex(
 
     if (NULL != filename && map->name == NULL) {
         // Use the provided name for the fmap name if one wasn't already set.
-        cli_basename(filename, strlen(filename), &map->name, true /* posix_support_backslash_pathsep */);
+        (void)cli_basename(filename, strlen(filename), &map->name, true /* posix_support_backslash_pathsep */);
     }
 
     return scan_common(

--- a/sigtool/sigtool.c
+++ b/sigtool/sigtool.c
@@ -278,10 +278,10 @@ done:
     if (NULL != new_map) {
         fmap_free(new_map);
     }
-    if (ctx.recursion_stack[ctx.recursion_level].evidence) {
-        evidence_free(ctx.recursion_stack[ctx.recursion_level].evidence);
-    }
     if (NULL != ctx.recursion_stack) {
+        if (ctx.recursion_stack[ctx.recursion_level].evidence) {
+            evidence_free(ctx.recursion_stack[ctx.recursion_level].evidence);
+        }
         free(ctx.recursion_stack);
     }
     if (NULL != engine) {
@@ -2815,10 +2815,10 @@ done:
     if (NULL != new_map) {
         fmap_free(new_map);
     }
-    if (ctx.recursion_stack[ctx.recursion_level].evidence) {
-        evidence_free(ctx.recursion_stack[ctx.recursion_level].evidence);
-    }
     if (NULL != ctx.recursion_stack) {
+        if (ctx.recursion_stack[ctx.recursion_level].evidence) {
+            evidence_free(ctx.recursion_stack[ctx.recursion_level].evidence);
+        }
         free(ctx.recursion_stack);
     }
     if (NULL != engine) {
@@ -4018,10 +4018,10 @@ done:
     if (NULL != new_map) {
         fmap_free(new_map);
     }
-    if (ctx.recursion_stack[ctx.recursion_level].evidence) {
-        evidence_free(ctx.recursion_stack[ctx.recursion_level].evidence);
-    }
     if (NULL != ctx.recursion_stack) {
+        if (ctx.recursion_stack[ctx.recursion_level].evidence) {
+            evidence_free(ctx.recursion_stack[ctx.recursion_level].evidence);
+        }
         free(ctx.recursion_stack);
     }
     if (NULL != engine) {

--- a/unit_tests/check_regex.c
+++ b/unit_tests/check_regex.c
@@ -466,10 +466,10 @@ static void do_phishing_test(const struct rtest *rtest)
             break;
     }
 
-    if (NULL != ctx.recursion_stack[ctx.recursion_level].evidence) {
-        evidence_free(ctx.recursion_stack[ctx.recursion_level].evidence);
-    }
     if (ctx.recursion_stack) {
+        if (NULL != ctx.recursion_stack[ctx.recursion_level].evidence) {
+            evidence_free(ctx.recursion_stack[ctx.recursion_level].evidence);
+        }
         free(ctx.recursion_stack);
     }
 }
@@ -583,10 +583,10 @@ static void do_phishing_test_allscan(const struct rtest *rtest)
 
     html_tag_arg_free(&hrefs);
 
-    if (NULL != ctx.recursion_stack[ctx.recursion_level].evidence) {
-        evidence_free(ctx.recursion_stack[ctx.recursion_level].evidence);
-    }
     if (ctx.recursion_stack) {
+        if (NULL != ctx.recursion_stack[ctx.recursion_level].evidence) {
+            evidence_free(ctx.recursion_stack[ctx.recursion_level].evidence);
+        }
         free(ctx.recursion_stack);
     }
 }


### PR DESCRIPTION
`clamscan/manager.c`: Fix memory leak in an error condition in `scanfile()`.

`common/optparser.c`: Fix uninitialized use of the `numarg` variable when `arg` is `NULL`.

`libclamav/cache.c`: Don't check if `ctx-fmap` is `NULL` when we've already dereferenced it.

`libclamav/crypto.c`: The `win_exception` variable and associated logic is Windows-specific and so needs preprocessor platform checks. Otherwise it generates unused variable warnings.

`libclamav/crypto.c`: Check for `size_t` overflow of the `byte_read` variable in the `cl_hash_file_fd_ex()` function.

`libclamav/crypto.c`: Fix a memory leak in the `cl_hash_file_fd_ex()` function.

`libclamav/fmap.c`: Correctly the `name` and `path` pointer if `fmap_duplicate()` fails. Also need to clear those variables when duplicating the parent `map` so that on error it does not free the wrong `name` or `path`.

`libclamav/fmap.c`: Refine error handling for `hash_string` cleanup in `cl_fmap_get_hash()`. Coverity's complaint was that `hash_string` could never be non-NULL if `status` is not `CL_SUCCESS`. I.e., the cleanup is dead code. I don't think my cleanup actually "fixes" that though it is definitely a better way to do the error handling.
The `if (NULL != hash_string) {` check is still technically dead code. It safeguards against future changes that may `goto done` between the allocation and transfering ownership from `hash_string` to `hash_out`.

`libclamav/others.c`: Fix possible memory leak in `cli_recursion_stack_push()`.

`libclamav/others.c`: Refactor an if/else + switch statement inside `cli_dispatch_scan_callback()` so that the `CL_SCAN_CALLBACK_ALERT` case is not dead-code. It's also easier to read now.

`libclamav/pdfdecode.c`: For logging, use the `%zu` to format `size_t` instead of casting to `long long` and using `%llu`. Simiularly use the `STDu32` format string macro for `uint32_t`.

`libclamav/pdfdecode.c`: Fix a possible double-free for the `decoded` pointer in `filter_lzwdecode()`.

`libclamav/pdfdecode.c`: Remove the `if (capacity > UINT_MAX) {` overflow check inside `filter_lzwdecode()`, which didn't do anything. The `capacity` variable this point is a fixed value and so I also changed the `avail_out` to be that fixed `INFLATE_CHUNK_SIZE` value rather than using `capacity`. It is more straightforward and replicates how similar logic works later in the file.
I also removed the copy-pasted `(Bytef *)` cast which didn't reaaally do anything, and was a copypaste from a different algorihm. The lzw implementation interface doesn't use `Bytef`.

`libclamav/readdb.c`: Fix a possible NULL-deref on the `matcher` variable in the error handling/cleanup code if the function fails.

`libclamav/scanners.c`: Fix an issue where the return value from some of the parsers may be lost/overridden by the call to
`cli_dispatch_scan_callback()` just after the `done:` label in `cli_magic_scan()`.

`libclamav/scanners.c`: Silence an unused-return value warning when calling `cli_basename()`.

`sigtool/sigtool.c` and `unit_tests/check_regex.c`: Fix possible NULL-derefs of the `ctx.recursion_stack` pointer in the error handling for several functions.

Also, and this isn't a Coverity thing:

`libclamav/json_api.c` and `libclamav/others.c`:
Fix support for libjson-c version 0.13 and older.
I don't think we *should* be using the old version, but some environments such as the current OSS-Fuzz base image are older and still use it. The issue is that `json_object_new_uint64()` was introduced in a later libjson-c version, so we have to fallback to use `json_object_new_int64()` with older libjson-c, provided the int were storing isn't too big.

CLAM-2768