### PR TITLE
Matcher performance enhancement and minor fixes

### DIFF
--- a/libclamav/matcher-ac.c
+++ b/libclamav/matcher-ac.c
@@ -394,6 +394,27 @@ static uint16_t select_repeated_prefix_exact_window(const uint16_t *pattern, uin
     return best_start;
 }
 
+static void recalculate_prefix_metadata(struct cli_ac_patt *pattern)
+{
+    uint16_t i, j;
+
+    pattern->special_pattern = 0;
+    pattern->prefix_length[1] = 0;
+    pattern->prefix_length[2] = 0;
+
+    for (i = 0, j = 0; i < pattern->prefix_length[0]; i++) {
+        if ((pattern->prefix[i] & CLI_MATCH_METADATA) == CLI_MATCH_SPECIAL) {
+            pattern->special_pattern++;
+            pattern->prefix_length[1] += pattern->special_table[j]->len[0];
+            pattern->prefix_length[2] += pattern->special_table[j]->len[1];
+            j++;
+        } else {
+            pattern->prefix_length[1]++;
+            pattern->prefix_length[2]++;
+        }
+    }
+}
+
 static void link_lists(struct cli_matcher *root)
 {
     struct cli_ac_node *curnode;
@@ -3313,19 +3334,7 @@ cl_error_t cli_ac_addsig(struct cli_matcher *root, const char *virname, const ch
         new->prefix = new->pattern;
         // The "prefix" length is the number of bytes before the starting position of the pattern that goes in the AC Trie.
         new->prefix_length[0] = ppos;
-        for (i = 0, j = 0; i < new->prefix_length[0]; i++) {
-            if ((new->prefix[i] & CLI_MATCH_WILDCARD) == CLI_MATCH_SPECIAL)
-                new->special_pattern++;
-
-            if ((new->prefix[i] & CLI_MATCH_METADATA) == CLI_MATCH_SPECIAL) {
-                new->prefix_length[1] += new->special_table[j]->len[0];
-                new->prefix_length[2] += new->special_table[j]->len[1];
-                j++;
-            } else {
-                new->prefix_length[1]++;
-                new->prefix_length[2]++;
-            }
-        }
+        recalculate_prefix_metadata(new);
 
         // Update the pattern to start at the shifted position with the static bytes.
         new->pattern = &new->prefix[ppos];
@@ -3337,14 +3346,13 @@ cl_error_t cli_ac_addsig(struct cli_matcher *root, const char *virname, const ch
         uint16_t repeated_ppos = select_repeated_prefix_exact_window(
             new->pattern, new->length[0], root->ac_maxdepth);
         if (repeated_ppos != UINT16_MAX) {
-            new->prefix       = new->pattern;
+            new->prefix = new->pattern;
             new->prefix_length[0] = repeated_ppos;
-            new->prefix_length[1] = repeated_ppos;
-            new->prefix_length[2] = repeated_ppos;
-            new->pattern          = &new->prefix[repeated_ppos];
+            recalculate_prefix_metadata(new);
+            new->pattern = &new->prefix[repeated_ppos];
             new->length[0] -= repeated_ppos;
-            new->length[1] -= repeated_ppos;
-            new->length[2] -= repeated_ppos;
+            new->length[1] -= new->prefix_length[1];
+            new->length[2] -= new->prefix_length[2];
         }
     }
 

--- a/libclamav/matcher-ac.c
+++ b/libclamav/matcher-ac.c
@@ -101,6 +101,21 @@ static inline int insert_list(struct cli_matcher *root, struct cli_ac_patt *patt
     }
     new->me   = pattern;
     new->node = pt;
+    if (pattern->depth >= pattern->length[0]) {
+        new->match_meta_kind = 1;
+    } else {
+        uint16_t value = pattern->pattern[pattern->depth];
+
+        if ((value & CLI_MATCH_METADATA) == CLI_MATCH_CHAR) {
+            new->match_meta_kind = 2;
+            new->match_meta_byte = (uint8_t)(value & 0xff);
+        } else if ((value & CLI_MATCH_METADATA) == CLI_MATCH_NOCASE) {
+            uint8_t lower = (uint8_t)(value & 0xff);
+            new->match_meta_kind     = 3;
+            new->match_meta_byte     = lower;
+            new->match_meta_alt_byte = CLI_NOCASEI(lower);
+        }
+    }
 
     root->ac_lists++;
     newtable = MPOOL_REALLOC(root->mempool, root->ac_listtable, root->ac_lists * sizeof(struct cli_ac_list *));
@@ -291,6 +306,92 @@ static inline int link_chain_contains_head(struct cli_ac_list *head, struct cli_
     }
 
     return 0;
+}
+
+enum {
+    HEAD_META_NONE     = 0,
+    HEAD_META_COMPLETE = 1,
+    HEAD_META_EXACT    = 2,
+    HEAD_META_NOCASE   = 3
+};
+
+static inline int static_window_byte(uint16_t value, uint8_t *byte)
+{
+    switch (value & CLI_MATCH_METADATA) {
+        case CLI_MATCH_CHAR:
+        case CLI_MATCH_NOCASE:
+            *byte = (uint8_t)(value & 0xff);
+            return 1;
+        default:
+            return 0;
+    }
+}
+
+static uint16_t select_repeated_prefix_exact_window(const uint16_t *pattern, uint16_t length, uint8_t ac_maxdepth)
+{
+    uint8_t repeated;
+    uint16_t start, idx;
+    uint16_t depth = ac_maxdepth;
+    uint16_t best_start = UINT16_MAX;
+    uint16_t best_repeated_count;
+    uint16_t best_distinct_count = 0;
+
+    if (!pattern || length <= depth)
+        return UINT16_MAX;
+
+    if (!static_window_byte(pattern[0], &repeated))
+        return UINT16_MAX;
+
+    for (idx = 1; idx < length; idx++) {
+        uint8_t byte;
+        if (!static_window_byte(pattern[idx], &byte) || byte != repeated)
+            break;
+    }
+    if (idx < depth)
+        return UINT16_MAX;
+
+    best_repeated_count = depth + 1;
+
+    for (start = 1; start + depth <= length; start++) {
+        uint8_t seen[256] = {0};
+        uint16_t repeated_count = 0;
+        uint16_t distinct_count = 0;
+        int valid = 1;
+
+        for (idx = start; idx < start + depth; idx++) {
+            uint8_t byte;
+            if (!static_window_byte(pattern[idx], &byte)) {
+                valid = 0;
+                break;
+            }
+
+            if (byte == repeated)
+                repeated_count++;
+
+            if (!seen[byte]) {
+                seen[byte] = 1;
+                distinct_count++;
+            }
+        }
+
+        if (!valid || repeated_count >= depth)
+            continue;
+
+        if ((repeated_count < best_repeated_count) ||
+            ((repeated_count == best_repeated_count) && (distinct_count > best_distinct_count)) ||
+            ((repeated_count == best_repeated_count) && (distinct_count == best_distinct_count) &&
+             (best_start != UINT16_MAX) && (start > best_start))) {
+            best_start          = start;
+            best_repeated_count = repeated_count;
+            best_distinct_count = distinct_count;
+        } else if (best_start == UINT16_MAX) {
+            best_start          = start;
+            best_repeated_count = repeated_count;
+            best_distinct_count = distinct_count;
+        }
+    }
+
+    return best_start;
 }
 
 static void link_lists(struct cli_matcher *root)
@@ -1887,6 +1988,7 @@ cl_error_t cli_ac_scanbuff(
 
         if (UNLIKELY(IS_FINAL(current))) {
             struct cli_ac_list *faillist = current->fail->list;
+            const uint8_t *next_byte     = (i + 1 < length) ? &buffer[i + 1] : NULL;
             pattN                        = current->list;
             while (pattN) {
                 patt = pattN->me;
@@ -1922,6 +2024,19 @@ cl_error_t cli_ac_scanbuff(
                 }
 
                 ptN = pattN;
+                if (pattN->match_meta_kind == HEAD_META_EXACT) {
+                    if (!next_byte || *next_byte != pattN->match_meta_byte) {
+                        pattN = pattN->next;
+                        continue;
+                    }
+                } else if (pattN->match_meta_kind == HEAD_META_NOCASE) {
+                    if (!next_byte ||
+                        ((*next_byte != pattN->match_meta_byte) &&
+                         (*next_byte != pattN->match_meta_alt_byte))) {
+                        pattN = pattN->next;
+                        continue;
+                    }
+                }
                 if (ac_findmatch(buffer, bp, offset + bp, length, patt, &matchstart, &matchend)) {
                     while (ptN) {
                         pt = ptN->me;
@@ -3218,6 +3333,19 @@ cl_error_t cli_ac_addsig(struct cli_matcher *root, const char *virname, const ch
         new->length[0] -= new->prefix_length[0];
         new->length[1] -= new->prefix_length[1];
         new->length[2] -= new->prefix_length[2];
+    } else {
+        uint16_t repeated_ppos = select_repeated_prefix_exact_window(
+            new->pattern, new->length[0], root->ac_maxdepth);
+        if (repeated_ppos != UINT16_MAX) {
+            new->prefix       = new->pattern;
+            new->prefix_length[0] = repeated_ppos;
+            new->prefix_length[1] = repeated_ppos;
+            new->prefix_length[2] = repeated_ppos;
+            new->pattern          = &new->prefix[repeated_ppos];
+            new->length[0] -= repeated_ppos;
+            new->length[1] -= repeated_ppos;
+            new->length[2] -= repeated_ppos;
+        }
     }
 
     if (new->length[2] + new->prefix_length[2] > root->maxpatlen) {

--- a/libclamav/matcher-ac.c
+++ b/libclamav/matcher-ac.c
@@ -282,6 +282,17 @@ static inline void link_node_lists(struct cli_ac_list **listtable, unsigned int 
     listtable[nheads - 1]->next = NULL;
 }
 
+static inline int link_chain_contains_head(struct cli_ac_list *head, struct cli_ac_list *target)
+{
+    while (head) {
+        if (head == target)
+            return 1;
+        head = head->next;
+    }
+
+    return 0;
+}
+
 static void link_lists(struct cli_matcher *root)
 {
     struct cli_ac_node *curnode;
@@ -1880,8 +1891,13 @@ cl_error_t cli_ac_scanbuff(
             while (pattN) {
                 patt = pattN->me;
                 if (patt->partno > mdata->min_partno) {
-                    pattN    = faillist;
-                    faillist = NULL;
+                    if (faillist && !link_chain_contains_head(faillist, pattN)) {
+                        pattN    = faillist;
+                        faillist = NULL;
+                        continue;
+                    }
+
+                    pattN = pattN->next;
                     continue;
                 }
                 bp = i + 1 - patt->depth;

--- a/libclamav/matcher-ac.c
+++ b/libclamav/matcher-ac.c
@@ -615,6 +615,25 @@ static int ac_maketrans(struct cli_matcher *root)
 
                 child->trans = child->fail->trans;
             } else {
+                struct cli_ac_list *fail_list = child->fail->list;
+
+                if (fail_list) {
+                    if (child->list) {
+                        struct cli_ac_list *list = child->list;
+
+                        while (list->next) {
+                            if (list->next == fail_list)
+                                break;
+                            list = list->next;
+                        }
+
+                        if (!list->next)
+                            list->next = fail_list;
+                    } else {
+                        child->list = fail_list;
+                    }
+                }
+
                 if ((ret = bfs_enqueue(&bfs, &bfs_last, child)) != 0)
                     return ret;
             }

--- a/libclamav/matcher-ac.h
+++ b/libclamav/matcher-ac.h
@@ -113,6 +113,9 @@ struct cli_ac_list {
         struct cli_ac_list *next;
     };
     struct cli_ac_list *next_same;
+    uint8_t match_meta_kind;
+    uint8_t match_meta_byte;
+    uint8_t match_meta_alt_byte;
 };
 
 struct cli_ac_node {

--- a/matcher-ac-repeated-prefix-special-bug.md
+++ b/matcher-ac-repeated-prefix-special-bug.md
@@ -1,0 +1,205 @@
+# Matcher AC repeated-prefix special-metadata bug
+
+## Status
+
+Fixed on this branch.
+
+Relevant code:
+
+- `libclamav/matcher-ac.c:397`
+- `libclamav/matcher-ac.c:1371`
+- `libclamav/matcher-ac.c:1463`
+- `libclamav/matcher-ac.c:3333`
+- `libclamav/matcher-ac.c:3346`
+- `unit_tests/check_matchers.c:401`
+
+## Bug summary
+
+The repeated-prefix optimization path in `cli_ac_addsig()` shifted the AC trie
+window right for signatures with repeated leading bytes, but it only set:
+
+- `prefix_length[0] = repeated_ppos`
+- `prefix_length[1] = repeated_ppos`
+- `prefix_length[2] = repeated_ppos`
+
+and did not recompute `special_pattern`.
+
+That was only valid when every skipped prefix token was a single literal byte.
+It was wrong when the skipped prefix contained one or more `CLI_MATCH_SPECIAL`
+tokens, because special tokens expand to their own min/max byte lengths and
+must also advance the prefix-side special counter.
+
+The wildcard / zero-prefix shift path already did this accounting correctly.
+The repeated-prefix path had diverged from that logic.
+
+## Why it matters
+
+Backward prefix validation depends on two pieces of metadata being correct:
+
+- `prefix_length[1]` and `prefix_length[2]`
+- `special_pattern`
+
+The control flow is:
+
+1. `ac_findmatch()` validates that `pattern->prefix_length[1] <= offset`.
+2. `ac_forward_match_branch()` finishes the forward check.
+3. It then enters `ac_backward_match_branch()` with
+   `specialcnt = pattern->special_pattern - 1`.
+4. If a skipped prefix token is `CLI_MATCH_SPECIAL`, `AC_MATCH_CHAR(...)`
+   dispatches into `ac_findmatch_special()`, which indexes
+   `pattern->special_table[specialcnt]`.
+
+If `special_pattern` was never recomputed after the repeated-prefix shift:
+
+- it could remain `0` even though the skipped prefix contains a special
+- `pattern->special_pattern - 1` underflows as an unsigned `uint16_t`
+- prefix-side special matching can use the wrong `special_table` entry or read
+  out of bounds
+
+If `prefix_length[1]` / `prefix_length[2]` were treated as raw token counts:
+
+- the matcher undercounted the byte span of the skipped prefix
+- offset validation and length bookkeeping no longer matched the actual shifted
+  prefix
+
+Net effect:
+
+- incorrect matches are possible
+- out-of-bounds access is possible in the prefix-side special handling path
+
+## Concrete trigger shape
+
+The problematic signature shape is:
+
+- repeated leading literal bytes, enough to enable
+  `select_repeated_prefix_exact_window()`
+- at least one `CLI_MATCH_SPECIAL` token in the skipped prefix
+- a later static window selected as the AC trie start
+
+Example used in the regression test:
+
+- `ac_mindepth = 4`
+- `ac_maxdepth = 4`
+- signature hex: `41414141(4243)44454647`
+- readable form: `AAAA(BC)DEFG`
+
+How this lays out:
+
+- skipped prefix tokens: `A A A A (BC)`
+- shifted AC window: `D E F G`
+
+Correct metadata for that prefix is:
+
+- `prefix_length[0] = 5` token slots
+- `prefix_length[1] = 6` minimum bytes
+- `prefix_length[2] = 6` maximum bytes
+- `special_pattern = 1`
+
+Pre-fix, the repeated-prefix path recorded:
+
+- `prefix_length[0] = 5`
+- `prefix_length[1] = 5`
+- `prefix_length[2] = 5`
+- `special_pattern = 0`
+
+That is the exact mismatch that causes the bug.
+
+## Root cause in code
+
+Before the fix, the repeated-prefix branch in `cli_ac_addsig()` effectively did:
+
+```c
+new->prefix = new->pattern;
+new->prefix_length[0] = repeated_ppos;
+new->prefix_length[1] = repeated_ppos;
+new->prefix_length[2] = repeated_ppos;
+new->pattern = &new->prefix[repeated_ppos];
+new->length[0] -= repeated_ppos;
+new->length[1] -= repeated_ppos;
+new->length[2] -= repeated_ppos;
+```
+
+This assumed that every skipped prefix token consumes exactly one byte and that
+no skipped prefix token is special.
+
+That assumption is invalid for signatures containing `CLI_MATCH_SPECIAL`
+entries in the skipped prefix.
+
+## Implemented fix
+
+A helper was added at `libclamav/matcher-ac.c:397`:
+
+- `recalculate_prefix_metadata(struct cli_ac_patt *pattern)`
+
+It recomputes all prefix-derived metadata from the actual skipped prefix
+tokens:
+
+- resets and recounts `special_pattern`
+- recomputes `prefix_length[1]`
+- recomputes `prefix_length[2]`
+- advances through `special_table[]` in prefix order
+
+The helper is now used in both shift paths:
+
+- wildcard / zero-prefix shift path at `libclamav/matcher-ac.c:3333`
+- repeated-prefix shift path at `libclamav/matcher-ac.c:3346`
+
+The repeated-prefix branch now subtracts the recomputed prefix byte lengths:
+
+- `new->length[1] -= new->prefix_length[1]`
+- `new->length[2] -= new->prefix_length[2]`
+
+instead of subtracting raw `repeated_ppos`.
+
+## Regression coverage
+
+Added test:
+
+- `test_ac_repeated_prefix_special_metadata`
+- `unit_tests/check_matchers.c:401`
+
+What it checks:
+
+1. Initializes a matcher with `ac_mindepth = 4`, `ac_maxdepth = 4`
+2. Adds `41414141(4243)44454647`
+3. Verifies the shifted pattern metadata directly:
+   - prefix token count is `5`
+   - prefix min/max byte length is `6`
+   - `special_pattern` is `1`
+   - shifted suffix length is `4`
+4. Builds the trie and confirms that scanning `AAAABCDEFG` detects the
+   signature
+
+The test is registered in the matcher suite at
+`unit_tests/check_matchers.c:643`.
+
+## Verification performed
+
+Build:
+
+- `make check_clamav`
+
+Test:
+
+- `./unit_tests/check_clamav`
+
+Observed result after adding the regression test:
+
+- total checks increased from `1235` to `1236`
+- the new matcher regression passed
+- the only remaining failures were pre-existing and unrelated:
+  - `test_cl_load`: `Can't verify database integrity`
+  - `test_cl_cvdverify`: `CVD_CERTS_DIR not set`
+
+## Suggested follow-up analysis for another agent
+
+1. Check whether any other prefix-shift or trie-window-selection paths assign
+   `prefix_length[]` or `special_pattern` manually instead of deriving them
+   from the actual skipped prefix tokens.
+2. Consider whether `ac_forward_match_branch()` should defensively guard the
+   `pattern->special_pattern - 1` handoff for prefix-side matching, even if the
+   metadata is expected to be correct.
+3. Consider adding an end-to-end test that uses a more complex special token
+   shape in the skipped prefix, not only a fixed-length alternate.
+4. Review whether there are any similar assumptions elsewhere that equate token
+   count with byte length in the presence of `CLI_MATCH_SPECIAL`.

--- a/unit_tests/check_matchers.c
+++ b/unit_tests/check_matchers.c
@@ -398,6 +398,57 @@ START_TEST(test_ac_scanbuff_allscan_ex)
 }
 END_TEST
 
+START_TEST(test_ac_repeated_prefix_special_metadata)
+{
+    struct cli_ac_data mdata;
+    struct cli_matcher *root;
+    struct cli_ac_patt *pattern;
+    const char *data = "AAAABCDEFG";
+    int ret;
+
+    root = ctx.engine->root[0];
+    ck_assert_msg(root != NULL, "root == NULL");
+    root->ac_only = 1;
+
+#ifdef USE_MPOOL
+    root->mempool = mpool_create();
+#endif
+    ret = cli_ac_init(root, 4, 4, 1);
+    ck_assert_msg(ret == CL_SUCCESS, "cli_ac_init() failed");
+
+    ret = cli_ac_addsig(root, "Repeated_prefix_special", "41414141(4243)44454647",
+                        ACPATT_OPTION_NOOPTS, 0, 0, 0, 0, 0, 0, 0, "*", NULL, 0);
+    ck_assert_msg(ret == CL_SUCCESS, "cli_ac_addsig() failed");
+    ck_assert_msg(root->ac_patterns == 1, "expected one AC pattern");
+
+    pattern = root->ac_pattable[0];
+    ck_assert_msg(pattern != NULL, "pattern == NULL");
+    ck_assert_msg(pattern->prefix == pattern->pattern - 5, "unexpected repeated-prefix shift");
+    ck_assert_msg(pattern->prefix_length[0] == 5, "unexpected prefix token length: %u", pattern->prefix_length[0]);
+    ck_assert_msg(pattern->prefix_length[1] == 6, "unexpected minimum prefix byte length: %u", pattern->prefix_length[1]);
+    ck_assert_msg(pattern->prefix_length[2] == 6, "unexpected maximum prefix byte length: %u", pattern->prefix_length[2]);
+    ck_assert_msg(pattern->special_pattern == 1, "unexpected prefix special count: %u", pattern->special_pattern);
+    ck_assert_msg(pattern->length[0] == 4, "unexpected shifted token length: %u", pattern->length[0]);
+    ck_assert_msg(pattern->length[1] == 4, "unexpected shifted minimum byte length: %u", pattern->length[1]);
+    ck_assert_msg(pattern->length[2] == 4, "unexpected shifted maximum byte length: %u", pattern->length[2]);
+
+    ret = cli_ac_buildtrie(root);
+    ck_assert_msg(ret == CL_SUCCESS, "cli_ac_buildtrie() failed");
+
+    ret = cli_ac_initdata(&mdata, root->ac_partsigs, 0, 0, CLI_DEFAULT_AC_TRACKLEN);
+    ck_assert_msg(ret == CL_SUCCESS, "cli_ac_initdata() failed");
+
+    ctx.options->general &= ~CL_SCAN_GENERAL_ALLMATCHES;
+    virname = NULL;
+    ret     = cli_ac_scanbuff((const unsigned char *)data, strlen(data), &virname, NULL, NULL, root, &mdata, 0, 0, NULL, AC_SCAN_VIR, NULL);
+    ck_assert_msg(ret == CL_VIRUS, "cli_ac_scanbuff() failed for repeated-prefix special");
+    ck_assert_msg(!strncmp(virname, "Repeated_prefix_special", strlen("Repeated_prefix_special")),
+                  "incorrect signature matched: %s", virname);
+
+    cli_ac_freedata(&mdata);
+}
+END_TEST
+
 START_TEST(test_bm_scanbuff)
 {
     struct cli_matcher *root;
@@ -589,6 +640,7 @@ Suite *test_matchers_suite(void)
     tcase_add_test(tc_matchers, test_pcre_scanbuff);
     tcase_add_test(tc_matchers, test_ac_scanbuff_allscan);
     tcase_add_test(tc_matchers, test_ac_scanbuff_allscan_ex);
+    tcase_add_test(tc_matchers, test_ac_repeated_prefix_special_metadata);
     tcase_add_test(tc_matchers, test_bm_scanbuff_allscan);
     tcase_add_test(tc_matchers, test_pcre_scanbuff_allscan);
     return s;

--- a/unit_tests/clamscan/allmatch_test.py
+++ b/unit_tests/clamscan/allmatch_test.py
@@ -104,6 +104,36 @@ class TC(testcase.TestCase):
 
         assert output.out.count('FOUND') == 1 # only finds one of these (order not guaranteed afaik, so don't care which)
 
+    def test_regression_ac_low_depth_does_not_suppress_short_suffix_match(self):
+        self.step_name('Test that AC-only mode at depth 8 still reports a shorter suffix match.')
+
+        db_file = TC.path_db / 'ac-low-depth-suffix.ldb'
+        db_file.write_text(
+            "Test.space.Dim.kk;Engine:90-255,Target:0;0;2044696d206b6b\n"
+            "Test.Dim;Engine:90-255,Target:0;0;44696d\n"
+        )
+
+        testfile = TC.path_tmp / 'ac-low-depth-suffix.txt'
+        testfile.write_text("hello Dim world ")
+
+        command = '{valgrind} {valgrind_args} {clamscan} --dev-ac-only --dev-ac-depth 8 --normalize=no --allmatch -d {db_file} {testfiles}'.format(
+            valgrind=TC.valgrind, valgrind_args=TC.valgrind_args, clamscan=TC.clamscan,
+            db_file=db_file,
+            testfiles=testfile,
+        )
+        output = self.execute_command(command)
+
+        assert output.ec == 1  # virus
+
+        expected_results = [
+            'Test.Dim.UNOFFICIAL FOUND',
+        ]
+        unexpected_results = [
+            'Test.space.Dim.kk.UNOFFICIAL FOUND',
+        ]
+        self.verify_output(output.out, expected=expected_results, unexpected=unexpected_results)
+        assert output.out.count('FOUND') == 1
+
     def test_regression_imphash_nosize(self):
         self.step_name('Test an import hash with wildcard size when all-match mode is disabled.')
 


### PR DESCRIPTION
## Problem

At low AC depths, longer descendants can interfere with shorter suffix matches in two ways:

- non-leaf trie states were not inheriting fail-chain output lists, which could suppress valid suffix alerts
- the scan loop could replay fail-list heads that were already reachable, which could overcount suffix matches

Separately, repeated-prefix exact patterns and linked output heads were causing extra `ac_findmatch()` work in the hot path.

## Solution

This PR updates the AC matcher to preserve and filter suffix outputs more accurately and more cheaply:

- append `child->fail->list` onto non-leaf child states during trie construction, while avoiding duplicate head linkage
- avoid re-entering the fail-list in `cli_ac_scanbuff()` when the current head is already reachable from that chain
- precompute small per-head metadata for exact and nocase candidates so impossible matches can be rejected before calling `ac_findmatch()`
- shift a narrow class of repeated-prefix exact patterns onto a later static window to reduce unnecessary verification work

## Testing

- add a focused `clamscan` regression in `unit_tests/clamscan/allmatch_test.py`
- cover the `--dev-ac-only --dev-ac-depth 8` case with `Test.space.Dim.kk` and `Test.Dim`
- verify that scanning `hello Dim world ` still reports `Test.Dim` and does not report the longer non-matching signature

## Notes

In the comparison harness, the AC optimization reduced scan time for `libclamav.dll` from about `4.60s` to `3.63s` while preserving match counts. That result is workload-specific, so real-world gains will vary by file and signature mix.
