### PR TITLE
fix: Fix `-Wcalloc-transposed-args` warnings (#1740)

### DIFF
--- a/clamav-milter/connpool.c
+++ b/clamav-milter/connpool.c
@@ -209,7 +209,7 @@ void cpool_init(struct optstruct *opts)
     const struct optstruct *opt;
     int failed = 0;
 
-    if (!(cp = calloc(sizeof(*cp), 1))) {
+    if (!(cp = calloc(1, sizeof(*cp)))) {
         logg(LOGG_ERROR, "Out of memory while initializing the connection pool");
         return;
     }

--- a/clambc/bcrun.c
+++ b/clambc/bcrun.c
@@ -402,7 +402,7 @@ int main(int argc, char *argv[])
         cctx.engine = engine;
 
         cctx.recursion_stack_size = cctx.engine->max_recursion_level;
-        cctx.recursion_stack      = calloc(sizeof(cli_scan_layer_t), cctx.recursion_stack_size);
+        cctx.recursion_stack      = calloc(cctx.recursion_stack_size, sizeof(cli_scan_layer_t));
         if (!cctx.recursion_stack) {
             fprintf(stderr, "Out of memory\n");
             exit(3);

--- a/libclamav/pdf.c
+++ b/libclamav/pdf.c
@@ -339,7 +339,7 @@ int pdf_findobj_in_objstm(struct pdf_struct *pdf, struct objstm_struct *objstm, 
     index           = objstm->streambuf + objstm->current_pair;
     bytes_remaining = objstm->streambuf_len - objstm->current_pair;
 
-    obj = calloc(sizeof(struct pdf_obj), 1);
+    obj = calloc(1, sizeof(struct pdf_obj));
     if (!obj) {
         cli_warnmsg("pdf_findobj_in_objstm: out of memory finding objects in stream\n");
         status = CL_EMEM;

--- a/libclamav/scanners.c
+++ b/libclamav/scanners.c
@@ -5760,7 +5760,7 @@ static cl_error_t scan_common(
     }
 
     ctx.recursion_stack_size = ctx.engine->max_recursion_level;
-    ctx.recursion_stack      = calloc(sizeof(cli_scan_layer_t), ctx.recursion_stack_size);
+    ctx.recursion_stack      = calloc(ctx.recursion_stack_size, sizeof(cli_scan_layer_t));
     if (!ctx.recursion_stack) {
         status = CL_EMEM;
         goto done;

--- a/libclamunrar_iface/unrar_iface.cpp
+++ b/libclamunrar_iface/unrar_iface.cpp
@@ -208,7 +208,7 @@ cl_unrar_error_t unrar_open(const char* filename, void** hArchive, char** commen
     /* Enable debug messages in unrar_iface.cpp */
     unrar_debug = debug_flag;
 
-    archiveData = (struct RAROpenArchiveDataEx*)calloc(sizeof(struct RAROpenArchiveDataEx), 1);
+    archiveData = (struct RAROpenArchiveDataEx*)calloc(1, sizeof(struct RAROpenArchiveDataEx));
     if (archiveData == NULL) {
         unrar_dbgmsg("unrar_open: Not enough memory to allocate main archive header data structure.\n");
         status = UNRAR_EMEM;

--- a/sigtool/sigtool.c
+++ b/sigtool/sigtool.c
@@ -220,7 +220,7 @@ static int hashpe(const char *filename, unsigned int class, cli_hash_type_t type
     ctx.dconf          = (struct cli_dconf *)engine->dconf;
 
     ctx.recursion_stack_size = ctx.engine->max_recursion_level;
-    ctx.recursion_stack      = calloc(sizeof(cli_scan_layer_t), ctx.recursion_stack_size);
+    ctx.recursion_stack      = calloc(ctx.recursion_stack_size, sizeof(cli_scan_layer_t));
     if (!ctx.recursion_stack) {
         goto done;
     }
@@ -485,7 +485,7 @@ static cli_ctx *convenience_ctx(int fd, const char *filepath)
     ctx->dconf = (struct cli_dconf *)engine->dconf;
 
     ctx->recursion_stack_size = ctx->engine->max_recursion_level;
-    ctx->recursion_stack      = calloc(sizeof(cli_scan_layer_t), ctx->recursion_stack_size);
+    ctx->recursion_stack      = calloc(ctx->recursion_stack_size, sizeof(cli_scan_layer_t));
     if (!ctx->recursion_stack) {
         status = CL_EMEM;
         goto done;
@@ -2772,7 +2772,7 @@ static void matchsig(char *sig, const char *offset, int fd)
     ctx.dconf          = (struct cli_dconf *)engine->dconf;
 
     ctx.recursion_stack_size = ctx.engine->max_recursion_level;
-    ctx.recursion_stack      = calloc(sizeof(cli_scan_layer_t), ctx.recursion_stack_size);
+    ctx.recursion_stack      = calloc(ctx.recursion_stack_size, sizeof(cli_scan_layer_t));
     if (!ctx.recursion_stack) {
         goto done;
     }
@@ -3977,7 +3977,7 @@ static int dumpcerts(const struct optstruct *opts)
     ctx.dconf          = (struct cli_dconf *)engine->dconf;
 
     ctx.recursion_stack_size = ctx.engine->max_recursion_level;
-    ctx.recursion_stack      = calloc(sizeof(cli_scan_layer_t), ctx.recursion_stack_size);
+    ctx.recursion_stack      = calloc(ctx.recursion_stack_size, sizeof(cli_scan_layer_t));
     if (!ctx.recursion_stack) {
         goto done;
     }

--- a/unit_tests/check_bytecode.c
+++ b/unit_tests/check_bytecode.c
@@ -81,7 +81,7 @@ static void runtest(const char *file, uint64_t expected, int fail, int nojit,
     cctx.dconf = cctx.engine->dconf;
 
     cctx.recursion_stack_size = cctx.engine->max_recursion_level;
-    cctx.recursion_stack      = calloc(sizeof(cli_scan_layer_t), cctx.recursion_stack_size);
+    cctx.recursion_stack      = calloc(cctx.recursion_stack_size, sizeof(cli_scan_layer_t));
     ck_assert_msg(!!cctx.recursion_stack, "calloc() for recursion_stack failed");
 
     // ctx was memset, so recursion_level starts at 0.

--- a/unit_tests/check_clamav.c
+++ b/unit_tests/check_clamav.c
@@ -73,7 +73,7 @@ START_TEST(test_cl_build)
 {
     // struct cl_engine *engine;
     // ck_assert_msg(CL_ENULLARG == cl_build(NULL), "cl_build null pointer");
-    // engine = calloc(sizeof(struct cl_engine),1);
+    // engine = calloc(1, sizeof(struct cl_engine));
     // ck_assert_msg(engine, "cl_build calloc");
     // ck_assert_msg(CL_ENULLARG == cl_build(engine), "cl_build(engine) with null ->root");
 

--- a/unit_tests/check_matchers.c
+++ b/unit_tests/check_matchers.c
@@ -172,7 +172,7 @@ static void setup(void)
     ctx.dconf = ctx.engine->dconf;
 
     ctx.recursion_stack_size = ctx.engine->max_recursion_level;
-    ctx.recursion_stack      = calloc(sizeof(cli_scan_layer_t), ctx.recursion_stack_size);
+    ctx.recursion_stack      = calloc(ctx.recursion_stack_size, sizeof(cli_scan_layer_t));
     ck_assert_msg(!!ctx.recursion_stack, "calloc() for recursion_stack failed");
 
     // ctx was memset, so recursion_level starts at 0.

--- a/unit_tests/check_regex.c
+++ b/unit_tests/check_regex.c
@@ -410,7 +410,7 @@ static void do_phishing_test(const struct rtest *rtest)
     ctx.engine = engine;
 
     ctx.recursion_stack_size = ctx.engine->max_recursion_level;
-    ctx.recursion_stack      = calloc(sizeof(cli_scan_layer_t), ctx.recursion_stack_size);
+    ctx.recursion_stack      = calloc(ctx.recursion_stack_size, sizeof(cli_scan_layer_t));
     ck_assert_msg(!!ctx.recursion_stack, "calloc() for recursion_stack failed");
 
     rc = phishingScan(&ctx, &hrefs);
@@ -505,7 +505,7 @@ static void do_phishing_test_allscan(const struct rtest *rtest)
     ctx.engine = engine;
 
     ctx.recursion_stack_size = ctx.engine->max_recursion_level;
-    ctx.recursion_stack      = calloc(sizeof(cli_scan_layer_t), ctx.recursion_stack_size);
+    ctx.recursion_stack      = calloc(ctx.recursion_stack_size, sizeof(cli_scan_layer_t));
     ck_assert_msg(!!ctx.recursion_stack, "calloc() for recursion_stack failed");
 
     rc = phishingScan(&ctx, &hrefs);


### PR DESCRIPTION
Fixes #1740 