### PR TITLE
Fix incorrect file name reference in error message within sigtool

### DIFF
--- a/sigtool/sigtool.c
+++ b/sigtool/sigtool.c
@@ -3734,7 +3734,7 @@ static int testsigs(const struct optstruct *opts)
 
     fd = open(opts->filename[0], O_RDONLY | O_BINARY);
     if (fd == -1) {
-        mprintf(LOGG_ERROR, "testsigs: Can't open file %s\n", optget(opts, "test-sigs")->strarg);
+        mprintf(LOGG_ERROR, "testsigs: Can't open file %s\n", opts->filename[0]);
         fclose(sigs);
         return -1;
     }


### PR DESCRIPTION
The error message printed when sigtool --testsigs cannot open the file provides the incorrect file reference creating a confusing situation for the end user.  This PR fixes that reference to match the file that was attempted.