### PR TITLE
fix out-of-bounds access in gpt_scan_partitions name loop

### DIFF
--- a/libclamav/gpt.c
+++ b/libclamav/gpt.c
@@ -303,7 +303,7 @@ static cl_error_t gpt_scan_partitions(cli_ctx *ctx, struct gpt_header hdr, size_
         gpe.lastLBA    = le64_to_host(gpe.lastLBA);
         gpe.attributes = le64_to_host(gpe.attributes);
         for (j = 0; j < 36; ++j) {
-            gpe.name[i] = le16_to_host(gpe.name[i]);
+            gpe.name[j] = le16_to_host(gpe.name[j]);
         }
 
         /* check that partition is not empty and within a valid location */


### PR DESCRIPTION
gpt_scan_partitions byte-swaps the 36-entry utf-16 partition name in a loop that runs j from 0 to 35 but subscripts gpe.name[i], the outer partition counter rather than the inner one. name is the last member of struct gpt_partition_entry, so once i reaches 36 the read-modify-write runs past the end of the on-stack entry; with the default maxpartitions of 50 a crafted gpt header advertising 37 or more table entries drives partition indices 36..49 and touches up to roughly two dozen bytes beyond the struct on a normal disk-image scan. using gpe.name[j] keeps the access inside the array and, as a knock-on, swaps each character once instead of the same one thirty-six times. seems safest to keep the loop counter and the subscript in step here.