### PR TITLE
Fixes clamdscan "Unable to determine the filepath given the file descriptor"

### DIFF
--- a/common/clamdcom.c
+++ b/common/clamdcom.c
@@ -23,6 +23,9 @@
 #include "clamav-config.h"
 #endif
 
+/* must be first because it may define _XOPEN_SOURCE */
+#include "fdpassing.h"
+
 #include <stdio.h>
 #include <stdint.h>
 #include <string.h>


### PR DESCRIPTION
Fixes #1653

Updated the CheckFDPassing.cmake file to ensure proper support for file descriptor passing on OpenBSD by conditionally defining _XOPEN_SOURCE. The logic now attempts to compile without this definition first, and if that fails, retries with it. Additionally, included fdpassing.h at the beginning of clamdcom.c to ensure correct macro definitions.