### PR TITLE
cmake: libtinfo check fails on systems where tinfo is named tinfow

### DIFF
--- a/cmake/FindCURSES.cmake
+++ b/cmake/FindCURSES.cmake
@@ -73,6 +73,11 @@ if(NCURSES_NOT_FOUND EQUAL -1)
         )
     endif()
 
+    find_library(TINFO_LIBRARY
+        NAMES tinfo tinfow
+        PATHS ${PC_NCurses_LIBRARY_DIRS}
+    )
+
     include(FindPackageHandleStandardArgs)
     find_package_handle_standard_args(CURSES
         FOUND_VAR CURSES_FOUND


### PR DESCRIPTION
This commit looks for tinfo and tinfow when performing the library check

https://github.com/Cisco-Talos/clamav/issues/1623

CLAM-2928