### PR TITLE
Fix typo in Linux cross-compile instructions

### DIFF
--- a/INSTALL-cross-linux-arm64.md
+++ b/INSTALL-cross-linux-arm64.md
@@ -144,7 +144,7 @@ set(CMAKE_SYSROOT           /opt/aarch64-wrs-linux-sysroot)
 #set(ENABLE_JSON_SHARED      OFF)
 
 #set(BZIP2_INCLUDE_DIR       "/usr/include/")
-#set(BZIP2_LIBRARY           "/usr/lib64/libbz2.a")
+#set(BZIP2_LIBRARY_RELEASE   "/usr/lib64/libbz2.a")
 
 #set(OPENSSL_ROOT_DIR        "/usr/")
 #set(OPENSSL_INCLUDE_DIR     "/usr/include/")
@@ -214,7 +214,7 @@ set(JSONC_LIBRARY           "/usr/lib/aarch64-linux-gnu/libjson-c.a")
 set(ENABLE_JSON_SHARED      OFF)
 
 set(BZIP2_INCLUDE_DIR       "/usr/include/")
-set(BZIP2_LIBRARY           "/usr/lib/aarch64-linux-gnu/libbz2.a")
+set(BZIP2_LIBRARY_RELEASE   "/usr/lib/aarch64-linux-gnu/libbz2.a")
 
 set(OPENSSL_ROOT_DIR        "/usr/")
 set(OPENSSL_INCLUDE_DIR     "/usr/include/")


### PR DESCRIPTION
BZIP2_LIBRARY should actually be BZIP2_LIBRARY_RELEASE or else BZIP2_LIBRARIES

Resolves: https://github.com/Cisco-Talos/clamav/issues/1611