### PR TITLE
Clamonacc: Fix multithreaded scanning issue; Remove the scan mutex safely

### DIFF
--- a/clamonacc/client/client.c
+++ b/clamonacc/client/client.c
@@ -47,6 +47,7 @@
 #include <errno.h>
 #include <dirent.h>
 #include <fcntl.h>
+#include <pthread.h>
 
 #ifdef HAVE_SYS_UIO_H
 #include <sys/uio.h>
@@ -70,6 +71,33 @@
 #include "socket.h"
 
 #include "../clamonacc.h"
+
+static pthread_mutex_t onas_disconnect_lock = PTHREAD_MUTEX_INITIALIZER;
+static bool onas_client_disconnected        = false;
+
+static void onas_client_note_connection_failure(CURLcode curlcode)
+{
+    pthread_mutex_lock(&onas_disconnect_lock);
+
+    if (!onas_client_disconnected) {
+        logg(LOGG_ERROR, "ClamClient: Connection to clamd failed, %s.\n", curl_easy_strerror(curlcode));
+        onas_client_disconnected = true;
+    }
+
+    pthread_mutex_unlock(&onas_disconnect_lock);
+}
+
+static void onas_client_note_connection_success(void)
+{
+    pthread_mutex_lock(&onas_disconnect_lock);
+
+    if (onas_client_disconnected) {
+        logg(LOGG_INFO, "ClamClient: Connection to clamd re-established.\n");
+        onas_client_disconnected = false;
+    }
+
+    pthread_mutex_unlock(&onas_disconnect_lock);
+}
 
 void onas_print_server_version(struct onas_context **ctx)
 {
@@ -535,7 +563,6 @@ int onas_client_scan(const char *tcpaddr, int64_t portnum, int32_t scantype, uin
     CURLcode curlcode = CURLE_OK;
     int errors        = 0;
     int ret;
-    static bool disconnected = false;
 
     *infected = 0;
 
@@ -552,17 +579,11 @@ int onas_client_scan(const char *tcpaddr, int64_t portnum, int32_t scantype, uin
 
     curlcode = curl_easy_perform(curl);
     if (CURLE_OK != curlcode) {
-        if (!disconnected) {
-            logg(LOGG_ERROR, "ClamClient: Connection to clamd failed, %s.\n", curl_easy_strerror(curlcode));
-            disconnected = true;
-        }
+        onas_client_note_connection_failure(curlcode);
         curl_easy_cleanup(curl);
         return CL_ECREAT;
     }
-    if (disconnected) {
-        logg(LOGG_INFO, "ClamClient: Connection to clamd re-established.\n");
-        disconnected = false;
-    }
+    onas_client_note_connection_success();
 
     if ((ret = onas_dsresult(curl, scantype, maxstream, fname, fd, timeout, &ret, err, ret_code)) >= 0) {
         *infected = ret;

--- a/clamonacc/client/protocol.c
+++ b/clamonacc/client/protocol.c
@@ -70,6 +70,27 @@
 
 static const char *scancmd[] = {"CONTSCAN", "MULTISCAN", "INSTREAM", "FILDES", "ALLMATCHSCAN"};
 
+struct onas_reply_state {
+    char last_filename[PATH_MAX + 1];
+};
+
+static int onas_count_virus_hit(struct onas_reply_state *reply_state, int scantype, const char *filename)
+{
+    if (scantype != ALLMATCH) {
+        return 1;
+    }
+
+    if ((NULL == filename) || (0 != strcmp(filename, reply_state->last_filename))) {
+        if (NULL != filename) {
+            strncpy(reply_state->last_filename, filename, PATH_MAX);
+            reply_state->last_filename[PATH_MAX] = '\0';
+        }
+        return 1;
+    }
+
+    return 0;
+}
+
 /* Issues an INSTREAM command to clamd and streams the given file
  * Returns >0 on success, 0 soft fail, -1 hard fail */
 static int onas_send_stream(CURL *curl, const char *filename, int fd, int64_t timeout, uint64_t maxstream)
@@ -237,9 +258,12 @@ int onas_dsresult(CURL *curl, int scantype, uint64_t maxstream, const char *file
     int infected = 0, len = 0, beenthere = 0;
     char *bol, *eol;
     struct onas_rcvln rcv;
+    struct onas_reply_state reply_state;
     STATBUF sb;
     int sockd                                                        = -1;
     int (*recv_func)(struct onas_rcvln *, char **, char **, int64_t) = NULL;
+
+    memset(&reply_state, 0, sizeof(reply_state));
 
     sockd = onas_get_sockd();
 
@@ -351,19 +375,10 @@ int onas_dsresult(CURL *curl, int scantype, uint64_t maxstream, const char *file
                 goto done;
 
             } else if (!memcmp(eol - 7, " FOUND", 6)) {
-                static char last_filename[PATH_MAX + 1] = {'\0'};
-                *(eol - 7)                              = 0;
-                *printok                                = 0;
+                *(eol - 7) = 0;
+                *printok   = 0;
 
-                if (scantype != ALLMATCH) {
-                    infected++;
-                } else {
-                    if (filename != NULL && strcmp(filename, last_filename)) {
-                        infected++;
-                        strncpy(last_filename, filename, PATH_MAX);
-                        last_filename[PATH_MAX] = '\0';
-                    }
-                }
+                infected += onas_count_virus_hit(&reply_state, scantype, filename);
 
                 if (filename) {
                     if (scantype >= STREAM) {

--- a/clamonacc/scan/thread.c
+++ b/clamonacc/scan/thread.c
@@ -46,8 +46,6 @@
 #include "../client/client.h"
 #include "thread.h"
 
-static pthread_mutex_t onas_scan_lock = PTHREAD_MUTEX_INITIALIZER;
-
 static int onas_scan(struct onas_scan_event *event_data, const char *fname, STATBUF sb, int *infected, int *err, cl_error_t *ret_code);
 static cl_error_t onas_scan_safe(struct onas_scan_event *event_data, const char *fname, STATBUF sb, int *infected, int *err, cl_error_t *ret_code);
 static cl_error_t onas_scan_thread_scanfile(struct onas_scan_event *event_data, const char *fname, STATBUF sb, int *infected, int *err, cl_error_t *ret_code);
@@ -103,11 +101,7 @@ static int onas_scan(struct onas_scan_event *event_data, const char *fname, STAT
 }
 
 /**
- * @brief Thread-safe scan wrapper to ensure there's no process contention over use of the socket.
- *
- * This is noticeably slower, and I had no issues running smaller scale tests with it off, but better than sorry until more testing can be done.
- *
- * TODO: make this configurable?
+ * @brief Scan wrapper that prepares transport-specific state before talking to clamd.
  */
 static cl_error_t onas_scan_safe(struct onas_scan_event *event_data, const char *fname, STATBUF sb, int *infected, int *err, cl_error_t *ret_code)
 {
@@ -125,12 +119,8 @@ static cl_error_t onas_scan_safe(struct onas_scan_event *event_data, const char 
     }
 #endif
 
-    pthread_mutex_lock(&onas_scan_lock);
-
     ret = onas_client_scan(event_data->tcpaddr, event_data->portnum, event_data->scantype, event_data->maxstream,
                            fname, fd, event_data->timeout, sb, infected, err, ret_code);
-
-    pthread_mutex_unlock(&onas_scan_lock);
 
     return ret;
 }

--- a/common/actions.c
+++ b/common/actions.c
@@ -58,6 +58,12 @@
 void (*action)(const char *) = NULL;
 unsigned int notmoved = 0, notremoved = 0;
 
+#ifdef _WIN32
+#define ACTION_COUNTER_INC(counter) InterlockedIncrement((volatile LONG *)&(counter))
+#else
+#define ACTION_COUNTER_INC(counter) __sync_add_and_fetch(&(counter), 1)
+#endif
+
 static char *actarget;
 static int targlen;
 
@@ -632,7 +638,7 @@ static void action_move(const char *filename)
     if (fd < 0 || (((copied = 1)) && filecopy(filename, nuname))) {
 #endif
         logg(LOGG_ERROR, "Can't move file %s to %s\n", filename, nuname);
-        notmoved++;
+        ACTION_COUNTER_INC(notmoved);
         if (nuname) traverse_unlink(nuname);
     } else {
         if (copied && (0 != traverse_unlink(filename)))
@@ -655,7 +661,7 @@ static void action_copy(const char *filename)
 
     if (fd < 0 || filecopy(filename, nuname)) {
         logg(LOGG_ERROR, "Can't copy file '%s'\n", filename);
-        notmoved++;
+        ACTION_COUNTER_INC(notmoved);
         if (nuname) traverse_unlink(nuname);
     } else
         logg(LOGG_INFO, "%s: copied to '%s'\n", filename, nuname);
@@ -674,7 +680,7 @@ static void action_remove(const char *filename)
 
     if (0 != traverse_unlink(filename)) {
         logg(LOGG_ERROR, "Can't remove file '%s'\n", filename);
-        notremoved++;
+        ACTION_COUNTER_INC(notremoved);
     } else {
         logg(LOGG_INFO, "%s: Removed.\n", filename);
     }

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -93,6 +93,30 @@ if(ENABLE_APP)
     endif()
     target_include_directories(check_clamd PRIVATE ${PROJECT_SOURCE_DIR} ${PROJECT_SOURCE_DIR}/libclamav ${CMAKE_BINARY_DIR})
     target_compile_definitions(check_clamd PUBLIC OBJDIR="${OBJDIR}" SRCDIR="${SRCDIR}")
+
+    if(C_LINUX AND ENABLE_CLAMONACC)
+        add_executable(check_clamonacc_client)
+        target_sources(check_clamonacc_client
+            PRIVATE
+                check_clamonacc_client.c
+                ${CMAKE_SOURCE_DIR}/clamonacc/client/client.c
+                ${CMAKE_SOURCE_DIR}/clamonacc/client/communication.c
+                ${CMAKE_SOURCE_DIR}/clamonacc/client/protocol.c
+                ${CMAKE_SOURCE_DIR}/clamonacc/client/socket.c)
+        target_link_libraries(check_clamonacc_client
+            PRIVATE
+                ClamAV::libclamav
+                ClamAV::common
+                libcheck::check
+                CURL::libcurl)
+        target_include_directories(check_clamonacc_client
+            PRIVATE
+                ${PROJECT_SOURCE_DIR}
+                ${PROJECT_SOURCE_DIR}/clamonacc
+                ${PROJECT_SOURCE_DIR}/libclamav
+                ${CMAKE_BINARY_DIR})
+        target_compile_definitions(check_clamonacc_client PUBLIC OBJDIR="${OBJDIR}" SRCDIR="${SRCDIR}")
+    endif()
 endif()
 
 #
@@ -400,6 +424,11 @@ if(ENABLE_EXAMPLES)
             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
         set_property(TEST examples_valgrind PROPERTY ENVIRONMENT ${ENVIRONMENT} VALGRIND=${Valgrind_EXECUTABLE})
     endif()
+endif()
+
+if(C_LINUX AND ENABLE_APP AND ENABLE_CLAMONACC)
+    add_test(NAME clamonacc_client COMMAND $<TARGET_FILE:check_clamonacc_client>)
+    set_property(TEST clamonacc_client PROPERTY ENVIRONMENT ${ENVIRONMENT})
 endif()
 
 if(WIN32)

--- a/unit_tests/check_clamonacc_client.c
+++ b/unit_tests/check_clamonacc_client.c
@@ -1,0 +1,925 @@
+/*
+ *  Copyright (C) 2026 Cisco Systems, Inc. and/or its affiliates. All rights reserved.
+ */
+
+#if HAVE_CONFIG_H
+#include "clamav-config.h"
+#endif
+
+#include <check.h>
+#include <curl/curl.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <netinet/in.h>
+#include <pthread.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#include "clamav.h"
+#include "others.h"
+#include "output.h"
+
+#include "../clamonacc/client/client.h"
+#include "../clamonacc/client/socket.h"
+#include "../clamonacc/clamonacc.h"
+#include "../common/clamdcom.h"
+#include "../common/optparser.h"
+
+#define TEST_HOST_URL "http://127.0.0.1"
+#define TEST_TIMEOUT_MS 5000
+#define TEST_MAXSTREAM (1024 * 1024)
+#define TEST_THREAD_COUNT 8
+
+enum fake_reply_mode {
+    FAKE_REPLY_STREAM_FOUND = 0,
+    FAKE_REPLY_ALLMATCH_DOUBLE_FOUND
+};
+
+struct fake_server {
+    int listen_fd;
+    uint16_t port;
+    int expected_connections;
+    int accepted_connections;
+    int ready;
+    int reply_mode;
+    int first_reply_count;
+    int release_second_reply;
+    int failed;
+    char failure_msg[256];
+    pthread_mutex_t lock;
+    pthread_cond_t ready_cond;
+    pthread_cond_t first_reply_cond;
+    pthread_cond_t second_reply_cond;
+    pthread_t accept_thread;
+    pthread_t client_threads[TEST_THREAD_COUNT];
+};
+
+struct fake_connect_server {
+    int listen_fd;
+    uint16_t port;
+    int expected_connections;
+    int accepted_connections;
+    int ready;
+    int failed;
+    char failure_msg[256];
+    int accepted_fds[TEST_THREAD_COUNT];
+    pthread_mutex_t lock;
+    pthread_cond_t ready_cond;
+    pthread_t accept_thread;
+};
+
+struct fake_fdpass_server {
+    int listen_fd;
+    int expected_connections;
+    int accepted_connections;
+    int ready;
+    int failed;
+    char socket_dir[PATH_MAX];
+    char socket_path[PATH_MAX];
+    char failure_msg[256];
+    pthread_mutex_t lock;
+    pthread_cond_t ready_cond;
+    pthread_t accept_thread;
+    pthread_t client_threads[TEST_THREAD_COUNT];
+};
+
+struct fake_client_request {
+    struct fake_server *server;
+    int conn_fd;
+    char filename[PATH_MAX];
+};
+
+struct fake_fdpass_request {
+    struct fake_fdpass_server *server;
+    int conn_fd;
+};
+
+struct scan_thread_args {
+    const char *tcpaddr;
+    uint16_t port;
+    int scantype;
+    int expect_infected;
+    char filename[PATH_MAX];
+    char temp_file[PATH_MAX];
+    int result;
+    int infected;
+    int err;
+    cl_error_t ret_code;
+};
+
+static int recv_all(int fd, void *buf, size_t len)
+{
+    char *cursor = buf;
+
+    while (len > 0) {
+        ssize_t bread = recv(fd, cursor, len, 0);
+        if (bread <= 0) {
+            return -1;
+        }
+
+        cursor += bread;
+        len -= bread;
+    }
+
+    return 0;
+}
+
+static void fake_server_set_failure(struct fake_server *server, const char *message)
+{
+    pthread_mutex_lock(&server->lock);
+    if (!server->failed) {
+        server->failed = 1;
+        strncpy(server->failure_msg, message, sizeof(server->failure_msg) - 1);
+        server->failure_msg[sizeof(server->failure_msg) - 1] = '\0';
+    }
+    pthread_mutex_unlock(&server->lock);
+}
+
+static void fake_connect_server_set_failure(struct fake_connect_server *server, const char *message)
+{
+    pthread_mutex_lock(&server->lock);
+    if (!server->failed) {
+        server->failed = 1;
+        strncpy(server->failure_msg, message, sizeof(server->failure_msg) - 1);
+        server->failure_msg[sizeof(server->failure_msg) - 1] = '\0';
+    }
+    pthread_mutex_unlock(&server->lock);
+}
+
+static void fake_fdpass_server_set_failure(struct fake_fdpass_server *server, const char *message)
+{
+    pthread_mutex_lock(&server->lock);
+    if (!server->failed) {
+        server->failed = 1;
+        strncpy(server->failure_msg, message, sizeof(server->failure_msg) - 1);
+        server->failure_msg[sizeof(server->failure_msg) - 1] = '\0';
+    }
+    pthread_mutex_unlock(&server->lock);
+}
+
+static int recv_command(int fd, char *buf, size_t buf_len)
+{
+    size_t used = 0;
+
+    while (used + 1 < buf_len) {
+        ssize_t bread = recv(fd, buf + used, 1, 0);
+        if (bread <= 0) {
+            return -1;
+        }
+
+        if (buf[used] == '\0') {
+            return 0;
+        }
+
+        used++;
+    }
+
+    return -1;
+}
+
+static int send_reply_line(int fd, const char *line)
+{
+    size_t len = strlen(line) + 1;
+
+    if (send(fd, line, len, 0) != (ssize_t)len) {
+        return -1;
+    }
+
+    return 0;
+}
+
+static int recv_fdpass_descriptor(int fd, int *received_fd)
+{
+    char dummy = '\0';
+    struct iovec iov;
+    struct msghdr msg;
+    struct cmsghdr *cmsg;
+    unsigned char control[CMSG_SPACE(sizeof(int))];
+    ssize_t bread;
+
+    memset(&msg, 0, sizeof(msg));
+    memset(control, 0, sizeof(control));
+
+    iov.iov_base       = &dummy;
+    iov.iov_len        = sizeof(dummy);
+    msg.msg_iov        = &iov;
+    msg.msg_iovlen     = 1;
+    msg.msg_control    = control;
+    msg.msg_controllen = sizeof(control);
+
+    bread = recvmsg(fd, &msg, 0);
+    if (bread <= 0) {
+        return -1;
+    }
+
+    cmsg = CMSG_FIRSTHDR(&msg);
+    if ((NULL == cmsg) ||
+        (cmsg->cmsg_level != SOL_SOCKET) ||
+        (cmsg->cmsg_type != SCM_RIGHTS) ||
+        (cmsg->cmsg_len != CMSG_LEN(sizeof(int)))) {
+        return -1;
+    }
+
+    memcpy(received_fd, CMSG_DATA(cmsg), sizeof(*received_fd));
+    return 0;
+}
+
+static int read_fd_payload(int fd, char *buf, size_t buf_len)
+{
+    ssize_t bytes_read;
+
+    if (lseek(fd, 0, SEEK_SET) == (off_t)-1) {
+        return -1;
+    }
+
+    bytes_read = read(fd, buf, buf_len - 1);
+    if (bytes_read < 0) {
+        return -1;
+    }
+
+    buf[bytes_read] = '\0';
+    return 0;
+}
+
+static void *fake_client_thread(void *arg)
+{
+    struct fake_client_request *request = arg;
+    struct fake_server *server          = request->server;
+    char command[PATH_MAX + 64];
+    char reply[PATH_MAX + 64];
+    const char *filename;
+    uint32_t payload_len;
+    uint32_t payload_end;
+    int conn_fd;
+
+    conn_fd = request->conn_fd;
+
+    if (recv_command(conn_fd, command, sizeof(command)) != 0) {
+        fake_server_set_failure(server, "failed to read command");
+        close(conn_fd);
+        free(request);
+        return NULL;
+    }
+
+    if (server->reply_mode == FAKE_REPLY_STREAM_FOUND) {
+        if (strcmp(command, "zINSTREAM") != 0) {
+            fake_server_set_failure(server, "unexpected stream command");
+            close(conn_fd);
+            free(request);
+            return NULL;
+        }
+
+        if (recv_all(conn_fd, &payload_len, sizeof(payload_len)) != 0) {
+            fake_server_set_failure(server, "failed to read stream length");
+            close(conn_fd);
+            free(request);
+            return NULL;
+        }
+        payload_len = ntohl(payload_len);
+
+        if (payload_len > 0) {
+            char payload[32];
+            size_t chunk = payload_len;
+
+            if (chunk > sizeof(payload)) {
+                chunk = sizeof(payload);
+            }
+
+            if (recv_all(conn_fd, payload, chunk) != 0) {
+                fake_server_set_failure(server, "failed to read stream payload");
+                close(conn_fd);
+                free(request);
+                return NULL;
+            }
+            if (payload_len > chunk) {
+                char discard[256];
+                size_t remaining = payload_len - chunk;
+
+                while (remaining > 0) {
+                    size_t piece = remaining;
+                    if (piece > sizeof(discard)) {
+                        piece = sizeof(discard);
+                    }
+                    if (recv_all(conn_fd, discard, piece) != 0) {
+                        fake_server_set_failure(server, "failed to drain stream payload");
+                        close(conn_fd);
+                        free(request);
+                        return NULL;
+                    }
+                    remaining -= piece;
+                }
+            }
+        }
+
+        if ((recv_all(conn_fd, &payload_end, sizeof(payload_end)) != 0) || (ntohl(payload_end) != 0)) {
+            fake_server_set_failure(server, "invalid stream terminator");
+            close(conn_fd);
+            free(request);
+            return NULL;
+        }
+
+        snprintf(reply, sizeof(reply), "%s: Fake.Test FOUND", request->filename);
+        if (send_reply_line(conn_fd, reply) != 0) {
+            fake_server_set_failure(server, "failed to send stream reply");
+        }
+    } else {
+        if (0 != strncmp(command, "zALLMATCHSCAN ", strlen("zALLMATCHSCAN "))) {
+            fake_server_set_failure(server, "unexpected allmatch command");
+            close(conn_fd);
+            free(request);
+            return NULL;
+        }
+
+        filename = command + strlen("zALLMATCHSCAN ");
+
+        snprintf(reply, sizeof(reply), "%s: Fake.First FOUND", filename);
+        if (send_reply_line(conn_fd, reply) != 0) {
+            fake_server_set_failure(server, "failed to send first allmatch reply");
+            close(conn_fd);
+            free(request);
+            return NULL;
+        }
+
+        pthread_mutex_lock(&server->lock);
+        server->first_reply_count++;
+        if (server->first_reply_count == server->expected_connections) {
+            pthread_cond_broadcast(&server->first_reply_cond);
+        }
+        while (!server->release_second_reply) {
+            pthread_cond_wait(&server->second_reply_cond, &server->lock);
+        }
+        pthread_mutex_unlock(&server->lock);
+
+        snprintf(reply, sizeof(reply), "%s: Fake.Second FOUND", filename);
+        if (send_reply_line(conn_fd, reply) != 0) {
+            fake_server_set_failure(server, "failed to send second allmatch reply");
+        }
+    }
+
+    close(conn_fd);
+    free(request);
+    return NULL;
+}
+
+static void *fake_fdpass_client_thread(void *arg)
+{
+    struct fake_fdpass_request *request = arg;
+    struct fake_fdpass_server *server   = request->server;
+    char command[64];
+    char payload[128];
+    int received_fd = -1;
+
+    if (recv_command(request->conn_fd, command, sizeof(command)) != 0) {
+        fake_fdpass_server_set_failure(server, "failed to read fdpass command");
+        close(request->conn_fd);
+        free(request);
+        return NULL;
+    }
+
+    if (strcmp(command, "zFILDES") != 0) {
+        fake_fdpass_server_set_failure(server, "unexpected fdpass command");
+        close(request->conn_fd);
+        free(request);
+        return NULL;
+    }
+
+    if (recv_fdpass_descriptor(request->conn_fd, &received_fd) != 0) {
+        fake_fdpass_server_set_failure(server, "failed to receive passed fd");
+        close(request->conn_fd);
+        free(request);
+        return NULL;
+    }
+
+    if (read_fd_payload(received_fd, payload, sizeof(payload)) != 0) {
+        fake_fdpass_server_set_failure(server, "failed to read passed fd payload");
+        close(received_fd);
+        close(request->conn_fd);
+        free(request);
+        return NULL;
+    }
+
+    if (strncmp(payload, "fdpass payload ", strlen("fdpass payload ")) != 0) {
+        fake_fdpass_server_set_failure(server, "unexpected fdpass payload");
+        close(received_fd);
+        close(request->conn_fd);
+        free(request);
+        return NULL;
+    }
+
+    if (send_reply_line(request->conn_fd, "fdpass: Fake.FD FOUND") != 0) {
+        fake_fdpass_server_set_failure(server, "failed to send fdpass reply");
+    }
+
+    close(received_fd);
+    close(request->conn_fd);
+    free(request);
+    return NULL;
+}
+
+static void *fake_connect_accept_thread(void *arg)
+{
+    struct fake_connect_server *server = arg;
+
+    pthread_mutex_lock(&server->lock);
+    server->ready = 1;
+    pthread_cond_broadcast(&server->ready_cond);
+    pthread_mutex_unlock(&server->lock);
+
+    while (server->accepted_connections < server->expected_connections) {
+        int conn_fd;
+
+        conn_fd = accept(server->listen_fd, NULL, NULL);
+        if (conn_fd == -1) {
+            fake_connect_server_set_failure(server, "connect-only accept failed");
+            break;
+        }
+
+        server->accepted_fds[server->accepted_connections] = conn_fd;
+        server->accepted_connections++;
+    }
+
+    return NULL;
+}
+
+static void *fake_server_accept_thread(void *arg)
+{
+    struct fake_server *server = arg;
+
+    pthread_mutex_lock(&server->lock);
+    server->ready = 1;
+    pthread_cond_broadcast(&server->ready_cond);
+    pthread_mutex_unlock(&server->lock);
+
+    while (server->accepted_connections < server->expected_connections) {
+        struct fake_client_request *request;
+        int conn_fd;
+
+        request = calloc(1, sizeof(*request));
+        if (NULL == request) {
+            fake_server_set_failure(server, "failed to allocate client request");
+            break;
+        }
+        request->server = server;
+        snprintf(request->filename, sizeof(request->filename), "thread-%d", server->accepted_connections);
+
+        conn_fd = accept(server->listen_fd, NULL, NULL);
+        if (conn_fd == -1) {
+            fake_server_set_failure(server, "accept failed");
+            free(request);
+            break;
+        }
+        request->conn_fd = conn_fd;
+
+        if (pthread_create(&server->client_threads[server->accepted_connections], NULL, fake_client_thread, request) != 0) {
+            fake_server_set_failure(server, "failed to create client thread");
+            close(conn_fd);
+            free(request);
+            break;
+        }
+
+        server->accepted_connections++;
+    }
+
+    return NULL;
+}
+
+static void *fake_fdpass_accept_thread(void *arg)
+{
+    struct fake_fdpass_server *server = arg;
+
+    pthread_mutex_lock(&server->lock);
+    server->ready = 1;
+    pthread_cond_broadcast(&server->ready_cond);
+    pthread_mutex_unlock(&server->lock);
+
+    while (server->accepted_connections < server->expected_connections) {
+        struct fake_fdpass_request *request;
+        int conn_fd;
+
+        request = calloc(1, sizeof(*request));
+        if (NULL == request) {
+            fake_fdpass_server_set_failure(server, "failed to allocate fdpass request");
+            break;
+        }
+        request->server = server;
+
+        conn_fd = accept(server->listen_fd, NULL, NULL);
+        if (conn_fd == -1) {
+            fake_fdpass_server_set_failure(server, "fdpass accept failed");
+            free(request);
+            break;
+        }
+        request->conn_fd = conn_fd;
+
+        if (pthread_create(&server->client_threads[server->accepted_connections], NULL, fake_fdpass_client_thread, request) != 0) {
+            fake_fdpass_server_set_failure(server, "failed to create fdpass client thread");
+            close(conn_fd);
+            free(request);
+            break;
+        }
+
+        server->accepted_connections++;
+    }
+
+    return NULL;
+}
+
+static void fake_server_start(struct fake_server *server, int expected_connections, int reply_mode)
+{
+    struct sockaddr_in addr;
+    socklen_t addr_len;
+    int enable = 1;
+
+    memset(server, 0, sizeof(*server));
+    server->listen_fd            = -1;
+    server->expected_connections = expected_connections;
+    server->reply_mode           = reply_mode;
+
+    ck_assert_int_eq(pthread_mutex_init(&server->lock, NULL), 0);
+    ck_assert_int_eq(pthread_cond_init(&server->ready_cond, NULL), 0);
+    ck_assert_int_eq(pthread_cond_init(&server->first_reply_cond, NULL), 0);
+    ck_assert_int_eq(pthread_cond_init(&server->second_reply_cond, NULL), 0);
+
+    server->listen_fd = socket(AF_INET, SOCK_STREAM, 0);
+    ck_assert_int_ne(server->listen_fd, -1);
+    ck_assert_int_eq(setsockopt(server->listen_fd, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(enable)), 0);
+
+    memset(&addr, 0, sizeof(addr));
+    addr.sin_family      = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    addr.sin_port        = 0;
+
+    ck_assert_int_eq(bind(server->listen_fd, (struct sockaddr *)&addr, sizeof(addr)), 0);
+    ck_assert_int_eq(listen(server->listen_fd, expected_connections), 0);
+
+    addr_len = sizeof(addr);
+    ck_assert_int_eq(getsockname(server->listen_fd, (struct sockaddr *)&addr, &addr_len), 0);
+    server->port = ntohs(addr.sin_port);
+
+    ck_assert_int_eq(pthread_create(&server->accept_thread, NULL, fake_server_accept_thread, server), 0);
+
+    pthread_mutex_lock(&server->lock);
+    while (!server->ready) {
+        pthread_cond_wait(&server->ready_cond, &server->lock);
+    }
+    pthread_mutex_unlock(&server->lock);
+}
+
+static void fake_server_release_second_reply(struct fake_server *server)
+{
+    pthread_mutex_lock(&server->lock);
+    while (server->first_reply_count < server->expected_connections) {
+        pthread_cond_wait(&server->first_reply_cond, &server->lock);
+    }
+    server->release_second_reply = 1;
+    pthread_cond_broadcast(&server->second_reply_cond);
+    pthread_mutex_unlock(&server->lock);
+}
+
+static void fake_server_stop(struct fake_server *server)
+{
+    if (server->listen_fd != -1) {
+        close(server->listen_fd);
+    }
+
+    pthread_join(server->accept_thread, NULL);
+    while (server->accepted_connections > 0) {
+        server->accepted_connections--;
+        pthread_join(server->client_threads[server->accepted_connections], NULL);
+    }
+    pthread_cond_destroy(&server->ready_cond);
+    pthread_cond_destroy(&server->first_reply_cond);
+    pthread_cond_destroy(&server->second_reply_cond);
+    pthread_mutex_destroy(&server->lock);
+}
+
+static void fake_fdpass_server_start(struct fake_fdpass_server *server, int expected_connections)
+{
+    struct sockaddr_un addr;
+    char *socket_dir;
+
+    memset(server, 0, sizeof(*server));
+    server->listen_fd            = -1;
+    server->expected_connections = expected_connections;
+
+    ck_assert_ptr_nonnull(strcpy(server->socket_dir, "/tmp/check-clamonacc-client.XXXXXX"));
+    socket_dir = mkdtemp(server->socket_dir);
+    ck_assert_ptr_nonnull(socket_dir);
+
+    ck_assert_int_eq(pthread_mutex_init(&server->lock, NULL), 0);
+    ck_assert_int_eq(pthread_cond_init(&server->ready_cond, NULL), 0);
+
+    server->listen_fd = socket(AF_UNIX, SOCK_STREAM, 0);
+    ck_assert_int_ne(server->listen_fd, -1);
+
+    memset(&addr, 0, sizeof(addr));
+    addr.sun_family = AF_UNIX;
+    ck_assert_uint_lt(strlen(server->socket_dir) + strlen("/clamd.sock"), sizeof(server->socket_path));
+    strcpy(server->socket_path, server->socket_dir);
+    strcat(server->socket_path, "/clamd.sock");
+    ck_assert_uint_lt(strlen(server->socket_path), sizeof(addr.sun_path));
+    strncpy(addr.sun_path, server->socket_path, sizeof(addr.sun_path) - 1);
+
+    ck_assert_int_eq(bind(server->listen_fd, (struct sockaddr *)&addr, sizeof(addr)), 0);
+    ck_assert_int_eq(listen(server->listen_fd, expected_connections), 0);
+    ck_assert_int_eq(pthread_create(&server->accept_thread, NULL, fake_fdpass_accept_thread, server), 0);
+
+    pthread_mutex_lock(&server->lock);
+    while (!server->ready) {
+        pthread_cond_wait(&server->ready_cond, &server->lock);
+    }
+    pthread_mutex_unlock(&server->lock);
+}
+
+static void fake_fdpass_server_stop(struct fake_fdpass_server *server)
+{
+    if (server->listen_fd != -1) {
+        close(server->listen_fd);
+    }
+
+    pthread_join(server->accept_thread, NULL);
+    while (server->accepted_connections > 0) {
+        server->accepted_connections--;
+        pthread_join(server->client_threads[server->accepted_connections], NULL);
+    }
+
+    if (server->socket_path[0] != '\0') {
+        unlink(server->socket_path);
+    }
+    if (server->socket_dir[0] != '\0') {
+        rmdir(server->socket_dir);
+    }
+
+    pthread_cond_destroy(&server->ready_cond);
+    pthread_mutex_destroy(&server->lock);
+}
+
+static void fake_connect_server_start(struct fake_connect_server *server, int expected_connections)
+{
+    struct sockaddr_in addr;
+    socklen_t addr_len;
+    int enable = 1;
+
+    memset(server, 0, sizeof(*server));
+    server->listen_fd            = -1;
+    server->expected_connections = expected_connections;
+
+    ck_assert_int_eq(pthread_mutex_init(&server->lock, NULL), 0);
+    ck_assert_int_eq(pthread_cond_init(&server->ready_cond, NULL), 0);
+
+    server->listen_fd = socket(AF_INET, SOCK_STREAM, 0);
+    ck_assert_int_ne(server->listen_fd, -1);
+    ck_assert_int_eq(setsockopt(server->listen_fd, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(enable)), 0);
+
+    memset(&addr, 0, sizeof(addr));
+    addr.sin_family      = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    addr.sin_port        = 0;
+
+    ck_assert_int_eq(bind(server->listen_fd, (struct sockaddr *)&addr, sizeof(addr)), 0);
+    ck_assert_int_eq(listen(server->listen_fd, expected_connections), 0);
+
+    addr_len = sizeof(addr);
+    ck_assert_int_eq(getsockname(server->listen_fd, (struct sockaddr *)&addr, &addr_len), 0);
+    server->port = ntohs(addr.sin_port);
+
+    ck_assert_int_eq(pthread_create(&server->accept_thread, NULL, fake_connect_accept_thread, server), 0);
+
+    pthread_mutex_lock(&server->lock);
+    while (!server->ready) {
+        pthread_cond_wait(&server->ready_cond, &server->lock);
+    }
+    pthread_mutex_unlock(&server->lock);
+}
+
+static void fake_connect_server_stop(struct fake_connect_server *server)
+{
+    int i;
+
+    if (server->listen_fd != -1) {
+        close(server->listen_fd);
+    }
+
+    pthread_join(server->accept_thread, NULL);
+    for (i = 0; i < server->accepted_connections; i++) {
+        close(server->accepted_fds[i]);
+    }
+    pthread_cond_destroy(&server->ready_cond);
+    pthread_mutex_destroy(&server->lock);
+}
+
+static struct optstruct *add_test_option(struct optstruct *opts, int toolmask, const char *name, const char *arg)
+{
+    struct optstruct *new_opts;
+
+    new_opts = optadditem(name, arg, 0, toolmask, 0, opts);
+    ck_assert_ptr_nonnull(new_opts);
+    return new_opts;
+}
+
+static void setup_fdpass_context(struct onas_context *ctx, const char *socket_path)
+{
+    memset(ctx, 0, sizeof(*ctx));
+
+    ctx->opts = add_test_option(NULL, OPT_CLAMONACC, "fdpass", "yes");
+    ctx->clamdopts = add_test_option(NULL, OPT_CLAMD, "LocalSocket", socket_path);
+
+    ck_assert_int_eq(onas_set_sock_only_once(ctx), CL_SUCCESS);
+}
+
+static void cleanup_fdpass_context(struct onas_context *ctx)
+{
+    optfree((struct optstruct *)ctx->opts);
+    optfree((struct optstruct *)ctx->clamdopts);
+}
+
+static void *run_scan_thread(void *arg)
+{
+    struct scan_thread_args *scan = arg;
+    struct stat sb;
+    char url[64];
+    int fd = -1;
+
+    memset(&sb, 0, sizeof(sb));
+    if ((scan->scantype == STREAM) || (scan->scantype == FILDES)) {
+        fd = open(scan->temp_file, O_RDONLY);
+        ck_assert_int_ne(fd, -1);
+        ck_assert_int_eq(fstat(fd, &sb), 0);
+    } else {
+        sb.st_mode = S_IFREG;
+    }
+
+    snprintf(url, sizeof(url), "%s", scan->tcpaddr ? scan->tcpaddr : TEST_HOST_URL);
+    scan->result = onas_client_scan(url, scan->port, scan->scantype, TEST_MAXSTREAM, scan->filename,
+                                    fd, TEST_TIMEOUT_MS, sb, &scan->infected, &scan->err, &scan->ret_code);
+
+    if (fd != -1) {
+        close(fd);
+    }
+
+    return NULL;
+}
+
+START_TEST(test_onas_client_scan_stream_concurrent)
+{
+    struct fake_server server;
+    struct scan_thread_args scans[TEST_THREAD_COUNT];
+    pthread_t threads[TEST_THREAD_COUNT];
+    int i;
+
+    fake_server_start(&server, TEST_THREAD_COUNT, FAKE_REPLY_STREAM_FOUND);
+
+    for (i = 0; i < TEST_THREAD_COUNT; i++) {
+        FILE *tmp;
+
+        memset(&scans[i], 0, sizeof(scans[i]));
+        scans[i].tcpaddr = TEST_HOST_URL;
+        scans[i].port = server.port;
+        scans[i].scantype = STREAM;
+        scans[i].expect_infected = 1;
+        snprintf(scans[i].filename, sizeof(scans[i].filename), "stream-%d", i);
+        snprintf(scans[i].temp_file, sizeof(scans[i].temp_file), "tmp.stream.%d", i);
+
+        tmp = fopen(scans[i].temp_file, "w");
+        ck_assert_ptr_nonnull(tmp);
+        ck_assert_int_eq(fputs("stream payload\n", tmp) >= 0, 1);
+        fclose(tmp);
+
+        ck_assert_int_eq(pthread_create(&threads[i], NULL, run_scan_thread, &scans[i]), 0);
+    }
+
+    for (i = 0; i < TEST_THREAD_COUNT; i++) {
+        pthread_join(threads[i], NULL);
+        ck_assert_int_eq(scans[i].infected, scans[i].expect_infected);
+        ck_assert_int_eq(scans[i].result, CL_VIRUS);
+        unlink(scans[i].temp_file);
+    }
+
+    fake_server_stop(&server);
+    ck_assert_msg(!server.failed, "%s", server.failure_msg);
+}
+END_TEST
+
+START_TEST(test_onas_client_scan_allmatch_concurrent)
+{
+    struct fake_server server;
+    struct scan_thread_args scans[TEST_THREAD_COUNT];
+    pthread_t threads[TEST_THREAD_COUNT];
+    int i;
+
+    fake_server_start(&server, TEST_THREAD_COUNT, FAKE_REPLY_ALLMATCH_DOUBLE_FOUND);
+
+    for (i = 0; i < TEST_THREAD_COUNT; i++) {
+        memset(&scans[i], 0, sizeof(scans[i]));
+        scans[i].tcpaddr = TEST_HOST_URL;
+        scans[i].port = server.port;
+        scans[i].scantype = ALLMATCH;
+        scans[i].expect_infected = 1;
+        snprintf(scans[i].filename, sizeof(scans[i].filename), "thread-%d", i);
+
+        ck_assert_int_eq(pthread_create(&threads[i], NULL, run_scan_thread, &scans[i]), 0);
+    }
+
+    fake_server_release_second_reply(&server);
+
+    for (i = 0; i < TEST_THREAD_COUNT; i++) {
+        pthread_join(threads[i], NULL);
+        ck_assert_int_eq(scans[i].infected, scans[i].expect_infected);
+        ck_assert_int_eq(scans[i].result, CL_VIRUS);
+    }
+
+    fake_server_stop(&server);
+    ck_assert_msg(!server.failed, "%s", server.failure_msg);
+}
+END_TEST
+
+START_TEST(test_onas_client_scan_fdpass_concurrent)
+{
+#ifdef HAVE_FD_PASSING
+    struct fake_connect_server connect_server;
+    struct fake_fdpass_server server;
+    struct onas_context ctx;
+    struct scan_thread_args scans[TEST_THREAD_COUNT];
+    pthread_t threads[TEST_THREAD_COUNT];
+    int i;
+
+    fake_connect_server_start(&connect_server, TEST_THREAD_COUNT);
+    fake_fdpass_server_start(&server, TEST_THREAD_COUNT);
+    setup_fdpass_context(&ctx, server.socket_path);
+
+    for (i = 0; i < TEST_THREAD_COUNT; i++) {
+        FILE *tmp;
+
+        memset(&scans[i], 0, sizeof(scans[i]));
+        scans[i].tcpaddr = TEST_HOST_URL;
+        scans[i].port = connect_server.port;
+        scans[i].scantype = FILDES;
+        scans[i].expect_infected = 1;
+        snprintf(scans[i].filename, sizeof(scans[i].filename), "fdpass-%d", i);
+        snprintf(scans[i].temp_file, sizeof(scans[i].temp_file), "tmp.fdpass.%d", i);
+
+        tmp = fopen(scans[i].temp_file, "w");
+        ck_assert_ptr_nonnull(tmp);
+        ck_assert_int_eq(fprintf(tmp, "fdpass payload %d\n", i) >= 0, 1);
+        fclose(tmp);
+
+        ck_assert_int_eq(pthread_create(&threads[i], NULL, run_scan_thread, &scans[i]), 0);
+    }
+
+    for (i = 0; i < TEST_THREAD_COUNT; i++) {
+        pthread_join(threads[i], NULL);
+        ck_assert_int_eq(scans[i].infected, scans[i].expect_infected);
+        ck_assert_int_eq(scans[i].result, CL_VIRUS);
+        unlink(scans[i].temp_file);
+    }
+
+    fake_connect_server_stop(&connect_server);
+    fake_fdpass_server_stop(&server);
+    cleanup_fdpass_context(&ctx);
+    ck_assert_msg(!connect_server.failed, "%s", connect_server.failure_msg);
+    ck_assert_msg(!server.failed, "%s", server.failure_msg);
+#endif
+}
+END_TEST
+
+Suite *clamonacc_client_suite(void)
+{
+    Suite *suite;
+    TCase *testcase;
+
+    suite = suite_create("clamonacc_client");
+    testcase = tcase_create("client");
+
+    tcase_add_test(testcase, test_onas_client_scan_stream_concurrent);
+    tcase_add_test(testcase, test_onas_client_scan_allmatch_concurrent);
+    tcase_add_test(testcase, test_onas_client_scan_fdpass_concurrent);
+    suite_add_tcase(suite, testcase);
+
+    return suite;
+}
+
+int main(void)
+{
+    Suite *suite;
+    SRunner *runner;
+    int failed;
+
+    curl_global_init(CURL_GLOBAL_DEFAULT);
+
+    suite = clamonacc_client_suite();
+    runner = srunner_create(suite);
+    srunner_run_all(runner, CK_NORMAL);
+    failed = srunner_ntests_failed(runner);
+    srunner_free(runner);
+
+    curl_global_cleanup();
+
+    return failed == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+}


### PR DESCRIPTION
A scan mutex is preventing concurrent scans from clamonacc's thread pool.

Removing the on-access scan mutex exposed thread-unsafe state in clamonacc and common helper code, and it left us without test coverage for concurrent client traffic. Under load this could miscount ALLMATCH detections, race connection-status logging, and hide regressions in fd-passing behavior.

Fix the shared state so concurrent scans can proceed safely by making the disconnect log state mutex-protected, tracking ALLMATCH filenames per scan request, and updating the action failure counters atomically.

Add a Linux-only clamonacc client unit test that exercises concurrent STREAM, ALLMATCH, and FDPASS scans against fake daemons.

Resolves: https://github.com/Cisco-Talos/clamav/issues/1698

CLAM-2251