### PR TITLE
Clarify Prelude output comment in clamd.conf.sample

### DIFF
--- a/etc/clamd.conf.sample
+++ b/etc/clamd.conf.sample
@@ -56,7 +56,7 @@ Example
 # Default: no
 #LogRotate yes
 
-# Enable Prelude output.
+# Enable output for Prelude-SIEM. Abandonware, ignore this.
 # Default: no
 #PreludeEnable yes
 #


### PR DESCRIPTION
Updated comment to clarify what Prelude is and point out that it's abandonware and thus irrelevant to most users. To prevent others from wasting a couple hours trying to figure out what on earth "enable prelude output" meant like I did.

Yes, abandonware. Both the domains that Wikipedia mentions are parked domains and latest release was five years ago. https://en.wikipedia.org/wiki/Prelude_SIEM