### PR TITLE
Fix cl_fmap_set_hash API hash-format mismatch

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,14 @@ differ slightly from third-party binary packages.
 
 ClamAV 1.6.0 includes the following improvements and changes:
 
+### Breaking changes
+
+- Changed the public `cl_fmap_set_hash()` API to accept a NUL-terminated
+  hexadecimal hash string, matching the format returned by
+  `cl_fmap_get_hash()`.
+  This changes the exported `libclamav` ABI and is accompanied by a
+  `libclamav` SOVERSION bump.
+
 ### Major changes
 
 - Retired the legacy ClamAV stats submission code used to send telemetry to

--- a/libclamav/clamav.h
+++ b/libclamav/clamav.h
@@ -673,10 +673,11 @@ extern cl_error_t cl_fmap_get_size(const cl_fmap_t *map, size_t *size_out);
  *
  * @param map           The file map to modify.
  * @param hash_alg      The hash algorithm to use (e.g., "md5", "sha1", "sha2-256").
- * @param hash          The hash value to set.
+ * @param hash          The NUL-terminated hexadecimal hash string to set.
+ *                      This must match the format returned by `cl_fmap_get_hash()`.
  * @return cl_error_t   CL_SUCCESS if the hash was successfully set.
  */
-extern cl_error_t cl_fmap_set_hash(const cl_fmap_t *map, const char *hash_alg, char hash);
+extern cl_error_t cl_fmap_set_hash(const cl_fmap_t *map, const char *hash_alg, const char *hash);
 
 /**
  * @brief Check if we already calculated a file hash of a specific type.

--- a/libclamav/fmap.c
+++ b/libclamav/fmap.c
@@ -1455,12 +1455,14 @@ done:
     return status;
 }
 
-extern cl_error_t cl_fmap_set_hash(const cl_fmap_t *map, const char *hash_alg, char hash)
+extern cl_error_t cl_fmap_set_hash(const cl_fmap_t *map, const char *hash_alg, const char *hash)
 {
     cl_error_t status = CL_ERROR;
     cli_hash_type_t type;
+    size_t hash_string_len;
+    uint8_t hash_bytes[CLI_HASHLEN_MAX] = {0};
 
-    if (!map || !hash_alg) {
+    if (!map || !hash_alg || !hash) {
         status = CL_ENULLARG;
         goto done;
     }
@@ -1477,7 +1479,21 @@ extern cl_error_t cl_fmap_set_hash(const cl_fmap_t *map, const char *hash_alg, c
         goto done;
     }
 
-    status = fmap_set_hash((fmap_t *)map, (uint8_t *)&hash, type);
+    hash_string_len = strlen(hash);
+    if (hash_string_len != cli_hash_len(type) * 2) {
+        cli_errmsg("cl_fmap_set_hash: Hash string length (%zu) does not match expected length for %s (%zu)\n",
+                   hash_string_len, hash_alg, cli_hash_len(type) * 2);
+        status = CL_EARG;
+        goto done;
+    }
+
+    status = cli_hexstr_to_bytes(hash, hash_string_len, hash_bytes);
+    if (status != CL_SUCCESS) {
+        cli_errmsg("cl_fmap_set_hash: Hash value is not a valid hexadecimal string for algorithm: %s\n", hash_alg);
+        goto done;
+    }
+
+    status = fmap_set_hash((fmap_t *)map, hash_bytes, type);
     if (status != CL_SUCCESS) {
         cli_errmsg("cl_fmap_set_hash: Failed to set hash for algorithm: %s\n", hash_alg);
         goto done;

--- a/unit_tests/check_clamav.c
+++ b/unit_tests/check_clamav.c
@@ -689,6 +689,53 @@ START_TEST(test_action_source_open_path_rejects_replaced_symlink)
 END_TEST
 #endif
 
+START_TEST(test_cl_fmap_set_hash_hex)
+{
+    static const unsigned char map_data[] = "fmap hash test";
+    static const char expected_sha256[]   = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    static const char invalid_sha256[]    = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdeg";
+    cl_fmap_t *map                        = NULL;
+    cl_error_t ret                        = CL_ERROR;
+    bool have_hash                        = true;
+    char *hash_out                        = NULL;
+
+    map = cl_fmap_open_memory(map_data, sizeof(map_data) - 1);
+    ck_assert_msg(NULL != map, "cl_fmap_open_memory failed");
+
+    ret = cl_fmap_have_hash(map, "sha256", &have_hash);
+    ck_assert_msg(CL_SUCCESS == ret, "cl_fmap_have_hash before set failed: %s", cl_strerror(ret));
+    ck_assert_msg(false == have_hash, "sha256 hash should not exist before cl_fmap_set_hash");
+
+    ret = cl_fmap_set_hash(map, "sha256", expected_sha256);
+    ck_assert_msg(CL_SUCCESS == ret, "cl_fmap_set_hash failed: %s", cl_strerror(ret));
+
+    ret = cl_fmap_have_hash(map, "sha2-256", &have_hash);
+    ck_assert_msg(CL_SUCCESS == ret, "cl_fmap_have_hash after set failed: %s", cl_strerror(ret));
+    ck_assert_msg(true == have_hash, "sha256 hash should exist after cl_fmap_set_hash");
+
+    ret = cl_fmap_get_hash(map, "sha2-256", &hash_out);
+    ck_assert_msg(CL_SUCCESS == ret, "cl_fmap_get_hash failed: %s", cl_strerror(ret));
+    ck_assert_msg(NULL != hash_out, "cl_fmap_get_hash did not return a hash string");
+    ck_assert_msg(0 == strcmp(expected_sha256, hash_out), "unexpected sha256 hash string: %s", hash_out);
+    free(hash_out);
+    hash_out = NULL;
+
+    ret = cl_fmap_set_hash(map, "sha256", "abcd");
+    ck_assert_msg(CL_EARG == ret, "cl_fmap_set_hash should reject the wrong hash length, got: %s", cl_strerror(ret));
+
+    ret = cl_fmap_set_hash(map, "sha256", invalid_sha256);
+    ck_assert_msg(CL_EFORMAT == ret, "cl_fmap_set_hash should reject invalid hex, got: %s", cl_strerror(ret));
+
+    ret = cl_fmap_get_hash(map, "sha256", &hash_out);
+    ck_assert_msg(CL_SUCCESS == ret, "cl_fmap_get_hash after invalid input failed: %s", cl_strerror(ret));
+    ck_assert_msg(NULL != hash_out, "cl_fmap_get_hash after invalid input did not return a hash string");
+    ck_assert_msg(0 == strcmp(expected_sha256, hash_out), "sha256 hash changed after invalid input: %s", hash_out);
+
+    free(hash_out);
+    cl_fmap_close(map);
+}
+END_TEST
+
 static char **testfiles     = NULL;
 static unsigned testfiles_n = 0;
 
@@ -1485,6 +1532,7 @@ static Suite *test_cl_suite(void)
     tcase_add_test(tc_cl, test_action_source_open_relative_path_stores_absolute_action_path);
     tcase_add_test(tc_cl, test_action_source_open_path_rejects_replaced_symlink);
 #endif
+    tcase_add_test(tc_cl, test_cl_fmap_set_hash_hex);
 
     suite_add_tcase(s, tc_cl_scan);
     tcase_add_checked_fixture(tc_cl_scan, engine_setup, engine_teardown);

--- a/unit_tests/check_clamav.c
+++ b/unit_tests/check_clamav.c
@@ -711,7 +711,7 @@ START_TEST(test_cl_fmap_set_hash_hex)
 
     ret = cl_fmap_have_hash(map, "sha2-256", &have_hash);
     ck_assert_msg(CL_SUCCESS == ret, "cl_fmap_have_hash after set failed: %s", cl_strerror(ret));
-    ck_assert_msg(true == have_hash, "sha256 hash should exist after cl_fmap_set_hash");
+    ck_assert_msg(true == have_hash, "sha2-256 hash should exist after cl_fmap_set_hash");
 
     ret = cl_fmap_get_hash(map, "sha2-256", &hash_out);
     ck_assert_msg(CL_SUCCESS == ret, "cl_fmap_get_hash failed: %s", cl_strerror(ret));


### PR DESCRIPTION
The public cl_fmap_set_hash API was broken: its signature exposed a single-character hash argument even though the implementation expected raw hash bytes, and that also diverged from cl_fmap_get_hash(), which returns hashes as hexadecimal strings. That made the public API
inconsistent and unusable for callers trying to set a hash through the documented interface.

Fix this by changing cl_fmap_set_hash() to accept a NUL-terminated hexadecimal string, decoding it to bytes before storing it internally, bumping libclamav's
SOVERSION for the ABI break, documenting the change in the 1.6.0 release notes, and adding unit coverage for the public cl_fmap_set_hash() path.