### PR TITLE
libclamav: Malformed regexes result in misleading memory error messages.

### DIFF
--- a/libclamav/regex_list.c
+++ b/libclamav/regex_list.c
@@ -816,6 +816,10 @@ static cl_error_t add_pattern_suffix(void *cbdata, const char *suffix, size_t su
 
         if (CL_SUCCESS != ret) {
             cli_hashtab_delete(&matcher->suffix_hash, suffix, suffix_len);
+            /* Check if there is anything to shrink back to */
+            if (n == 0) {
+                goto done;
+            }
             /*shrink the size back to what it was.*/
             CLI_MAX_REALLOC_OR_GOTO_DONE(matcher->suffix_regexes, n * sizeof(*matcher->suffix_regexes));
         } else {


### PR DESCRIPTION
The regex parsing code converted the return code of anything that did not return CL_SUCCESS to CL_EMEM in several places, resulting in a return code indicative of a malformed database returning a memory error instead. This change passes the real return code up the chain and also prevents trying to realloc 0 bytes when we don't have anything to realloc due to a malformed database.

CLAM-2191