### PR TITLE
Fix api documentation inconsistencies

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -366,7 +366,7 @@ ClamAV 1.5.0 includes the following improvements and changes:
     cl_error_t cl_fmap_get_path(cl_fmap_t *map, const char **path_out, size_t *offset_out, size_t *len_out);
     cl_error_t cl_fmap_get_fd(const cl_fmap_t *map, int *fd_out, size_t *offset_out, size_t *len_out);
     cl_error_t cl_fmap_get_size(const cl_fmap_t *map, size_t *size_out);
-    cl_error_t cl_fmap_set_hash(const cl_fmap_t *map, const char *hash_alg, char hash);
+    cl_error_t cl_fmap_set_hash(const cl_fmap_t *map, const char *hash_alg, const char *hash);
     cl_error_t cl_fmap_have_hash(const cl_fmap_t *map, const char *hash_alg, bool *have_hash_out);
     cl_error_t cl_fmap_will_need_hash_later(const cl_fmap_t *map, const char *hash_alg);
     cl_error_t cl_fmap_get_hash(const cl_fmap_t *map, const char *hash_alg, char **hash_out);

--- a/libclamav/clamav.h
+++ b/libclamav/clamav.h
@@ -1636,7 +1636,7 @@ extern cl_error_t cl_scandesc_callback(
  * This callback variant allows the caller to provide a context structure that
  * caller provided callback functions can interpret.
  *
- * This extended version of cl_scanmap_callback allows the caller to provide
+ * This extended version of cl_scandesc_callback allows the caller to provide
  * additional hints to the scanning engine, such as a file hash and file type.
  *
  * This variant also upgrades the `scanned` output parameter to a 64-bit integer.
@@ -1737,7 +1737,7 @@ extern cl_error_t cl_scanfile_callback(
  * This callback variant allows the caller to provide a context structure that
  * caller provided callback functions can interpret.
  *
- * This extended version of cl_scanmap_callback allows the caller to provide
+ * This extended version of cl_scanfile_callback allows the caller to provide
  * additional hints to the scanning engine, such as a file hash and file type.
  *
  * This variant also upgrades the `scanned` output parameter to a 64-bit integer.

--- a/libclamav/clamav.h
+++ b/libclamav/clamav.h
@@ -1959,13 +1959,12 @@ extern cl_error_t cl_cvdverify(const char *file);
 /**
  * @brief Verify a CVD file by loading and unloading it.
  *
- * May also verify the CVD digital signature.
+ * For `.cvd` files, this also verifies the CVD digital signature.
  *
  * @param file              Filepath of CVD file.
  * @param certs_directory   Directory containing CA certificates required to verify the CVD digital signature.
  * @param dboptions         Bitmask of flags to modify behavior.
  *                          Set CL_DB_FIPS_LIMITS to require the CVD to be signed with a FIPS-compliant external '.sign' file.
- *                          Set CL_DB_UNSIGNED to disable verification of CVD digital signatures. Allow load testing unsigned CVD files.
  * @return cl_error_t       CL_SUCCESS if success, else a CL_E* error code.
  */
 extern cl_error_t cl_cvdverify_ex(const char *file, const char *certs_directory, uint32_t dboptions);

--- a/libclamav/clamav.h
+++ b/libclamav/clamav.h
@@ -635,7 +635,7 @@ extern cl_error_t cl_fmap_set_path(cl_fmap_t *map, const char *path);
  * @param[out] offset_out (optional) Pointer to a variable to receive the offset of the current layer within the given file.
  * @param[out] len_out    (optional) Pointer to a variable to receive the length of the current layer within the given file.
  * @return cl_error_t     CL_SUCCESS if the path was successfully retrieved.
- *                        CL_EACCES if the map does not have a file descriptor.
+ *                        CL_EACCES if the map does not have a stored path.
  *                        CL_ENULLARG if null arguments were provided.
  */
 extern cl_error_t cl_fmap_get_path(cl_fmap_t *map, const char **path_out, size_t *offset_out, size_t *len_out);

--- a/libclamav/clamav.h
+++ b/libclamav/clamav.h
@@ -591,7 +591,7 @@ extern cl_error_t cl_fmap_set_name(cl_fmap_t *map, const char *name);
  *
  * @param map           The file map to query.
  * @param[out] name_out Pointer to a variable to receive the name of the file map.
- * @return const char*  The name of the file map, or NULL if not set.
+ * @return cl_error_t   CL_SUCCESS if the name was retrieved successfully.
  */
 extern cl_error_t cl_fmap_get_name(cl_fmap_t *map, const char **name_out);
 

--- a/libclamav/clamav.h
+++ b/libclamav/clamav.h
@@ -685,10 +685,10 @@ extern cl_error_t cl_fmap_get_size(const cl_fmap_t *map, size_t *size_out);
  *
  * @param map           The file map to modify.
  * @param hash_alg      The hash algorithm to use (e.g., "md5", "sha1", "sha2-256").
- * @param hash          The hash value to set.
+ * @param hash          Pointer to the hash value to set.
  * @return cl_error_t   CL_SUCCESS if the hash was successfully set.
  */
-extern cl_error_t cl_fmap_set_hash(const cl_fmap_t *map, const char *hash_alg, char hash);
+extern cl_error_t cl_fmap_set_hash(const cl_fmap_t *map, const char *hash_alg, const char *hash);
 
 /**
  * @brief Check if we already calculated a file hash of a specific type.

--- a/libclamav/clamav.h
+++ b/libclamav/clamav.h
@@ -1641,7 +1641,7 @@ extern cl_error_t cl_scandesc_callback(
  *
  * This variant also upgrades the `scanned` output parameter to a 64-bit integer.
  *
- * @param desc               File descriptor of an open file. The caller must provide this or the map.
+ * @param desc               File descriptor of an open file.
  * @param filename           (Optional) Filepath of the open file descriptor or file map.
  * @param[out] verdict_out   A pointer to a cl_verdict_t that will be set to the scan verdict.
  *                           You should check the verdict even if the function returns an error.

--- a/libclamav/clamav.h
+++ b/libclamav/clamav.h
@@ -1797,7 +1797,7 @@ extern cl_error_t cl_scanfile_ex(
  * - `cl_fmap_open_handle()` for a file handle, or
  * - `cl_fmap_open_memory()` for a memory buffer.
  *
- * After the scan, you can also get the file hash with `cl_fmap_get_file_hash()`.
+ * After the scan, you can also get the file hash with `cl_fmap_get_hash()`.
  *
  * @param map           Buffer to be scanned, in form of a cl_fmap_t.
  * @param filename      Name of data origin. Does not need to be an actual
@@ -1831,7 +1831,7 @@ extern cl_error_t cl_scanmap_callback(
  * - `cl_fmap_open_handle()` for a file handle, or
  * - `cl_fmap_open_memory()` for a memory buffer.
  *
- * After the scan, you can also get the file hash with `cl_fmap_get_file_hash()`.
+ * After the scan, you can also get the file hash with `cl_fmap_get_hash()`.
  *
  * This extended version of cl_scanmap_callback allows the caller to provide
  * additional hints to the scanning engine, such as a file hash and file type.

--- a/libclamav/crypto.c
+++ b/libclamav/crypto.c
@@ -709,12 +709,16 @@ extern cl_error_t cl_hash_file_fd_ex(
     }
 
     do {
-        blocksize = MIN(blocksize, length - byte_read);
+        size_t read_size = blocksize;
+
+        if (length != 0) {
+            read_size = MIN(read_size, length - byte_read);
+        }
 
 #ifdef _WIN32
-        nread = _read(fd, block, blocksize);
+        nread = _read(fd, block, read_size);
 #else
-        nread = read(fd, block, blocksize);
+        nread = read(fd, block, read_size);
 #endif
         if (nread < 0) {
             cli_errmsg("cl_hash_data_ex: Failed to read from file descriptor %d: %s\n", fd, cl_strerror(CL_EREAD));

--- a/libclamav/fmap.c
+++ b/libclamav/fmap.c
@@ -1455,12 +1455,12 @@ done:
     return status;
 }
 
-extern cl_error_t cl_fmap_set_hash(const cl_fmap_t *map, const char *hash_alg, char hash)
+extern cl_error_t cl_fmap_set_hash(const cl_fmap_t *map, const char *hash_alg, const char *hash)
 {
     cl_error_t status = CL_ERROR;
     cli_hash_type_t type;
 
-    if (!map || !hash_alg) {
+    if (!map || !hash_alg || !hash) {
         status = CL_ENULLARG;
         goto done;
     }
@@ -1477,7 +1477,7 @@ extern cl_error_t cl_fmap_set_hash(const cl_fmap_t *map, const char *hash_alg, c
         goto done;
     }
 
-    status = fmap_set_hash((fmap_t *)map, (uint8_t *)&hash, type);
+    status = fmap_set_hash((fmap_t *)map, (uint8_t *)hash, type);
     if (status != CL_SUCCESS) {
         cli_errmsg("cl_fmap_set_hash: Failed to set hash for algorithm: %s\n", hash_alg);
         goto done;

--- a/libclamav/scanners.c
+++ b/libclamav/scanners.c
@@ -6488,11 +6488,12 @@ cl_error_t cl_scanfile(
         NULL);
 
     if (NULL != scanned) {
-        if (SIZEOF_LONG == 4 && scanned_bytes > UINT32_MAX) {
+        if ((SIZEOF_LONG == 4) &&
+            (scanned_bytes / CL_COUNT_PRECISION > UINT32_MAX)) {
             cli_warnmsg("cl_scanfile_callback: scanned_bytes exceeds UINT32_MAX, setting to UINT32_MAX\n");
             *scanned = UINT32_MAX;
         } else {
-            *scanned = (unsigned long int)scanned_bytes;
+            *scanned = (unsigned long int)(scanned_bytes / CL_COUNT_PRECISION);
         }
     }
 
@@ -6532,11 +6533,12 @@ cl_error_t cl_scanfile_callback(
         NULL);
 
     if (NULL != scanned) {
-        if (SIZEOF_LONG == 4 && scanned_out > UINT32_MAX) {
+        if ((SIZEOF_LONG == 4) &&
+            (scanned_out / CL_COUNT_PRECISION > UINT32_MAX)) {
             cli_warnmsg("cl_scanfile_callback: scanned_out exceeds UINT32_MAX, setting to UINT32_MAX\n");
             *scanned = UINT32_MAX;
         } else {
-            *scanned = (unsigned long int)scanned_out;
+            *scanned = (unsigned long int)(scanned_out / CL_COUNT_PRECISION);
         }
     }
 


### PR DESCRIPTION
## Summary

Review and fix `libclamav/clamav.h` API/documentation inconsistencies by
comparing the public header against the prototypes and implementations.

This PR includes both real API/behavior fixes and header comment
corrections found during that audit.

## Changes

- Fix `cl_fmap_set_hash()` to accept a hash buffer pointer instead of a
  single `char`.
- Fix `cl_hash_file_fd_ex()` so `length == 0` hashes to EOF as
  documented.
- Fix legacy `cl_scanfile()` and `cl_scanfile_callback()` wrappers to
  return `scanned / CL_COUNT_PRECISION` again.
- Correct `clamav.h` docs for:
  - `cl_cvdverify_ex()` signature verification behavior
  - `cl_fmap_get_name()` return semantics
  - `cl_scandesc_ex()` / `cl_scanfile_ex()` cross-references
  - stale `cl_fmap_get_file_hash()` references
  - `cl_scandesc_ex()` parameter description
  - `cl_fmap_get_path()` `CL_EACCES` description
- Update `NEWS.md` for the `cl_fmap_set_hash()` API fix.
