### PR TITLE
Clam 2924 win crash leave temps tempdir

### DIFF
--- a/libclamav/others.c
+++ b/libclamav/others.c
@@ -1771,6 +1771,10 @@ cl_error_t cli_recursion_stack_push(cli_ctx *ctx, cl_fmap_t *map, cli_file_t typ
     char *new_temp_path = NULL;
     char *fmap_basename = NULL;
 
+#ifdef _WIN32
+    FFIError *mkdir_w32_error = NULL;
+#endif
+
     old_recursion_level = ctx->recursion_level;
 
     // Check the regular limits
@@ -1869,11 +1873,21 @@ cl_error_t cli_recursion_stack_push(cli_ctx *ctx, cl_fmap_t *map, cli_file_t typ
             }
         }
 
-        if (mkdir(new_temp_path, 0700)) {
-            cli_errmsg("cli_magic_scan: Can't create tmp sub-directory for scan: %s.\n", new_temp_path);
+#ifdef _WIN32
+
+        if (!mkdir_w32(new_temp_path, &mkdir_w32_error)) {
+            cli_errmsg("cli_magic_scan: Can't create tmp sub-directory (%s) for scan. Error: %s\n", new_temp_path, ffierror_fmt(mkdir_w32_error));
+            ffierror_free(mkdir_w32_error);
             status = CL_EACCES;
             goto done;
         }
+#else
+        if (mkdir(new_temp_path, 0700)) {
+            cli_errmsg("cli_magic_scan: Can't create tmp sub-directory (%s) for scan. Error: %s\n", new_temp_path, strerror(errno));
+            status = CL_EACCES;
+            goto done;
+        }
+#endif
 
         ctx->recursion_stack[ctx->recursion_level].tmpdir = new_temp_path;
         ctx->this_layer_tmpdir                            = new_temp_path;

--- a/libclamav/others.c
+++ b/libclamav/others.c
@@ -1766,9 +1766,12 @@ cl_error_t cli_recursion_stack_push(cli_ctx *ctx, cl_fmap_t *map, cli_file_t typ
 
     cli_scan_layer_t *current_layer = NULL;
     cli_scan_layer_t *new_layer     = NULL;
+    uint32_t old_recursion_level    = 0;
 
     char *new_temp_path = NULL;
     char *fmap_basename = NULL;
+
+    old_recursion_level = ctx->recursion_level;
 
     // Check the regular limits
     if (CL_SUCCESS != (status = cli_checklimits("cli_recursion_stack_push", ctx, map->len, 0, 0))) {
@@ -1995,6 +1998,18 @@ cl_error_t cli_recursion_stack_push(cli_ctx *ctx, cl_fmap_t *map, cli_file_t typ
     }
 
 done:
+
+    if (CL_SUCCESS != status) {
+        // The push failed, so roll back the recursion level change.
+        ctx->recursion_level = old_recursion_level;
+
+        ctx->this_layer_tmpdir = ctx->recursion_stack[ctx->recursion_level].tmpdir;
+        ctx->fmap              = ctx->recursion_stack[ctx->recursion_level].fmap;
+
+        if (SCAN_COLLECT_METADATA) {
+            ctx->this_layer_metadata_json = ctx->recursion_stack[ctx->recursion_level].metadata_json;
+        }
+    }
 
     if (new_temp_path) {
         free(new_temp_path);

--- a/libclamav_rust/cbindgen.toml
+++ b/libclamav_rust/cbindgen.toml
@@ -59,6 +59,7 @@ include = [
   "scanners::scan_onenote",
   "scanners::cli_scanalz",
   "util::glob_rm",
+  "util::mkdir_w32",
 ]
 
 # prefix = "CAPI_"

--- a/libclamav_rust/src/util.rs
+++ b/libclamav_rust/src/util.rs
@@ -146,7 +146,7 @@ pub unsafe fn scan_archive_metadata(
 /// No parameters may be NULL.
 #[export_name = "glob_rm"]
 pub unsafe extern "C" fn glob_rm(glob_str: *const c_char, err: *mut *mut FFIError) -> bool {
-    let glob_str = validate_str_param!(glob_str);
+    let glob_str = validate_str_param!(glob_str, err = err);
 
     for entry in glob(glob_str).expect("Failed to read glob pattern") {
         match entry {
@@ -173,7 +173,7 @@ pub unsafe extern "C" fn glob_rm(glob_str: *const c_char, err: *mut *mut FFIErro
 /// No parameters may be NULL.
 #[export_name = "mkdir_w32"]
 pub unsafe extern "C" fn mkdir_w32(path: *const c_char, err: *mut *mut FFIError) -> bool {
-    let path = validate_str_param!(path);
+    let path = validate_str_param!(path, err = err);
 
     if let Err(e) = std::fs::create_dir_all(&path) {
         warn!("Failed to create directory: {path:?}");

--- a/libclamav_rust/src/util.rs
+++ b/libclamav_rust/src/util.rs
@@ -165,3 +165,20 @@ pub unsafe extern "C" fn glob_rm(glob_str: *const c_char, err: *mut *mut FFIErro
 
     true
 }
+
+/// C interface to create a directory
+///
+/// # Safety
+///
+/// No parameters may be NULL.
+#[export_name = "mkdir_w32"]
+pub unsafe extern "C" fn mkdir_w32(path: *const c_char, err: *mut *mut FFIError) -> bool {
+    let path = validate_str_param!(path);
+
+    if let Err(e) = std::fs::create_dir_all(&path) {
+        warn!("Failed to create directory: {path:?}");
+        return ffi_error!(err = err, Error::IoError(e));
+    }
+
+    true
+}


### PR DESCRIPTION
- Fix error handling when a scan fails to push a new embedded layer to the scan context

  If pushing a new layer to the recursion stack in the scan context fails,
  we need to restore the original recursion level, and undo any changes to
  the convenience `ctx->this_level_...` convenience pointers.

  This fixes a crash observed when scanning certain files on Windows with
  `--leave-temps` enabled and also `--tempdir` set to "C:\temp".

  CLAM-2924

- Windows: Fix issue creating new temp subdirectory

  On Windows, when scanning some files with `--leave-temps` enabled and
  with `--tempdir` set to something like `C:\temp`, it may fail to create
  a new subdirectory to store the temp files because the absolute file
  path is too long for the `mkdir()` function.
  
  The `mkdir()` function may fail on Windows if the filepath is longer than
  the legacy MAX_PATH.
  Fixing this in C or C++ is rather difficult, requiring either a registry
  key + application manifest change, or else converting the path to UTF16
  and UNC format (i.e. `"\\?\C:\temp"`) to pass to `CreateDirectoryW()`.
  
  The solution in this commit is to use the Rust `std` library instead. It
  is able to handle the longer file paths without issue.

  CLAM-2924

This issue was also fixed in the 1.5.2 patch version. 