### PR TITLE
onas_ht_insert: fix issue causing active bckts to be unlinked from ht->head chain 

### DIFF
--- a/clamonacc/inotif/hash.c
+++ b/clamonacc/inotif/hash.c
@@ -254,10 +254,12 @@ int onas_ht_insert(struct onas_ht *ht, struct onas_element *elem)
     int idx                  = onas_hash(elem->key, elem->klen, ht->size);
     struct onas_bucket *bckt = ht->htable[idx];
 
-    int ret        = 0;
-    uint32_t bsize = 0;
+    int ret          = 0;
+    uint32_t bsize   = 0;
+    bool bckt_is_new = false;
 
     if (bckt == NULL) {
+        bckt_is_new     = true;
         ht->htable[idx] = onas_bucket_init();
         if (ht->htable[idx] == NULL) return CL_EMEM;
 
@@ -270,7 +272,7 @@ int onas_ht_insert(struct onas_ht *ht, struct onas_element *elem)
         ht->tail   = bckt;
         bckt->prev = NULL;
         bckt->next = NULL;
-    } else {
+    } else if (bckt_is_new) { // bckts are never removed from the linked list
         struct onas_bucket *ht_tail = ht->tail;
         ht_tail->next               = bckt;
         bckt->prev                  = ht_tail;


### PR DESCRIPTION
Whenever there was a hash collision, `onas_ht_insert` would try to reinsert the pointer to a preexisting bckt into the `ht->head` list of buckets, **even though that bucket would have already been put into the list when it was first initialized w/ `onas_bucket_init()`**.
This can cause a break in the ht->head chain where some active bckts can not be accessed via iterating via `bckt = ht->head`+`bckt = bckt->next`, due to setting bckt->next to NULL.

This causes issues when trying to process `OnAccessExcludePath`, where iterating over the linked list of bckts currently causes some directories to not be excluded when they should

Here's a simple diagram to illustrate how `onas_ht_insert` is currently broken w/ hash collisions:

Lets say we first insert two bckts w/ `onas_ht_insert`, let B1 be the first bckt, & B2 be the second bckt:
let H: `ht->head`, T: `ht->tail` `-->`: link/`bckt->next`, `<--`: `bckt-prev`
first insertion:
```
         H --> B1
         T --> B1
NULL <-- B1 --> NULL
```
second insertion:
```
         H --> B1
         T --> B2
NULL <-- B1 --> B2
  B1 <-- B2 --> NULL
```

Normally, the third insertion for B3 would seem pretty intuitive:
```
         H --> B1
         T --> B3
NULL <-- B1 --> B2
  B1 <-- B2 --> B3
  B2 <-- B3 --> NULL
```

Now lets consider what happens if, for the third insertion, instead of a new bucket, B3, we try inserting B1 again:

```
T: B2
T->next = B1
B1->prev = T
B1->next = NULL
T = B1
```
```
         H --> B1
         T --> B1
  B2 <-- B1 --> NULL
  B1 <-- B2 --> B1
```
Now we can no longer access bckt B2 via `bckt = ht->head` & `bckt = bckt->next`, which, as mentioned, is what is used to iterate over each bucket for `OnAccessExcludePath`: https://github.com/Cisco-Talos/clamav/blob/9fe785d6ff885236fa92952cb2c55c28bac71d5b/clamonacc/inotif/inotif.c#L534-L554

Guard against this issue by only inserting the bckt if this is a newly initialized bckt 