### PR TITLE
Libclamav: copy HWPML callback attributes

### DIFF
--- a/libclamav/msxml_parser.c
+++ b/libclamav/msxml_parser.c
@@ -55,6 +55,19 @@
         }                                                                    \
     } while (0)
 
+#define check_state_goto(state, label)                                       \
+    do {                                                                     \
+        if (state == -1) {                                                   \
+            cli_warnmsg("check_state[msxml]: CL_EPARSE @ ln%d\n", __LINE__); \
+            status = CL_EPARSE;                                              \
+            goto label;                                                      \
+        } else if (state == 0) {                                             \
+            cli_dbgmsg("check_state[msxml]: CL_BREAK @ ln%d\n", __LINE__);   \
+            status = CL_BREAK;                                               \
+            goto label;                                                      \
+        }                                                                    \
+    } while (0)
+
 #define track_json(mxctx) (mxctx->ictx->flags & MSXML_FLAG_JSON)
 
 struct msxml_ictx {
@@ -157,13 +170,58 @@ static int msxml_parse_value(json_object *wrkptr, const char *arrname, const xml
 }
 
 #define MAX_ATTRIBS 20
+
+/**
+ * @brief Free owned attribute strings for scan callbacks.
+ */
+static void msxml_free_attribs(struct attrib_entry *attribs, int num_attribs)
+{
+    int i;
+
+    if (!attribs)
+        return;
+
+    for (i = 0; i < num_attribs; i++) {
+        xmlFree((xmlChar *)attribs[i].key);
+        xmlFree((xmlChar *)attribs[i].value);
+        attribs[i].key   = NULL;
+        attribs[i].value = NULL;
+    }
+}
+
+/**
+ * @brief Copy the current XML reader attribute for later scan-callback use.
+ */
+static cl_error_t msxml_read_attrib(xmlTextReaderPtr reader, struct attrib_entry *attrib)
+{
+    xmlChar *key;
+    xmlChar *value;
+
+    if (!reader || !attrib)
+        return CL_ENULLARG;
+
+    key   = xmlTextReaderLocalName(reader);
+    value = xmlTextReaderValue(reader);
+    if (!key || !value) {
+        xmlFree(key);
+        xmlFree(value);
+        return CL_EMEM;
+    }
+
+    attrib->key   = (const char *)key;
+    attrib->value = (const char *)value;
+
+    return CL_SUCCESS;
+}
+
 static cl_error_t msxml_parse_element(struct msxml_ctx *mxctx, xmlTextReaderPtr reader, int rlvl, void *jptr)
 {
     const xmlChar *element_name = NULL;
     const xmlChar *node_name = NULL, *node_value = NULL;
     const struct key_entry *keyinfo;
-    struct attrib_entry attribs[MAX_ATTRIBS];
-    cl_error_t ret;
+    struct attrib_entry attribs[MAX_ATTRIBS] = {{0}};
+    cl_error_t status = CL_SUCCESS;
+    cl_error_t ret = CL_SUCCESS;
     int state, node_type, endtag = 0, num_attribs = 0;
     cli_ctx *ctx = mxctx->ictx->ctx;
 
@@ -296,67 +354,87 @@ static cl_error_t msxml_parse_element(struct msxml_ctx *mxctx, xmlTextReaderPtr 
                 }
             }
 
-            /* populate attributes for scanning callback - BROKEN, probably from the fact the reader is pointed to the attribute from previously parsing attributes */
+            /*
+             * Populate attributes for the scanning callback. The callback runs
+             * after the reader advances through child nodes, so keep owned
+             * copies instead of xmlTextReaderConst* pointers tied to reader
+             * state.
+             */
             if ((keyinfo->type & MSXML_SCAN_CB) && mxctx->scan_cb) {
-                state = xmlTextReaderHasAttributes(reader);
-                if (state == 0) {
-                    state = xmlTextReaderMoveToFirstAttribute(reader);
-                    if (state == 1) {
-                        /* read first attribute (current head) */
-                        attribs[num_attribs].key   = (const char *)xmlTextReaderConstLocalName(reader);
-                        attribs[num_attribs].value = (const char *)xmlTextReaderConstValue(reader);
-                        num_attribs++;
-                    } else if (state == -1) {
-                        return CL_EPARSE;
-                    }
+                state = xmlTextReaderMoveToElement(reader);
+                if (state == -1) {
+                    status = CL_EPARSE;
+                    goto done;
                 }
 
-                /* start reading attributes or read remainder of attributes */
+                state = xmlTextReaderHasAttributes(reader);
                 if (state == 1) {
                     cli_msxmlmsg("msxml_parse_element: adding attributes to scanning context\n");
 
-                    while ((num_attribs < MAX_ATTRIBS) && (xmlTextReaderMoveToNextAttribute(reader) == 1)) {
-                        attribs[num_attribs].key   = (const char *)xmlTextReaderConstLocalName(reader);
-                        attribs[num_attribs].value = (const char *)xmlTextReaderConstValue(reader);
+                    state = xmlTextReaderMoveToFirstAttribute(reader);
+                    while ((state == 1) && (num_attribs < MAX_ATTRIBS)) {
+                        ret = msxml_read_attrib(reader, &attribs[num_attribs]);
+                        if (ret != CL_SUCCESS) {
+                            status = ret;
+                            goto done;
+                        }
                         num_attribs++;
+
+                        state = xmlTextReaderMoveToNextAttribute(reader);
+                    }
+
+                    if (state == -1) {
+                        status = CL_EPARSE;
+                        goto done;
                     }
                 } else if (state == -1) {
-                    return CL_EPARSE;
+                    status = CL_EPARSE;
+                    goto done;
                 }
             }
 
             /* check self-containment */
             state = xmlTextReaderMoveToElement(reader);
-            if (state == -1)
-                return CL_EPARSE;
+            if (state == -1) {
+                status = CL_EPARSE;
+                goto done;
+            }
 
             state = xmlTextReaderIsEmptyElement(reader);
             if (state == 1) {
                 cli_msxmlmsg("msxml_parse_element: SELF-CLOSING\n");
 
                 state = xmlTextReaderNext(reader);
-                check_state(state);
-                return CL_SUCCESS;
-            } else if (state == -1)
-                return CL_EPARSE;
+                check_state_goto(state, done);
+                status = CL_SUCCESS;
+                goto done;
+            } else if (state == -1) {
+                status = CL_EPARSE;
+                goto done;
+            }
 
             /* advance to first content node */
             state = xmlTextReaderRead(reader);
-            check_state(state);
+            check_state_goto(state, done);
 
             while (!endtag) {
-                if (track_json(mxctx) && (cli_json_timeout_cycle_check(ctx, &(mxctx->ictx->toval)) != CL_SUCCESS))
-                    return CL_ETIMEOUT;
+                if (track_json(mxctx) && (cli_json_timeout_cycle_check(ctx, &(mxctx->ictx->toval)) != CL_SUCCESS)) {
+                    status = CL_ETIMEOUT;
+                    goto done;
+                }
 
                 node_type = xmlTextReaderNodeType(reader);
-                if (node_type == -1)
-                    return CL_EPARSE;
+                if (node_type == -1) {
+                    status = CL_EPARSE;
+                    goto done;
+                }
 
                 switch (node_type) {
                     case XML_READER_TYPE_ELEMENT:
                         ret = msxml_parse_element(mxctx, reader, rlvl + 1, thisjobj ? thisjobj : parent);
                         if (ret != CL_SUCCESS) {
-                            return ret;
+                            status = ret;
+                            goto done;
                         }
                         break;
 
@@ -368,8 +446,10 @@ static cl_error_t msxml_parse_element(struct msxml_ctx *mxctx, xmlTextReaderPtr 
                         if (thisjobj && (keyinfo->type & MSXML_JSON_VALUE)) {
 
                             ret = msxml_parse_value(thisjobj, "Value", node_value);
-                            if (ret != CL_SUCCESS)
-                                return ret;
+                            if (ret != CL_SUCCESS) {
+                                status = ret;
+                                goto done;
+                            }
 
                             cli_msxmlmsg("msxml_parse_element: added json value [%s: %s]\n", keyinfo->name, (const char *)node_value);
                         }
@@ -385,7 +465,8 @@ static cl_error_t msxml_parse_element(struct msxml_ctx *mxctx, xmlTextReaderPtr 
 
                             if ((ret = cli_gentempfd(ctx->this_layer_tmpdir, &tempfile, &of)) != CL_SUCCESS) {
                                 cli_warnmsg("msxml_parse_element: failed to create temporary file %s\n", tempfile);
-                                return ret;
+                                status = ret;
+                                goto done;
                             }
 
                             if (cli_writen(of, (char *)node_value, vlen) != vlen) {
@@ -393,7 +474,8 @@ static cl_error_t msxml_parse_element(struct msxml_ctx *mxctx, xmlTextReaderPtr 
                                 if (!(ctx->engine->keeptmp))
                                     cli_unlink(tempfile);
                                 free(tempfile);
-                                return CL_EWRITE;
+                                status = CL_EWRITE;
+                                goto done;
                             }
 
                             cli_dbgmsg("msxml_parse_element: extracted binary data to %s\n", tempfile);
@@ -405,7 +487,8 @@ static cl_error_t msxml_parse_element(struct msxml_ctx *mxctx, xmlTextReaderPtr 
                             }
                             free(tempfile);
                             if (ret != CL_SUCCESS) {
-                                return ret;
+                                status = ret;
+                                goto done;
                             }
                         }
 
@@ -422,14 +505,15 @@ static cl_error_t msxml_parse_element(struct msxml_ctx *mxctx, xmlTextReaderPtr 
                             if (!decoded) {
                                 cli_warnmsg("msxml_parse_element: failed to decode base64-encoded binary data\n");
                                 state = xmlTextReaderRead(reader);
-                                check_state(state);
+                                check_state_goto(state, done);
                                 break;
                             }
 
                             if ((ret = cli_gentempfd(ctx->this_layer_tmpdir, &tempfile, &of)) != CL_SUCCESS) {
                                 cli_warnmsg("msxml_parse_element: failed to create temporary file %s\n", tempfile);
                                 free(decoded);
-                                return ret;
+                                status = ret;
+                                goto done;
                             }
 
                             if (cli_writen(of, decoded, decodedlen) != decodedlen) {
@@ -438,7 +522,8 @@ static cl_error_t msxml_parse_element(struct msxml_ctx *mxctx, xmlTextReaderPtr 
                                 if (!(ctx->engine->keeptmp))
                                     cli_unlink(tempfile);
                                 free(tempfile);
-                                return CL_EWRITE;
+                                status = CL_EWRITE;
+                                goto done;
                             }
                             free(decoded);
 
@@ -450,13 +535,14 @@ static cl_error_t msxml_parse_element(struct msxml_ctx *mxctx, xmlTextReaderPtr 
                                 cli_unlink(tempfile);
                             free(tempfile);
                             if (ret != CL_SUCCESS) {
-                                return ret;
+                                status = ret;
+                                goto done;
                             }
                         }
 
                         /* advance to next node */
                         state = xmlTextReaderRead(reader);
-                        check_state(state);
+                        check_state_goto(state, done);
                         break;
 
                     case XML_READER_TYPE_COMMENT:
@@ -468,19 +554,20 @@ static cl_error_t msxml_parse_element(struct msxml_ctx *mxctx, xmlTextReaderPtr 
                         if ((keyinfo->type & MSXML_COMMENT_CB) && mxctx->comment_cb) {
                             ret = mxctx->comment_cb((const char *)node_value, ctx, thisjobj, mxctx->comment_data);
                             if (ret != CL_SUCCESS) {
-                                return ret;
+                                status = ret;
+                                goto done;
                             }
                         }
 
                         /* advance to next node */
                         state = xmlTextReaderRead(reader);
-                        check_state(state);
+                        check_state_goto(state, done);
                         break;
 
                     case XML_READER_TYPE_SIGNIFICANT_WHITESPACE:
                         /* advance to next node */
                         state = xmlTextReaderRead(reader);
-                        check_state(state);
+                        check_state_goto(state, done);
                         break;
 
                     case XML_READER_TYPE_END_ELEMENT:
@@ -488,17 +575,19 @@ static cl_error_t msxml_parse_element(struct msxml_ctx *mxctx, xmlTextReaderPtr 
                         node_name = xmlTextReaderConstLocalName(reader);
                         if (!node_name) {
                             cli_dbgmsg("msxml_parse_element: element end tag node nameless\n");
-                            return CL_EPARSE; /* no name, nameless */
+                            status = CL_EPARSE;
+                            goto done; /* no name, nameless */
                         }
 
                         if (xmlStrcmp(element_name, node_name)) {
                             cli_dbgmsg("msxml_parse_element: element tag does not match end tag %s != %s\n", element_name, node_name);
-                            return CL_EFORMAT;
+                            status = CL_EFORMAT;
+                            goto done;
                         }
 
                         /* advance to next element tag */
                         state = xmlTextReaderRead(reader);
-                        check_state(state);
+                        check_state_goto(state, done);
 
                         endtag = 1;
                         break;
@@ -510,7 +599,7 @@ static cl_error_t msxml_parse_element(struct msxml_ctx *mxctx, xmlTextReaderPtr 
                         cli_dbgmsg("msxml_parse_element: unhandled xml secondary node %s [%d]: %s\n", node_name, node_type, node_value);
 
                         state = xmlTextReaderRead(reader);
-                        check_state(state);
+                        check_state_goto(state, done);
                 }
             }
 
@@ -528,7 +617,9 @@ static cl_error_t msxml_parse_element(struct msxml_ctx *mxctx, xmlTextReaderPtr 
             cli_dbgmsg("msxml_parse_element: unhandled xml primary node %s [%d]: %s\n", node_name, node_type, node_value);
     }
 
-    return CL_SUCCESS;
+done:
+    msxml_free_attribs(attribs, num_attribs);
+    return status;
 }
 
 /* reader initialization and closing handled by caller */

--- a/libclamav/ooxml.c
+++ b/libclamav/ooxml.c
@@ -176,13 +176,31 @@ static cl_error_t ooxml_extn_cb(int fd, const char *filepath, cli_ctx *ctx, cons
     return ret;
 }
 
+/**
+ * Copy an XML attribute value that must outlive the current text reader call.
+ */
+static cl_error_t ooxml_copy_attr_value(xmlChar **dst, const xmlChar *value)
+{
+    xmlChar *copy = xmlStrdup(value);
+
+    if (copy == NULL)
+        return CL_EMEM;
+
+    xmlFree(*dst);
+    *dst = copy;
+
+    return CL_SUCCESS;
+}
+
 static cl_error_t ooxml_content_cb(int fd, const char *filepath, cli_ctx *ctx, const char *name, uint32_t attributes)
 {
-    cl_error_t ret = CL_SUCCESS;
+    cl_error_t status = CL_SUCCESS;
+    cl_error_t ret    = CL_SUCCESS;
     int tmp, toval = 0, state;
     int core = 0, extn = 0, cust = 0, dsig = 0;
     int mcore = 0, mextn = 0, mcust = 0;
-    const xmlChar *localname, *value, *CT, *PN;
+    const xmlChar *localname, *value;
+    xmlChar *CT = NULL, *PN = NULL;
     xmlTextReaderPtr reader = NULL;
     uint32_t loff;
 
@@ -216,8 +234,8 @@ static cl_error_t ooxml_content_cb(int fd, const char *filepath, cli_ctx *ctx, c
     /* locate core-properties, extended-properties, and custom-properties (optional) */
     while ((state = xmlTextReaderRead(reader)) == 1) {
         if (cli_json_timeout_cycle_check(ctx, &toval) != CL_SUCCESS) {
-            ret = CL_ETIMEOUT;
-            goto ooxml_content_exit;
+            status = CL_ETIMEOUT;
+            goto done;
         }
 
         localname = xmlTextReaderConstLocalName(reader);
@@ -227,6 +245,8 @@ static cl_error_t ooxml_content_cb(int fd, const char *filepath, cli_ctx *ctx, c
 
         if (xmlTextReaderHasAttributes(reader) != 1) continue;
 
+        xmlFree(CT);
+        xmlFree(PN);
         CT = PN = NULL;
         while (xmlTextReaderMoveToNextAttribute(reader) == 1) {
             localname = xmlTextReaderConstLocalName(reader);
@@ -234,9 +254,17 @@ static cl_error_t ooxml_content_cb(int fd, const char *filepath, cli_ctx *ctx, c
             if (localname == NULL || value == NULL) continue;
 
             if (!xmlStrcmp(localname, (const xmlChar *)"ContentType")) {
-                CT = value;
+                ret = ooxml_copy_attr_value(&CT, value);
+                if (ret != CL_SUCCESS) {
+                    status = ret;
+                    goto done;
+                }
             } else if (!xmlStrcmp(localname, (const xmlChar *)"PartName")) {
-                PN = value;
+                ret = ooxml_copy_attr_value(&PN, value);
+                if (ret != CL_SUCCESS) {
+                    status = ret;
+                    goto done;
+                }
             }
 
             cli_dbgmsg("%s: %s\n", localname, value);
@@ -248,7 +276,7 @@ static cl_error_t ooxml_content_cb(int fd, const char *filepath, cli_ctx *ctx, c
             /* default: /docProps/core.xml*/
             tmp = unzip_search_single(ctx, (const char *)(PN + 1), xmlStrlen(PN) - 1, &loff);
             if (tmp == CL_ETIMEOUT) {
-                ret = tmp;
+                status = tmp;
             } else if (tmp != CL_VIRUS) {
                 cli_dbgmsg("cli_process_ooxml: failed to find core properties file \"%s\"!\n", PN);
                 mcore++;
@@ -257,7 +285,7 @@ static cl_error_t ooxml_content_cb(int fd, const char *filepath, cli_ctx *ctx, c
                 if (!core) {
                     tmp = unzip_single_internal(ctx, loff, ooxml_core_cb);
                     if (tmp == CL_ETIMEOUT || tmp == CL_EMEM) {
-                        ret = tmp;
+                        status = tmp;
                     }
                 }
                 core++;
@@ -266,7 +294,7 @@ static cl_error_t ooxml_content_cb(int fd, const char *filepath, cli_ctx *ctx, c
             /* default: /docProps/app.xml */
             tmp = unzip_search_single(ctx, (const char *)(PN + 1), xmlStrlen(PN) - 1, &loff);
             if (tmp == CL_ETIMEOUT) {
-                ret = tmp;
+                status = tmp;
             } else if (tmp != CL_VIRUS) {
                 cli_dbgmsg("cli_process_ooxml: failed to find extended properties file \"%s\"!\n", PN);
                 mextn++;
@@ -275,7 +303,7 @@ static cl_error_t ooxml_content_cb(int fd, const char *filepath, cli_ctx *ctx, c
                 if (!extn) {
                     tmp = unzip_single_internal(ctx, loff, ooxml_extn_cb);
                     if (tmp == CL_ETIMEOUT || tmp == CL_EMEM) {
-                        ret = tmp;
+                        status = tmp;
                     }
                 }
                 extn++;
@@ -284,7 +312,7 @@ static cl_error_t ooxml_content_cb(int fd, const char *filepath, cli_ctx *ctx, c
             /* default: /docProps/custom.xml */
             tmp = unzip_search_single(ctx, (const char *)(PN + 1), xmlStrlen(PN) - 1, &loff);
             if (tmp == CL_ETIMEOUT) {
-                ret = tmp;
+                status = tmp;
             } else if (tmp != CL_VIRUS) {
                 cli_dbgmsg("cli_process_ooxml: failed to find custom properties file \"%s\"!\n", PN);
                 mcust++;
@@ -297,11 +325,11 @@ static cl_error_t ooxml_content_cb(int fd, const char *filepath, cli_ctx *ctx, c
             dsig++;
         }
 
-        if (ret != CL_SUCCESS)
-            goto ooxml_content_exit;
+        if (status != CL_SUCCESS)
+            goto done;
     }
 
-ooxml_content_exit:
+done:
     if (core) {
         cli_jsonint(ctx->this_layer_metadata_json, "CorePropertiesFileCount", core);
         if (core > 1)
@@ -343,9 +371,11 @@ ooxml_content_exit:
     ctx->scansize     = sav_scansize;
     ctx->scannedfiles = sav_scannedfiles;
 
+    xmlFree(CT);
+    xmlFree(PN);
     xmlTextReaderClose(reader);
     xmlFreeTextReader(reader);
-    return ret;
+    return status;
 }
 
 static cl_error_t ooxml_hwp_cb(int fd, const char *filepath, cli_ctx *ctx, const char *name, uint32_t attributes)

--- a/libclamav/ooxml.c
+++ b/libclamav/ooxml.c
@@ -248,26 +248,42 @@ static cl_error_t ooxml_content_cb(int fd, const char *filepath, cli_ctx *ctx, c
         xmlFree(CT);
         xmlFree(PN);
         CT = PN = NULL;
-        while (xmlTextReaderMoveToNextAttribute(reader) == 1) {
+
+        state = xmlTextReaderMoveToFirstAttribute(reader);
+        while (state == 1) {
             localname = xmlTextReaderConstLocalName(reader);
             value     = xmlTextReaderConstValue(reader);
-            if (localname == NULL || value == NULL) continue;
 
-            if (!xmlStrcmp(localname, (const xmlChar *)"ContentType")) {
-                ret = ooxml_copy_attr_value(&CT, value);
-                if (ret != CL_SUCCESS) {
-                    status = ret;
-                    goto done;
+            if (localname != NULL && value != NULL) {
+                if (!xmlStrcmp(localname, (const xmlChar *)"ContentType")) {
+                    ret = ooxml_copy_attr_value(&CT, value);
+                    if (ret != CL_SUCCESS) {
+                        status = ret;
+                        goto done;
+                    }
+                } else if (!xmlStrcmp(localname, (const xmlChar *)"PartName")) {
+                    ret = ooxml_copy_attr_value(&PN, value);
+                    if (ret != CL_SUCCESS) {
+                        status = ret;
+                        goto done;
+                    }
                 }
-            } else if (!xmlStrcmp(localname, (const xmlChar *)"PartName")) {
-                ret = ooxml_copy_attr_value(&PN, value);
-                if (ret != CL_SUCCESS) {
-                    status = ret;
-                    goto done;
-                }
+
+                cli_dbgmsg("%s: %s\n", localname, value);
             }
 
-            cli_dbgmsg("%s: %s\n", localname, value);
+            state = xmlTextReaderMoveToNextAttribute(reader);
+        }
+
+        if (state == -1) {
+            status = CL_EPARSE;
+            goto done;
+        }
+
+        state = xmlTextReaderMoveToElement(reader);
+        if (state == -1) {
+            status = CL_EPARSE;
+            goto done;
         }
 
         if (!CT || !PN) continue;


### PR DESCRIPTION
The MSXML parser stored libxml2 reader-owned attribute name and value pointers for HWPML scan callbacks. The callback runs after the reader has advanced through child nodes, so libxml2 can invalidate that storage before the HWPML callback compares the saved attributes.

Copy callback attributes with the non-Const reader APIs and release the owned strings when leaving the element parser. This keeps callback attribute lifetimes independent from the reader state while leaving immediate-use xmlTextReaderConst* paths unchanged.

We do not believe this is a security concern. The stale pointer is only read by strcmp() while checking attribute strings; there is no write-after-free, function pointer use, or disclosure path, and a non-sanitized scan did not reproduce a crash. Treat this as a hardening fix rather than a security fix.

Reported by David Pokora and Evan Sultanik of Trail of Bits, working with Anthropic.

CLAM-2993