### PR TITLE
clamav: Add support for PDFium to clamav cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -349,7 +349,7 @@ if (WIN32)
     set(CMAKE_INSTALL_SYSTEM_RUNTIME_DESTINATION .)
     if(ENABLE_WINDOWS_INSTALL_THIRDPARTY_DEPENDENCIES)
         include(InstallRequiredSystemLibraries)
-    endif()	
+    endif()
 
     set(CPACK_GENERATOR                  "ZIP;WIX")
     set(CPACK_PACKAGE_VENDOR             "Cisco Systems, Inc.")
@@ -535,13 +535,7 @@ if(NOT WIN32)
 endif()
 
 if(ENABLE_PDFIUM)
-    find_package(PDFIUM QUIET)
-    if(PDFIUM_FOUND)
-        set(HAVE_PDFIUM 1)
-    else()
-        set(ENABLE_PDFIUM OFF)
-        message(STATUS "PDFium not found; PDFium support disabled")
-    endif()
+    find_package(PDFIUM REQUIRED MODULE)
 endif()
 
 if(ENABLE_JSON_SHARED)
@@ -1270,6 +1264,14 @@ ${b}        JSON support:       ${e}
 ${_}            json-c          ${e}${JSONC_INCLUDE_DIRS}
 ${_}                            ${e}${JSONC_LIBRARIES}
 ${b}        Threading support:  ${e}")
+if(ENABLE_PDFIUM)
+message("\
+${_}            pdfium          ${e}${PDFIUM_INCLUDE_DIRS}
+${_}                            ${e}${PDFIUM_LIBRARIES}")
+else()
+message("\
+${o}            no              ${e}")
+endif()
 if(WIN32)
 message("\
 ${_}            pthread-win32   ${e}${PThreadW32_INCLUDE_DIRS}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,7 @@ endif()
 set(ENABLE_DOXYGEN_DEFAULT          OFF)
 set(ENABLE_UNRAR_DEFAULT            ON)
 set(ENABLE_SYSTEMD_DEFAULT          ON)
+set(ENABLE_PDFIUM_DEFAULT           ON)
 
 # See CMakeOptions.cmake for additional options.
 include(CMakeOptions.cmake)
@@ -531,6 +532,16 @@ if(NOT WIN32)
     find_package(Iconv REQUIRED)
     # Set variable required by libclamav to use iconv
     set(HAVE_ICONV 1)
+endif()
+
+if(ENABLE_PDFIUM)
+    find_package(PDFIUM QUIET)
+    if(PDFIUM_FOUND)
+        set(HAVE_PDFIUM 1)
+    else()
+        set(ENABLE_PDFIUM OFF)
+        message(STATUS "PDFium not found; PDFium support disabled")
+    endif()
 endif()
 
 if(ENABLE_JSON_SHARED)

--- a/CMakeOptions.cmake
+++ b/CMakeOptions.cmake
@@ -122,6 +122,10 @@ option(ENABLE_SYSTEMD
     "Install systemd service files if systemd is found."
     ${ENABLE_SYSTEMD_DEFAULT})
 
+option(ENABLE_PDFIUM
+    "Enable PDFium support if available."
+    ${ENABLE_PDFIUM_DEFAULT})
+
 # For reference determining target platform:
 #  Rust Targets:  https://doc.rust-lang.org/nightly/rustc/platform-support.html
 option(RUST_COMPILER_TARGET

--- a/clamav-config.h.cmake.in
+++ b/clamav-config.h.cmake.in
@@ -186,6 +186,9 @@
 /* Define to '1' if you have the curses.h library */
 #cmakedefine HAVE_LIBPDCURSES 1
 
+/* Define to '1' if PDFium is available */
+#cmakedefine HAVE_PDFIUM 1
+
 /* Define to 1 if you have the <limits.h> header file. */
 #cmakedefine HAVE_LIMITS_H 1
 

--- a/cmake/FindPDFIUM.cmake
+++ b/cmake/FindPDFIUM.cmake
@@ -1,0 +1,65 @@
+# FindPDFIUM.cmake
+#
+# Finds the PDFium library.
+#
+# Variables set:
+#  PDFIUM_FOUND
+#  PDFIUM_LIBRARY
+#  PDFIUM_INCLUDE_DIR
+#
+# Imported targets:
+#  PDFIUM::pdfium
+
+if(PDFIUM_LIBRARY)
+    set(PDFIUM_LIBRARY_FOUND TRUE)
+elseif(DEFINED ENV{PDFIUM_LIBRARY})
+    set(PDFIUM_LIBRARY "$ENV{PDFIUM_LIBRARY}")
+    set(PDFIUM_LIBRARY_FOUND TRUE)
+endif()
+
+if(NOT PDFIUM_LIBRARY_FOUND)
+    set(_PDFIUM_ROOT "${PDFIUM_ROOT}")
+    if(NOT _PDFIUM_ROOT AND DEFINED ENV{PDFIUM_ROOT})
+        set(_PDFIUM_ROOT "$ENV{PDFIUM_ROOT}")
+    endif()
+
+    find_library(PDFIUM_LIBRARY
+        NAMES pdfium
+        HINTS "${_PDFIUM_ROOT}"
+        PATH_SUFFIXES lib lib64)
+
+    find_path(PDFIUM_INCLUDE_DIR
+        NAMES fpdfview.h
+        HINTS "${_PDFIUM_ROOT}"
+        PATH_SUFFIXES include)
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(PDFIUM
+    FOUND_VAR PDFIUM_FOUND
+    REQUIRED_VARS PDFIUM_LIBRARY)
+
+if(PDFIUM_FOUND AND NOT TARGET PDFIUM::pdfium)
+    add_library(PDFIUM::pdfium UNKNOWN IMPORTED)
+    set_target_properties(PDFIUM::pdfium PROPERTIES
+        IMPORTED_LOCATION "${PDFIUM_LIBRARY}")
+    if(PDFIUM_INCLUDE_DIR)
+        set_target_properties(PDFIUM::pdfium PROPERTIES
+            INTERFACE_INCLUDE_DIRECTORIES "${PDFIUM_INCLUDE_DIR}")
+    endif()
+endif()
+
+if(PDFIUM_FOUND)
+    set(PDFIUM_LIBRARIES "${PDFIUM_LIBRARY}")
+    if(PDFIUM_INCLUDE_DIR)
+        set(PDFIUM_INCLUDE_DIRS "${PDFIUM_INCLUDE_DIR}")
+    else()
+        set(PDFIUM_INCLUDE_DIRS "")
+    endif()
+    if(DEFINED ENABLE_PDFIUM AND ENABLE_PDFIUM)
+        message(STATUS "PDFium library: ${PDFIUM_LIBRARY}")
+        if(PDFIUM_INCLUDE_DIR)
+            message(STATUS "PDFium include dir: ${PDFIUM_INCLUDE_DIR}")
+        endif()
+    endif()
+endif()

--- a/libclamav/CMakeLists.txt
+++ b/libclamav/CMakeLists.txt
@@ -450,6 +450,11 @@ if(ENABLE_SHARED_LIB)
             LibXml2::LibXml2
             JSONC::jsonc )
 
+    if(ENABLE_PDFIUM AND PDFIUM_FOUND)
+        target_link_libraries( clamav PUBLIC ${PDFIUM_LIBRARY} )
+        target_compile_definitions( clamav PRIVATE HAVE_PDFIUM=1 )
+    endif()
+
     if(WIN32)
         target_link_libraries( clamav
             PUBLIC
@@ -573,6 +578,10 @@ if(ENABLE_STATIC_LIB)
             PCRE2::pcre2
             LibXml2::LibXml2
             JSONC::jsonc )
+        if(ENABLE_PDFIUM AND PDFIUM_FOUND)
+            target_link_libraries( clamav_static PUBLIC ${PDFIUM_LIBRARY} )
+            target_compile_definitions( clamav_static PRIVATE HAVE_PDFIUM=1 )
+        endif()
         if (ENABLE_UNRAR)
             target_link_libraries( clamav_static PUBLIC ClamAV::libunrar_iface_static ClamAV::libunrar_iface_iface)
         endif()

--- a/libclamav/CMakeLists.txt
+++ b/libclamav/CMakeLists.txt
@@ -450,9 +450,8 @@ if(ENABLE_SHARED_LIB)
             LibXml2::LibXml2
             JSONC::jsonc )
 
-    if(ENABLE_PDFIUM AND PDFIUM_FOUND)
-        target_link_libraries( clamav PUBLIC ${PDFIUM_LIBRARY} )
-        target_compile_definitions( clamav PRIVATE HAVE_PDFIUM=1 )
+    if(ENABLE_PDFIUM)
+        target_link_libraries( clamav PUBLIC PDFIUM::pdfium )
     endif()
 
     if(WIN32)
@@ -578,9 +577,8 @@ if(ENABLE_STATIC_LIB)
             PCRE2::pcre2
             LibXml2::LibXml2
             JSONC::jsonc )
-        if(ENABLE_PDFIUM AND PDFIUM_FOUND)
-            target_link_libraries( clamav_static PUBLIC ${PDFIUM_LIBRARY} )
-            target_compile_definitions( clamav_static PRIVATE HAVE_PDFIUM=1 )
+        if(ENABLE_PDFIUM)
+            target_link_libraries( clamav_static PUBLIC PDFIUM::pdfium )
         endif()
         if (ENABLE_UNRAR)
             target_link_libraries( clamav_static PUBLIC ClamAV::libunrar_iface_static ClamAV::libunrar_iface_iface)


### PR DESCRIPTION
In order to support utilizing PDFium to render pdf files to image and then hash the image, we need to be able to link against PDFium. This change adds support to link at build time.

CLAM-2817