### PR TITLE
ADD: Minimal sarif output for clamscan

### DIFF
--- a/common/misc.c
+++ b/common/misc.c
@@ -127,8 +127,8 @@ char *freshdbdir(void)
 void print_version(const char *dbdir)
 {
     unsigned int db_version = 0;
-    time_t db_time = 0;
-    int got = 0;
+    time_t db_time          = 0;
+    int got                 = 0;
 
     got = cl_get_db_build_info(dbdir, &db_version, &db_time);
 
@@ -157,9 +157,9 @@ int cl_get_db_build_info(const char *dbdir, unsigned int *out_version, time_t *o
 {
     char *fdbdir = NULL, *path = NULL;
     const char *pt;
-    struct cl_cvd *daily = NULL;
+    struct cl_cvd *daily    = NULL;
     unsigned int db_version = 0;
-    time_t db_time = 0;
+    time_t db_time          = 0;
 
     if (dbdir)
         pt = dbdir;

--- a/common/misc.h
+++ b/common/misc.h
@@ -109,4 +109,9 @@ unsigned int countlines(const char *filename);
 /* Checks if a virus database file or directory is older than 'days'. */
 cl_error_t check_if_cvd_outdated(const char *path, long long days);
 
+/* Retrieve DB build info: version and build time.
+ * Returns 1 if found, 0 if no DB found, -1 on error.
+ */
+int cl_get_db_build_info(const char *dbdir, unsigned int *out_version, time_t *out_time);
+
 #endif

--- a/common/optparser.c
+++ b/common/optparser.c
@@ -276,6 +276,8 @@ const struct clam_option __clam_options[] = {
 
     {"LogFile", "log", 'l', CLOPT_TYPE_STRING, NULL, -1, NULL, 0, OPT_CLAMD | OPT_MILTER | OPT_CLAMSCAN | OPT_CLAMDSCAN | OPT_CLAMONACC, "Save all reports to a log file.", "/tmp/clamav.log"},
 
+    {"Sarif", "sarif", 0, CLOPT_TYPE_STRING, NULL, -1, NULL, 0, OPT_CLAMD | OPT_MILTER | OPT_CLAMSCAN | OPT_CLAMDSCAN | OPT_CLAMONACC, "Produce a report in SARIF format.", "/tmp/clamav.sarif"},
+
     {"LogFileUnlock", NULL, 0, CLOPT_TYPE_BOOL, MATCH_BOOL, 0, NULL, 0, OPT_CLAMD | OPT_MILTER, "By default the log file is locked for writing and only a single\ndaemon process can write to it. This option disables the lock.", "yes"},
 
     {"LogFileMaxSize", NULL, 0, CLOPT_TYPE_SIZE, MATCH_SIZE, 1048576, NULL, 0, OPT_CLAMD | OPT_FRESHCLAM | OPT_MILTER, "Maximum size of the log file.\nValue of 0 disables the limit.", "5M"},


### PR DESCRIPTION
Closes: #1673 

This is a PR to add a [SARIF](https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/sarif-v2.1.0-errata01-os-complete.html#_Toc141790888) format output for clamscan. This feature will help with users who run clamav in CI pipelines and are taking actions based on the output.

This PR Is a pretty minimal implementation and the SARIF schema allows for A LOT more fidelity on the nature of the scan, it's environment, and findings. However, this is my first PR to the repo and I feel like it's big enough already. The next iteration of this would have to involve some changes to how clamscan finds infected files, right now it just logs them to stdout/stderr. In order to get that into a sarif output it'd involve storing those findings in a data structure along with which signature was associated with a positive finding. After that, when formatting, the SARIF ruleID field is a good 1:1 match for signature id.

Additionally, I broke the print_version() function up so that there is now an option to get the db build info without printing to screen as well as adding the `--sarif=FILE` option and help text.

Note: I put this change in clamscan.c since it had the `s_info` struct. If it belongs better in output.c or misc.c, I can move it, but since `s_info` is declared in `global.h` and none of the files in `/common` include it already, I figured ya'll wouldn't want it there.

example of the sarif output on a successful run:

<img width="755" height="618" alt="image" src="https://github.com/user-attachments/assets/1aae9dd3-fe09-45c3-b1b0-d99541300c9f" />
