### PR TITLE
bound decodeLine output to buflen in quoted-printable and yenc paths

### DIFF
--- a/libclamav/message.c
+++ b/libclamav/message.c
@@ -1843,7 +1843,8 @@ decodeLine(message *m, encoding_type et, const char *line, unsigned char *buf, s
             }
 
             softbreak = false;
-            while (buflen && *line) {
+            /* reserve two bytes for the trailing '\n' and '\0' written below */
+            while (buflen > 2 && *line) {
                 if (*line == '=') {
                     unsigned char byte;
 
@@ -1962,13 +1963,17 @@ decodeLine(message *m, encoding_type et, const char *line, unsigned char *buf, s
             if (strncmp(line, "=yend ", 6) == 0)
                 break;
 
-            while (*line)
+            /* reserve one byte for the trailing '\0' written below */
+            while (buflen > 1 && *line) {
                 if (*line == '=') {
                     if (*++line == '\0')
                         break;
                     *buf++ = ((*line++ - 64) & 255);
-                } else
+                } else {
                     *buf++ = ((*line++ - 42) & 255);
+                }
+                buflen--;
+            }
             break;
     }
 

--- a/libclamav/message.c
+++ b/libclamav/message.c
@@ -1843,8 +1843,8 @@ decodeLine(message *m, encoding_type et, const char *line, unsigned char *buf, s
             }
 
             softbreak = false;
-            /* reserve two bytes for the trailing '\n' and '\0' written below */
-            while (buflen > 2 && *line) {
+            /* keep at least one byte for the terminating '\0' written below */
+            while (buflen > 1 && *line) {
                 if (*line == '=') {
                     unsigned char byte;
 
@@ -1862,6 +1862,7 @@ decodeLine(message *m, encoding_type et, const char *line, unsigned char *buf, s
                          * adhering to RFC2045
                          */
                         *buf++ = byte;
+                        --buflen;
                         break;
                     }
 
@@ -1882,8 +1883,8 @@ decodeLine(message *m, encoding_type et, const char *line, unsigned char *buf, s
                 ++line;
                 --buflen;
             }
-            if (!softbreak) {
-                /* Put the new line back in */
+            if (!softbreak && buflen > 1) {
+                /* Put the new line back in, only if it still fits before '\0' */
                 *buf++ = '\n';
             }
             break;


### PR DESCRIPTION
**Out-of-bounds write in decodeLine**

The quoted-printable and yEncode branches write into `buf` without honouring `buflen`: quoted-printable appends a trailing newline and the terminating null past the bytes it counted, and yEncode never checks the length at all, so a 1024-byte mail line decoded into messageToText's fixed buffer lands one or two bytes past the end. The other branches already respect the length (uudecode checks `buflen`, messageExport sizes its buffer as `strlen + 2`), so I reserved room for the trailing bytes in these two to keep the behaviour consistent.