### PR TITLE
fix clamonacc onas_ddd_watch_hierarchy sometimes returning errors on excluded paths

### DIFF
--- a/clamonacc/inotif/hash.c
+++ b/clamonacc/inotif/hash.c
@@ -564,7 +564,7 @@ cl_error_t onas_rm_listnode(struct onas_lnode *head, const char *dirname)
         if (NULL == curr->dirname) {
             logg(LOGG_DEBUG, "ClamHash: node's directory name is NULL!\n");
             return CL_ERROR;
-        } else if (!strncmp(curr->dirname, dirname, n)) {
+        } else if (strlen(curr->dirname) == n && !memcmp(curr->dirname, dirname, n)) {
             if (curr->next != NULL)
                 curr->next->prev = curr->prev;
             if (curr->prev != NULL)


### PR DESCRIPTION
fixes issue #1701

the `strncmp` was causing `onas_rm_listnode` to remove the wrong `onas_lnode` whenever there was a directory name that started with the same characters as the intended-to-remove dirname

an example in my case, was that, when trying to exclude the path `.local/share/Steam/compatibilitytools.d/GE-Proton10-10/files/share/wine/mono/wine-mono-10.0.0/lib/mono/gac/System.Runtime.Serialization`
the dirname `System.Runtime.Serialization.Formatters.Soap` would appear before `System.Runtime.Serialization`, and would then cause the lnode for `System.Runtime.Serialization.Formatters.Soap` to be removed instead of `System.Runtime.Serialization`