### PR TITLE
Windows: fix number of arguments in function call

### DIFF
--- a/common/scanmem.c
+++ b/common/scanmem.c
@@ -572,13 +572,12 @@ int scanfile(const char *filename, scanmem_data *scan_data, struct mem_info *inf
             &info->bytes_scanned,
             info->engine,
             info->options,
-            NULL,
-            NULL,
-            NULL,
-            NULL,
-            NULL,
-            NULL,
-            NULL);
+            NULL,  // void *context,
+            NULL,  // const char *hash_hint,
+            NULL,  // char **hash_out,
+            NULL,  // const char *hash_alg,
+            NULL,  // const char *file_type_hint,
+            NULL); // char **file_type_out);
 
         switch (verdict) {
             case CL_VERDICT_NOTHING_FOUND: {

--- a/examples/ex_scan_callbacks.c
+++ b/examples/ex_scan_callbacks.c
@@ -1445,13 +1445,12 @@ int main(int argc, char **argv)
         &size,
         engine,
         &options,
-        script_context, // context,
-        hash_hint,      // hash_hint,
-        &hash_out,      // hash_out,
-        hash_alg,       // hash_alg,
-        file_type_hint, // file_type_hint,
-        &file_type_out  // file_type_out
-    );
+        script_context,
+        hash_hint,
+        &hash_out,
+        hash_alg,
+        file_type_hint,
+        &file_type_out);
 
     /* Calculate size of scanned data */
     printf("\n");

--- a/libclamav/scanners.c
+++ b/libclamav/scanners.c
@@ -6255,12 +6255,12 @@ cl_error_t cl_scandesc(
         &scanned_out,
         engine,
         scanoptions,
-        NULL,
-        NULL,
-        NULL,
-        NULL,
-        NULL,
-        NULL);
+        NULL,  // void *context,
+        NULL,  // const char *hash_hint,
+        NULL,  // char **hash_out,
+        NULL,  // const char *hash_alg,
+        NULL,  // const char *file_type_hint,
+        NULL); // char **file_type_out);
 
     if (NULL != scanned) {
         if ((SIZEOF_LONG == 4) &&
@@ -6303,11 +6303,11 @@ cl_error_t cl_scandesc_callback(
         engine,
         scanoptions,
         context,
-        NULL,
-        NULL,
-        NULL,
-        NULL,
-        NULL);
+        NULL,  // const char *hash_hint,
+        NULL,  // char **hash_out,
+        NULL,  // const char *hash_alg,
+        NULL,  // const char *file_type_hint,
+        NULL); // char **file_type_out);
 
     if (NULL != scanned) {
         if ((SIZEOF_LONG == 4) &&


### PR DESCRIPTION
Fix the number of NULL arguments in `scanmem.c` call to `cl_scandesc_ex()`.