### PR TITLE
clamav: Add support for PDFium to clamav cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,7 @@ endif()
 set(ENABLE_DOXYGEN_DEFAULT          OFF)
 set(ENABLE_UNRAR_DEFAULT            ON)
 set(ENABLE_SYSTEMD_DEFAULT          ON)
+set(ENABLE_PDFIUM_DEFAULT           ON)
 
 # See CMakeOptions.cmake for additional options.
 include(CMakeOptions.cmake)
@@ -531,6 +532,16 @@ if(NOT WIN32)
     find_package(Iconv REQUIRED)
     # Set variable required by libclamav to use iconv
     set(HAVE_ICONV 1)
+endif()
+
+if(ENABLE_PDFIUM)
+    find_package(PDFIUM QUIET)
+    if(PDFIUM_FOUND)
+        set(HAVE_PDFIUM 1)
+    else()
+        set(ENABLE_PDFIUM OFF)
+        message(STATUS "PDFium not found; PDFium support disabled")
+    endif()
 endif()
 
 if(ENABLE_JSON_SHARED)

--- a/CMakeOptions.cmake
+++ b/CMakeOptions.cmake
@@ -122,6 +122,10 @@ option(ENABLE_SYSTEMD
     "Install systemd service files if systemd is found."
     ${ENABLE_SYSTEMD_DEFAULT})
 
+option(ENABLE_PDFIUM
+    "Enable PDFium support if available."
+    ${ENABLE_PDFIUM_DEFAULT})
+
 # For reference determining target platform:
 #  Rust Targets:  https://doc.rust-lang.org/nightly/rustc/platform-support.html
 option(RUST_COMPILER_TARGET

--- a/clamav-config.h.cmake.in
+++ b/clamav-config.h.cmake.in
@@ -186,6 +186,9 @@
 /* Define to '1' if you have the curses.h library */
 #cmakedefine HAVE_LIBPDCURSES 1
 
+/* Define to '1' if PDFium is available */
+#cmakedefine HAVE_PDFIUM 1
+
 /* Define to 1 if you have the <limits.h> header file. */
 #cmakedefine HAVE_LIMITS_H 1
 

--- a/libclamav/CMakeLists.txt
+++ b/libclamav/CMakeLists.txt
@@ -450,6 +450,11 @@ if(ENABLE_SHARED_LIB)
             LibXml2::LibXml2
             JSONC::jsonc )
 
+    if(ENABLE_PDFIUM AND PDFIUM_FOUND)
+        target_link_libraries( clamav PUBLIC ${PDFIUM_LIBRARY} )
+        target_compile_definitions( clamav PRIVATE HAVE_PDFIUM=1 )
+    endif()
+
     if(WIN32)
         target_link_libraries( clamav
             PUBLIC
@@ -573,6 +578,10 @@ if(ENABLE_STATIC_LIB)
             PCRE2::pcre2
             LibXml2::LibXml2
             JSONC::jsonc )
+        if(ENABLE_PDFIUM AND PDFIUM_FOUND)
+            target_link_libraries( clamav_static PUBLIC ${PDFIUM_LIBRARY} )
+            target_compile_definitions( clamav_static PRIVATE HAVE_PDFIUM=1 )
+        endif()
         if (ENABLE_UNRAR)
             target_link_libraries( clamav_static PUBLIC ClamAV::libunrar_iface_static ClamAV::libunrar_iface_iface)
         endif()


### PR DESCRIPTION
In order to support utilizing PDFium to render pdf files to image and then hash the image, we need to be able to link against PDFium. This change adds support to link at build time.

CLAM-2817