### PR TITLE
Including PUAs no longer works

### DIFF
--- a/libclamav/readdb.c
+++ b/libclamav/readdb.c
@@ -1228,7 +1228,7 @@ static int cli_chkpua(const char *signame, const char *pua_cats, unsigned int op
     // Add null terminator.
     cat[catlen + 1] = '\0';
 
-    cat_pt = strstr(cat, pua_cats);
+    cat_pt = strstr(pua_cats, cat);
     cli_dbgmsg("cli_chkpua:                cat=[%s]\n", cat);
     cli_dbgmsg("cli_chkpua:                sig=[%s]\n", sig);
     if (options & CL_DB_PUA_INCLUDE)


### PR DESCRIPTION
In cli_chkpua when looking for the cat in pua_cats in strstr the parameters are backwards. Before it was looking for pua_cats in cat and failing.

Found by enabling debug and seeing when I asked for specific PUAs they were skipped: ./obj-x86_64-linux-gnu/clamscan/clamscan --debug --detect-pua --include-pua=PUA.Pdf.Exploit  --include-pua=PUA.Pdf.Trojan mypdf.pdf > out.txt 2>&1 out.txt grep PUA.Pdf out.txt |grep Skipping
LibClamAV debug: Skipping PUA signature PUA.Pdf.Trojan.OpenActionObjectwithJavascript-1 - excluded category .Pdf.Trojan. LibClamAV debug: Skipping PUA signature PUA.Pdf.Trojan.OpenActionObjectwithJS-1 - excluded category .Pdf.Trojan. LibClamAV debug: Skipping PUA signature PUA.Pdf.Trojan.CVE_2013_0622-1 - excluded category .Pdf.Trojan. LibClamAV debug: Skipping PUA signature PUA.Pdf.Trojan.EmbeddedFile-1 - excluded category .Pdf.Trojan. LibClamAV debug: cli_loadldb: Skipping PUA signature PUA.Pdf.Trojan.EmbeddedFile-1 LibClamAV debug: Skipping PUA signature PUA.Pdf.Exploit.CVE_2013_0624-4255860-2 - excluded category .Pdf.Exploit. LibClamAV debug: cli_loadldb: Skipping PUA signature PUA.Pdf.Exploit.CVE_2013_0624-4255860-2

After the fix
./obj-x86_64-linux-gnu/clamscan/clamscan --debug --detect-pua --include-pua=PUA.Pdf.Exploit  --include-pua=PUA.Pdf.Trojan mypdf.pdf > out.txt 2>&1 out.txt grep PUA.Pdf out.txt |grep Skipping # doesn't return anything