### PR TITLE
CLAM-3013: Report scan alert results consistently

### DIFF
--- a/examples/ex_scan_callbacks.c
+++ b/examples/ex_scan_callbacks.c
@@ -1474,7 +1474,13 @@ int main(int argc, char **argv)
     }
     printf("Return Code:  %s (%d)\n", cl_error_t_to_string(ret), ret);
 
-    status = ret == CL_VIRUS ? 1 : 0;
+    if (CL_SUCCESS == ret) {
+        status = 0;
+    } else if (CL_VIRUS == ret) {
+        status = 1;
+    } else {
+        status = 2;
+    }
 
 done:
 

--- a/libclamav/clamav.h
+++ b/libclamav/clamav.h
@@ -1458,8 +1458,8 @@ extern cl_error_t cl_scandesc_callback(
  * @param filename           (Optional) Filepath of the open file descriptor or file map.
  * @param[out] verdict_out   A pointer to a cl_verdict_t that will be set to the scan verdict.
  *                           You should check the verdict even if the function returns an error.
- * @param[out] last_alert_out Will be set to a statically allocated (i.e. needs not be freed) signature name if the scan
- *                           matches against a signature.
+ * @param[out] last_alert_out (Optional) Will be set to a statically allocated (i.e. does not need to be freed)
+ *                           signature name if the scan matches against a signature.
  * @param[out] scanned_out   The (exact) number of bytes scanned.
  * @param engine             The scanning engine.
  * @param scanoptions        Scanning options.
@@ -1481,9 +1481,10 @@ extern cl_error_t cl_scandesc_callback(
  *                           of the top layer as determined by ClamAV.
  *                           Will take the form of the standard ClamAV file type format. E.g. "CL_TYPE_PE".
  *                           See also: https://docs.clamav.net/appendix/FileTypes.html#file-types
- * @return cl_error_t        CL_SUCCESS if no error occured.
+ * @return cl_error_t        CL_SUCCESS if no error occurred.
  *                           Otherwise a CL_E* error code.
- *                           Does NOT return CL_VIRUS for a signature match. Check the `verdict_out` parameter instead.
+ *                           Detection-only matches are reported through `verdict_out`; this function does not return
+ *                           CL_VIRUS for a signature match.
  */
 extern cl_error_t cl_scandesc_ex(
     int desc,
@@ -1558,8 +1559,8 @@ extern cl_error_t cl_scanfile_callback(
  * @param filename           Filepath of the file to be scanned.
  * @param[out] verdict_out   A pointer to a cl_verdict_t that will be set to the scan verdict.
  *                           You should check the verdict even if the function returns an error.
- * @param[out] last_alert_out Will be set to a statically allocated (i.e. needs not be freed) signature name if the scan
- *                           matches against a signature.
+ * @param[out] last_alert_out (Optional) Will be set to a statically allocated (i.e. does not need to be freed)
+ *                           signature name if the scan matches against a signature.
  * @param[out] scanned_out   The (exact) number of bytes scanned.
  * @param engine             The scanning engine.
  * @param scanoptions        Scanning options.
@@ -1581,9 +1582,10 @@ extern cl_error_t cl_scanfile_callback(
  *                           of the top layer as determined by ClamAV.
  *                           Will take the form of the standard ClamAV file type format. E.g. "CL_TYPE_PE".
  *                           See also: https://docs.clamav.net/appendix/FileTypes.html#file-types
- * @return cl_error_t        CL_SUCCESS if no error occured.
+ * @return cl_error_t        CL_SUCCESS if no error occurred.
  *                           Otherwise a CL_E* error code.
- *                           Does NOT return CL_VIRUS for a signature match. Check the `verdict_out` parameter instead.
+ *                           Detection-only matches are reported through `verdict_out`; this function does not return
+ *                           CL_VIRUS for a signature match.
  */
 extern cl_error_t cl_scanfile_ex(
     const char *filename,
@@ -1656,8 +1658,8 @@ extern cl_error_t cl_scanmap_callback(
  *                           May be NULL if a name is not available.
  * @param[out] verdict_out   A pointer to a cl_verdict_t that will be set to the scan verdict.
  *                           You should check the verdict even if the function returns an error.
- * @param[out] last_alert_out Will be set to a statically allocated (i.e. needs not be freed) signature name if the scan
- *                           matches against a signature.
+ * @param[out] last_alert_out (Optional) Will be set to a statically allocated (i.e. does not need to be freed)
+ *                           signature name if the scan matches against a signature.
  * @param[out] scanned_out   The (exact) number of bytes scanned.
  * @param engine             The scanning engine.
  * @param scanoptions        Scanning options.
@@ -1679,9 +1681,10 @@ extern cl_error_t cl_scanmap_callback(
  *                           of the top layer as determined by ClamAV.
  *                           Will take the form of the standard ClamAV file type format. E.g. "CL_TYPE_PE".
  *                           See also: https://docs.clamav.net/appendix/FileTypes.html#file-types
- * @return cl_error_t        CL_SUCCESS if no error occured.
+ * @return cl_error_t        CL_SUCCESS if no error occurred.
  *                           Otherwise a CL_E* error code.
- *                           Does NOT return CL_VIRUS for a signature match. Check the `verdict_out` parameter instead.
+ *                           Detection-only matches are reported through `verdict_out`; this function does not return
+ *                           CL_VIRUS for a signature match.
  */
 extern cl_error_t cl_scanmap_ex(
     cl_fmap_t *map,

--- a/libclamav/others.c
+++ b/libclamav/others.c
@@ -1363,9 +1363,53 @@ cl_error_t cli_unlink(const char *pathname)
     return CL_SUCCESS;
 }
 
-cl_error_t cli_virus_found_cb(cli_ctx *ctx, const char *virname, bool is_potentially_unwanted)
+cl_error_t cli_virus_found_cb_with_fd(
+    cli_ctx *ctx,
+    const char *virname,
+    IndicatorType indicator_type,
+    int legacy_virus_found_fd);
+static const char *indicator_type_metadata_name(IndicatorType type);
+static cl_error_t metadata_mark_alert_ignored(cli_ctx *ctx, const char *virname, IndicatorType indicator_type);
+
+/**
+ * @brief Dispatch the alert / virus found callbacks.
+ *
+ * For clamscan this prints the FOUND message.
+ *
+ * @param ctx            The scan context.
+ * @param virname        The name of the alert.
+ * @param indicator_type The evidence indicator type for the alert.
+ * @return cl_error_t    CL_SUCCESS if the callback ignored the alert, CL_VIRUS
+ *                       if the alert remains, CL_BREAK or CL_VERIFIED if
+ *                       requested by the callback, or a CL_E* error code.
+ */
+cl_error_t cli_virus_found_cb(cli_ctx *ctx, const char *virname, IndicatorType indicator_type)
+{
+    int legacy_virus_found_fd = -1;
+
+    if (ctx && ctx->fmap) {
+        legacy_virus_found_fd = fmap_fd(ctx->fmap);
+    }
+
+    return cli_virus_found_cb_with_fd(ctx, virname, indicator_type, legacy_virus_found_fd);
+}
+
+/**
+ * @brief Dispatch the alert / virus found callbacks with an explicit file descriptor
+ *        for the deprecated legacy virus-found callback.
+ *
+ * @param ctx                   The scan context.
+ * @param virname               The name of the alert.
+ * @param indicator_type        The evidence indicator type for the alert.
+ * @param legacy_virus_found_fd File descriptor for the deprecated clcb_virus_found callback.
+ * @return cl_error_t           CL_SUCCESS if the callback ignored the alert, CL_VIRUS
+ *                              if the alert remains, CL_BREAK or CL_VERIFIED if
+ *                              requested by the callback, or a CL_E* error code.
+ */
+cl_error_t cli_virus_found_cb_with_fd(cli_ctx *ctx, const char *virname, IndicatorType indicator_type, int legacy_virus_found_fd)
 {
     cl_error_t status = CL_VIRUS;
+    FFIError *remove_indicator_error = NULL;
 
     if (!ctx || !virname) {
         return CL_ENULLARG;
@@ -1374,7 +1418,7 @@ cl_error_t cli_virus_found_cb(cli_ctx *ctx, const char *virname, bool is_potenti
     /* Run deprecated legacy virus callback */
     if (ctx->engine->cb_virus_found) {
         ctx->engine->cb_virus_found(
-            fmap_fd(ctx->fmap),
+            legacy_virus_found_fd,
             virname,
             ctx->cb_ctx);
     }
@@ -1386,84 +1430,183 @@ cl_error_t cli_virus_found_cb(cli_ctx *ctx, const char *virname, bool is_potenti
         // An alert callback returning CL_CLEAN means to ignore this alert and keep scanning.
         // We need to remove the last alerting indicator from the evidence.
         bool remove_successful;
-        FFIError *remove_indicator_error = NULL;
 
         remove_successful = evidence_remove_indicator(
             ctx->this_layer_evidence,
             virname,
-            is_potentially_unwanted ? IndicatorType_PotentiallyUnwanted : IndicatorType_Strong,
+            indicator_type,
             &remove_indicator_error);
         if (!remove_successful) {
-            cli_errmsg("cli_virus_found_cb: Failed to remove indicator from scan evidence: %s\n", ffierror_fmt(remove_indicator_error));
+            const char *error_msg = (NULL != remove_indicator_error)
+                                        ? ffierror_fmt(remove_indicator_error)
+                                        : "unknown error";
+            cli_errmsg("cli_virus_found_cb: Failed to remove indicator from scan evidence: %s\n", error_msg);
             status = CL_ERROR;
             goto done;
         }
 
         if (SCAN_COLLECT_METADATA && ctx->this_layer_metadata_json) {
-            // Remove the last alert from the "Alerts" array.
-            json_object *alerts = NULL;
-            if (json_object_object_get_ex(ctx->this_layer_metadata_json, "Alerts", &alerts)) {
-                int json_ret = 0;
-
-                // Get the index of the last alert.
-                size_t num_alerts = json_object_array_length(alerts);
-                if (0 == num_alerts) {
-                    cli_errmsg("cli_virus_found_cb: Attempting to ignore an alert, but alert not found in metadata Alerts array.\n");
-                    status = CL_ERROR;
-                    goto done;
-                }
-
-                // Remove the alert from the Alerts array.
-                json_ret = json_object_array_del_idx(alerts, num_alerts - 1, 1);
-                if (0 != json_ret) {
-                    cli_errmsg("cli_virus_found_cb: Failed to remove alert from metadata JSON.\n");
-                    status = CL_ERROR;
-                    goto done;
-                }
-
-                // If there aren't any other alerts, we should also delete the "Alerts" array.
-                if (num_alerts == 1) {
-                    json_object_object_del(ctx->this_layer_metadata_json, "Alerts");
-                }
-            }
-
-            // Add "Ignored" key to the last alert from the "Indicators" array.
-            json_object *indicators = NULL;
-            if (json_object_object_get_ex(ctx->this_layer_metadata_json, "Indicators", &indicators)) {
-                int json_ret = 0;
-
-                // Get the index of the last indicator.
-                size_t num_indicators = json_object_array_length(indicators);
-                if (0 == num_indicators) {
-                    cli_errmsg("cli_virus_found_cb: Attempting to ignore an alert, but alert not found in metadata Alerts array.\n");
-                    status = CL_ERROR;
-                    goto done;
-                }
-
-                // Get the last indicator.
-                json_object *indicator_obj = json_object_array_get_idx(indicators, num_indicators - 1);
-                if (NULL == indicator_obj) {
-                    cli_errmsg("cli_virus_found_cb: Failed to get last indicator from Indicators array.\n");
-                    status = CL_ERROR;
-                    goto done;
-                }
-
-                // Add an "Ignored" string to the indicator object.
-                json_object *ignored = json_object_new_string("Signature ignored by alert application callback");
-                if (!ignored) {
-                    cli_errmsg("cli_virus_found_cb: no memory for json ignored indicator object\n");
-                    status = CL_EMEM;
-                    goto done;
-                }
-                json_ret = json_object_object_add(indicator_obj, "Ignored", ignored);
-                if (0 != json_ret) {
-                    cli_errmsg("cli_virus_found_cb: Failed to add Ignored boolean to indicator object\n");
-                    status = CL_ERROR;
-                    goto done;
-                }
+            status = metadata_mark_alert_ignored(ctx, virname, indicator_type);
+            if (CL_SUCCESS != status) {
+                goto done;
             }
         }
     }
+
+done:
+    if (NULL != remove_indicator_error) {
+        ffierror_free(remove_indicator_error);
+    }
+
+    return status;
+}
+
+static const char *indicator_type_metadata_name(IndicatorType type)
+{
+    switch (type) {
+        case IndicatorType_Strong:
+            return "Strong";
+        case IndicatorType_PotentiallyUnwanted:
+            return "PotentiallyUnwanted";
+        case IndicatorType_Weak:
+            return "Weak";
+    }
+
+    return NULL;
+}
+
+static bool metadata_indicator_matches(json_object *indicator_obj, const char *virname, const char *indicator_type_name)
+{
+    json_object *name_obj = NULL;
+    json_object *type_obj = NULL;
+
+    if ((NULL == indicator_obj) ||
+        !json_object_object_get_ex(indicator_obj, "Name", &name_obj) ||
+        !json_object_object_get_ex(indicator_obj, "Type", &type_obj)) {
+        return false;
+    }
+
+    if (!json_object_is_type(name_obj, json_type_string) ||
+        !json_object_is_type(type_obj, json_type_string)) {
+        return false;
+    }
+
+    return (0 == strcmp(json_object_get_string(name_obj), virname)) &&
+           (0 == strcmp(json_object_get_string(type_obj), indicator_type_name));
+}
+
+static bool metadata_find_matching_indicator(
+    json_object *indicators,
+    const char *virname,
+    const char *indicator_type_name,
+    size_t *index_out,
+    json_object **indicator_out)
+{
+    size_t i;
+
+    if ((NULL == indicators) || !json_object_is_type(indicators, json_type_array)) {
+        return false;
+    }
+
+    for (i = json_object_array_length(indicators); i > 0; i--) {
+        size_t index               = i - 1;
+        json_object *indicator_obj = json_object_array_get_idx(indicators, index);
+
+        if (!metadata_indicator_matches(indicator_obj, virname, indicator_type_name)) {
+            continue;
+        }
+
+        if (NULL != index_out) {
+            *index_out = index;
+        }
+        if (NULL != indicator_out) {
+            *indicator_out = indicator_obj;
+        }
+
+        return true;
+    }
+
+    return false;
+}
+
+static cl_error_t metadata_mark_indicator_ignored(json_object *indicator_obj)
+{
+    json_object *ignored = json_object_new_string("Signature ignored by alert application callback");
+    if (NULL == ignored) {
+        cli_errmsg("cli_virus_found_cb: no memory for json ignored indicator object\n");
+        return CL_EMEM;
+    }
+
+    if (0 != json_object_object_add(indicator_obj, "Ignored", ignored)) {
+        cli_errmsg("cli_virus_found_cb: Failed to add Ignored string to indicator object\n");
+        json_object_put(ignored);
+        return CL_ERROR;
+    }
+
+    return CL_SUCCESS;
+}
+
+static cl_error_t metadata_mark_alert_ignored(cli_ctx *ctx, const char *virname, IndicatorType indicator_type)
+{
+    cl_error_t status = CL_ERROR;
+    const char *indicator_type_name;
+    json_object *alerts = NULL;
+    json_object *indicators = NULL;
+    json_object *indicator_obj = NULL;
+    size_t alert_index = 0;
+    bool found_indicator;
+    bool found_alert;
+
+    indicator_type_name = indicator_type_metadata_name(indicator_type);
+    if (NULL == indicator_type_name) {
+        cli_errmsg("cli_virus_found_cb: invalid indicator type: %d\n", (int)indicator_type);
+        status = CL_EARG;
+        goto done;
+    }
+
+    /*
+     * Evidence removes the latest matching indicator for this name/type. Match
+     * metadata the same way instead of assuming the ignored alert is last.
+     */
+    if (!json_object_object_get_ex(ctx->this_layer_metadata_json, "Indicators", &indicators)) {
+        cli_errmsg("cli_virus_found_cb: missing metadata Indicators array for ignored alert '%s'\n", virname);
+        status = CL_ERROR;
+        goto done;
+    }
+    found_indicator = metadata_find_matching_indicator(indicators, virname, indicator_type_name, NULL, &indicator_obj);
+    if (!found_indicator) {
+        cli_errmsg("cli_virus_found_cb: failed to find matching metadata indicator for ignored alert '%s'\n", virname);
+        status = CL_ERROR;
+        goto done;
+    }
+
+    if (!json_object_object_get_ex(ctx->this_layer_metadata_json, "Alerts", &alerts)) {
+        cli_errmsg("cli_virus_found_cb: missing metadata Alerts array for ignored alert '%s'\n", virname);
+        status = CL_ERROR;
+        goto done;
+    }
+    found_alert = metadata_find_matching_indicator(alerts, virname, indicator_type_name, &alert_index, NULL);
+    if (!found_alert) {
+        cli_errmsg("cli_virus_found_cb: failed to find matching metadata alert for ignored alert '%s'\n", virname);
+        status = CL_ERROR;
+        goto done;
+    }
+
+    status = metadata_mark_indicator_ignored(indicator_obj);
+    if (CL_SUCCESS != status) {
+        goto done;
+    }
+
+    if (0 != json_object_array_del_idx(alerts, alert_index, 1)) {
+        cli_errmsg("cli_virus_found_cb: Failed to remove ignored alert from metadata JSON.\n");
+        status = CL_ERROR;
+        goto done;
+    }
+    if (0 == json_object_array_length(alerts)) {
+        json_object_object_del(ctx->this_layer_metadata_json, "Alerts");
+    }
+
+    status = CL_SUCCESS;
 
 done:
     return status;
@@ -1484,8 +1627,16 @@ static cl_error_t append_virus(cli_ctx *ctx, const char *virname, IndicatorType 
     cl_error_t status             = CL_ERROR;
     cl_error_t callback_ret       = CL_VIRUS;
     FFIError *add_indicator_error = NULL;
+    const char *indicator_type_name;
     bool add_successful;
     char *location = NULL;
+
+    indicator_type_name = indicator_type_metadata_name(type);
+    if (NULL == indicator_type_name) {
+        cli_errmsg("append_virus: invalid indicator type: %d\n", (int)type);
+        status = CL_EARG;
+        goto done;
+    }
 
     if (NULL == ctx->recursion_stack[ctx->recursion_level].evidence) {
         // evidence storage for this layer not initialized, initialize a new evidence store.
@@ -1505,7 +1656,10 @@ static cl_error_t append_virus(cli_ctx *ctx, const char *virname, IndicatorType 
         ctx->recursion_stack[ctx->recursion_level].object_id,
         &add_indicator_error);
     if (!add_successful) {
-        cli_errmsg("Failed to add indicator to scan evidence: %s\n", ffierror_fmt(add_indicator_error));
+        const char *error_msg = (NULL != add_indicator_error)
+                                    ? ffierror_fmt(add_indicator_error)
+                                    : "unknown error";
+        cli_errmsg("Failed to add indicator to scan evidence: %s\n", error_msg);
         status = CL_ERROR;
         goto done;
     }
@@ -1513,36 +1667,51 @@ static cl_error_t append_virus(cli_ctx *ctx, const char *virname, IndicatorType 
     if (SCAN_COLLECT_METADATA && ctx->this_layer_metadata_json) {
         // Add the indicator to the metadata.
         json_object *indicators = NULL;
+        json_object *indicator_obj = NULL;
+
         if (!json_object_object_get_ex(ctx->this_layer_metadata_json, "Indicators", &indicators)) {
             indicators = json_object_new_array();
             if (NULL == indicators) {
                 cli_errmsg("append_virus: no memory for json Indicators array\n");
-            } else {
-                json_object_object_add(ctx->this_layer_metadata_json, "Indicators", indicators);
+                status = CL_EMEM;
+                goto done;
+            }
+            if (0 != json_object_object_add(ctx->this_layer_metadata_json, "Indicators", indicators)) {
+                cli_errmsg("append_virus: failed to add json Indicators array\n");
+                json_object_put(indicators);
+                status = CL_ERROR;
+                goto done;
             }
         }
 
         // Create json object containing name, type, depth, and object_id
-        json_object *indicator_obj = json_object_new_object();
+        indicator_obj = json_object_new_object();
         if (NULL == indicator_obj) {
             cli_errmsg("append_virus: no memory for json indicator object\n");
-        } else {
-            (void)json_object_object_add(indicator_obj, "Name", json_object_new_string(virname));
-            switch (type) {
-                case IndicatorType_Strong: {
-                    (void)json_object_object_add(indicator_obj, "Type", json_object_new_string("Strong"));
-                } break;
-                case IndicatorType_PotentiallyUnwanted: {
-                    (void)json_object_object_add(indicator_obj, "Type", json_object_new_string("PotentiallyUnwanted"));
-                } break;
-                case IndicatorType_Weak: {
-                    (void)json_object_object_add(indicator_obj, "Type", json_object_new_string("Weak"));
-                } break;
-            }
-            (void)json_object_object_add(indicator_obj, "Depth", json_object_new_int(0)); // 0 for this layer
-            (void)cli_jsonuint64(indicator_obj, "ObjectID", (uint64_t)ctx->recursion_stack[ctx->recursion_level].object_id);
-            (void)json_object_array_add(indicators, indicator_obj);
+            status = CL_EMEM;
+            goto done;
         }
+
+        if ((CL_SUCCESS != (status = cli_jsonstr(indicator_obj, "Name", virname))) ||
+            (CL_SUCCESS != (status = cli_jsonstr(indicator_obj, "Type", indicator_type_name))) ||
+            (CL_SUCCESS != (status = cli_jsonint(indicator_obj, "Depth", 0))) ||
+            (CL_SUCCESS != (status = cli_jsonuint64(indicator_obj, "ObjectID", (uint64_t)ctx->recursion_stack[ctx->recursion_level].object_id)))) {
+            cli_errmsg("append_virus: failed to add json indicator metadata\n");
+            json_object_put(indicator_obj);
+            goto done;
+        }
+
+        if (0 != json_object_array_add(indicators, indicator_obj)) {
+            cli_errmsg("append_virus: failed to add indicator to json Indicators array\n");
+            json_object_put(indicator_obj);
+            status = CL_ERROR;
+            goto done;
+        }
+
+        /*
+         * indicator_obj is now owned by the Indicators array. If it is also alerting,
+         * the Alerts array gets an additional reference below.
+         */
 
         // If this is a strong or potentially unwanted indicator, we add it to the "Alerts" array.
         if (type != IndicatorType_Weak) {
@@ -1554,14 +1723,24 @@ static cl_error_t append_virus(cli_ctx *ctx, const char *virname, IndicatorType 
                     status = CL_EMEM;
                     goto done;
                 }
-                (void)json_object_object_add(ctx->this_layer_metadata_json, "Alerts", arrobj);
+                if (0 != json_object_object_add(ctx->this_layer_metadata_json, "Alerts", arrobj)) {
+                    cli_errmsg("append_virus: failed to add json Alerts array\n");
+                    json_object_put(arrobj);
+                    status = CL_ERROR;
+                    goto done;
+                }
             }
 
             // Increment the indicator_obj reference count, so that it can be added to the "Alerts" array.
             (void)json_object_get(indicator_obj);
 
             // Add the same indicator object to the "Alerts" array.
-            (void)json_object_array_add(arrobj, indicator_obj);
+            if (0 != json_object_array_add(arrobj, indicator_obj)) {
+                cli_errmsg("append_virus: failed to add indicator to json Alerts array\n");
+                json_object_put(indicator_obj);
+                status = CL_ERROR;
+                goto done;
+            }
         }
     }
 
@@ -1647,6 +1826,9 @@ static cl_error_t append_virus(cli_ctx *ctx, const char *virname, IndicatorType 
 done:
     if (NULL != location) {
         free(location);
+    }
+    if (NULL != add_indicator_error) {
+        ffierror_free(add_indicator_error);
     }
 
     return status;

--- a/libclamav/others.h
+++ b/libclamav/others.h
@@ -685,18 +685,6 @@ const char *cli_get_last_virus(const cli_ctx *ctx);
 const char *cli_get_last_virus_str(const cli_ctx *ctx);
 
 /**
- * @brief Dispatch the alert / virus found callbacks.
- *
- * AKA for clamscan it will print FOUND message.
- *
- * @param ctx                     The scan context.
- * @param virname                 The name of the virus.
- * @param is_potentially_unwanted true if the alert is for a potentially unwanted application (PUA).
- * @return cl_error_t
- */
-cl_error_t cli_virus_found_cb(cli_ctx *ctx, const char *virname, bool is_potentially_unwanted);
-
-/**
  * @brief Push a new fmap onto our scan recursion stack.
  *
  * May fail if we exceed max recursion depth.

--- a/libclamav/scanners.c
+++ b/libclamav/scanners.c
@@ -4501,13 +4501,25 @@ done:
     return halt_scan;
 }
 
+static void scan_update_verdict_from_evidence(cli_ctx *ctx);
+static bool scan_verdict_is_alert(cl_verdict_t verdict);
+static cl_error_t scan_normalize_status_for_verdict(cl_error_t status, cl_verdict_t verdict);
+static void scan_report_potentially_unwanted_alerts(cli_ctx *ctx);
+/* These helpers live in others.c. Keep the prototypes local because IndicatorType comes from
+ * the generated Rust FFI header, and others.h intentionally avoids that dependency. */
+extern cl_error_t cli_virus_found_cb(cli_ctx *ctx, const char *virname, IndicatorType indicator_type);
+extern cl_error_t cli_virus_found_cb_with_fd(
+    cli_ctx *ctx,
+    const char *virname,
+    IndicatorType indicator_type,
+    int legacy_virus_found_fd);
+
 cl_error_t cli_magic_scan(cli_ctx *ctx, cli_file_t type)
 {
     cl_error_t status = CL_SUCCESS;
     cl_error_t ret;
 
-    cl_error_t cache_check_result      = CL_VIRUS;
-    cl_verdict_t verdict_at_this_level = CL_VERDICT_NOTHING_FOUND;
+    cl_error_t cache_check_result = CL_VIRUS;
 
     bool cache_enabled              = true;
     cli_file_t dettype              = CL_TYPE_ANY;
@@ -5295,7 +5307,11 @@ done:
     if (ctx->engine->cb_post_scan) {
         cl_error_t callback_ret;
         cl_error_t append_ret;
+        cl_error_t result_at_this_level;
         const char *virusname = NULL;
+
+        scan_update_verdict_from_evidence(ctx);
+        result_at_this_level = scan_verdict_is_alert(ctx->recursion_stack[ctx->recursion_level].verdict) ? CL_VIRUS : CL_CLEAN;
 
         // Get the last signature that matched (if any).
         if (0 < evidence_num_alerts(ctx->this_layer_evidence)) {
@@ -5303,7 +5319,7 @@ done:
         }
 
         perf_start(ctx, PERFT_POSTCB);
-        callback_ret = ctx->engine->cb_post_scan(fmap_fd(ctx->fmap), verdict_at_this_level, virusname, ctx->cb_ctx);
+        callback_ret = ctx->engine->cb_post_scan(fmap_fd(ctx->fmap), result_at_this_level, virusname, ctx->cb_ctx);
         perf_stop(ctx, PERFT_POSTCB);
 
         switch (callback_ret) {
@@ -5352,11 +5368,7 @@ done:
          * Update the verdict for this layer based on the scan results.
          * If the verdict is CL_VERDICT_TRUSTED, then we don't change it.
          */
-        if (0 < evidence_num_indicators_type(ctx->this_layer_evidence, IndicatorType_Strong)) {
-            ctx->recursion_stack[ctx->recursion_level].verdict = CL_VERDICT_STRONG_INDICATOR;
-        } else if (0 < evidence_num_indicators_type(ctx->this_layer_evidence, IndicatorType_PotentiallyUnwanted)) {
-            ctx->recursion_stack[ctx->recursion_level].verdict = CL_VERDICT_POTENTIALLY_UNWANTED;
-        }
+        scan_update_verdict_from_evidence(ctx);
     }
 
     /*
@@ -5610,6 +5622,123 @@ cl_error_t cli_magic_scan_buff(const void *buffer, size_t length, cli_ctx *ctx, 
     return ret;
 }
 
+static void scan_init_outputs(
+    cl_verdict_t *verdict_out,
+    const char **last_alert_out,
+    uint64_t *scanned_out,
+    char **hash_out,
+    char **file_type_out)
+{
+    if (NULL != verdict_out) {
+        *verdict_out = CL_VERDICT_NOTHING_FOUND;
+    }
+    if (NULL != last_alert_out) {
+        *last_alert_out = NULL;
+    }
+    if (NULL != scanned_out) {
+        *scanned_out = 0;
+    }
+    if (NULL != hash_out) {
+        *hash_out = NULL;
+    }
+    if (NULL != file_type_out) {
+        *file_type_out = NULL;
+    }
+}
+
+static void scan_update_verdict_from_evidence(cli_ctx *ctx)
+{
+    if (NULL == ctx) {
+        return;
+    }
+
+    if (CL_VERDICT_TRUSTED == ctx->recursion_stack[ctx->recursion_level].verdict) {
+        return;
+    }
+
+    if (0 < evidence_num_indicators_type(ctx->this_layer_evidence, IndicatorType_Strong)) {
+        ctx->recursion_stack[ctx->recursion_level].verdict = CL_VERDICT_STRONG_INDICATOR;
+    } else if (0 < evidence_num_indicators_type(ctx->this_layer_evidence, IndicatorType_PotentiallyUnwanted)) {
+        ctx->recursion_stack[ctx->recursion_level].verdict = CL_VERDICT_POTENTIALLY_UNWANTED;
+    } else {
+        ctx->recursion_stack[ctx->recursion_level].verdict = CL_VERDICT_NOTHING_FOUND;
+    }
+}
+
+static bool scan_verdict_is_alert(cl_verdict_t verdict)
+{
+    return (CL_VERDICT_STRONG_INDICATOR == verdict) || (CL_VERDICT_POTENTIALLY_UNWANTED == verdict);
+}
+
+static cl_error_t scan_normalize_status_for_verdict(cl_error_t status, cl_verdict_t verdict)
+{
+    if ((CL_VIRUS == status) && scan_verdict_is_alert(verdict)) {
+        return CL_SUCCESS;
+    }
+
+    return status;
+}
+
+static void scan_report_potentially_unwanted_alerts(cli_ctx *ctx)
+{
+    size_t num_potentially_unwanted_indicators;
+
+    if ((NULL == ctx) || (NULL == ctx->this_layer_evidence)) {
+        return;
+    }
+
+    /*
+     * Potentially unwanted indicators are reported after the scan so strong
+     * indicators can take precedence. Do this before metadata serialization
+     * because alert callbacks can suppress alerts and update evidence/metadata.
+     */
+    num_potentially_unwanted_indicators = evidence_num_indicators_type(
+        ctx->this_layer_evidence,
+        IndicatorType_PotentiallyUnwanted);
+    if (0 == num_potentially_unwanted_indicators) {
+        return;
+    }
+
+    if (ctx->options->general & CL_SCAN_GENERAL_ALLMATCHES) {
+        size_t i = 0;
+
+        while (i < evidence_num_indicators_type(ctx->this_layer_evidence, IndicatorType_PotentiallyUnwanted)) {
+            const char *pua_alert = evidence_get_indicator(
+                ctx->this_layer_evidence,
+                IndicatorType_PotentiallyUnwanted,
+                i,
+                NULL, // Don't need to get the depth here.
+                NULL  // Don't need to get the object ID here.
+            );
+
+            if (NULL != pua_alert) {
+                cl_error_t callback_ret = cli_virus_found_cb_with_fd(ctx, pua_alert, IndicatorType_PotentiallyUnwanted, -1);
+
+                if (CL_SUCCESS == callback_ret) {
+                    // The callback removed this indicator from evidence. Keep the same index.
+                    continue;
+                }
+                if ((CL_VERIFIED == callback_ret) || (CL_BREAK == callback_ret)) {
+                    break;
+                }
+            }
+
+            i++;
+        }
+    } else if (0 == evidence_num_indicators_type(ctx->this_layer_evidence, IndicatorType_Strong)) {
+        cl_error_t callback_ret = CL_SUCCESS;
+
+        while ((CL_SUCCESS == callback_ret) &&
+               (0 < evidence_num_indicators_type(ctx->this_layer_evidence, IndicatorType_PotentiallyUnwanted))) {
+            callback_ret = cli_virus_found_cb(
+                ctx,
+                cli_get_last_virus(ctx),
+                IndicatorType_PotentiallyUnwanted);
+            // If the callback returned CL_SUCCESS, it also removed the indicator from evidence.
+        }
+    }
+}
+
 /**
  * @brief   The main function to initiate a scan of an fmap.
  *
@@ -5617,7 +5746,8 @@ cl_error_t cli_magic_scan_buff(const void *buffer, size_t length, cli_ctx *ctx, 
  * @param filepath            (optional, recommended) filepath of the open file descriptor or file map.
  * @param[out] verdict_out    A pointer to a cl_verdict_t that will be set to the scan verdict.
  *                            You should check the verdict even if the function returns an error.
- * @param[out] last_alert_out Will be set to a statically allocated (i.e. needs not be freed) signature name if the scan matches against a signature.
+ * @param[out] last_alert_out Storage for a statically allocated (i.e. does not need to be freed) signature name if the
+ *                            scan matches against a signature. Public wrappers accept NULL and pass discard storage.
  * @param[out] scanned_out    (Optional) The number of bytes scanned.
  * @param engine              The scanning engine.
  * @param scanoptions         Scanning options.
@@ -5638,9 +5768,10 @@ cl_error_t cli_magic_scan_buff(const void *buffer, size_t length, cli_ctx *ctx, 
  *                            of the top layer as determined by ClamAV.
  *                            Will take the form of the standard ClamAV file type format. E.g. "CL_TYPE_PE".
  *                            The caller is responsible for freeing this string.
- * @return cl_error_t         CL_SUCCESS if no error occured.
+ * @return cl_error_t         CL_SUCCESS if no error occurred.
  *                            Otherwise a CL_E* error code.
- *                            Does NOT return CL_VIRUS for a signature match. Check the `verdict_out` parameter instead.
+ *                            Detection-only matches are reported through `verdict_out`; this function does not return
+ *                            CL_VIRUS for a signature match.
  */
 static cl_error_t scan_common(
     cl_fmap_t *map,
@@ -5663,6 +5794,7 @@ static cl_error_t scan_common(
     cli_ctx ctx = {0};
 
     bool logg_initialized = false;
+    bool top_level_maxfilesize_exceeded = false;
 
     char *target_basename = NULL;
     char *new_temp_prefix = NULL;
@@ -5671,8 +5803,6 @@ static cl_error_t scan_common(
 
     time_t current_time;
     struct tm tm_struct;
-
-    size_t num_potentially_unwanted_indicators = 0;
 
     // The default type is SHA2-256.
     cli_hash_type_t requested_hash_type = CLI_HASH_SHA2_256;
@@ -5683,10 +5813,6 @@ static cl_error_t scan_common(
         return CL_ENULLARG;
     }
 
-    /* Initialize output variables */
-    *verdict_out    = CL_VERDICT_NOTHING_FOUND;
-    *last_alert_out = NULL;
-
     // If the caller provided a file type hint, we make a best effort to use it.
     if (file_type_hint) {
         file_type = cli_ftcode_human_friendly(file_type_hint);
@@ -5694,10 +5820,6 @@ static cl_error_t scan_common(
             cli_dbgmsg("scan_common: Unsupported file type hint: %s. Will treat it as unknown (CL_TYPE_ANY)\n", file_type_hint);
             file_type = CL_TYPE_ANY;
         }
-    }
-
-    if (NULL != hash_out) {
-        *hash_out = NULL;
     }
 
     if (NULL != hash_alg) {
@@ -5716,14 +5838,15 @@ static cl_error_t scan_common(
         }
     }
 
-    // If hash_hint is provided, we need to check if the hash_alg is valid.
+    // If hash_hint is provided, validate it for the selected hash algorithm.
     if (NULL != hash_hint) {
         uint8_t hash[CLI_HASHLEN_MAX] = {0};
         size_t hash_string_len        = strlen(hash_hint);
+        const char *hash_name         = cli_hash_name(requested_hash_type);
 
         if (hash_string_len != cli_hash_len(requested_hash_type) * 2) {
             cli_errmsg("scan_common: hash_hint provided, but its length (%zu) does not match the expected length for %s (%zu).\n",
-                       hash_string_len, hash_alg, cli_hash_len(requested_hash_type) * 2);
+                       hash_string_len, hash_name, cli_hash_len(requested_hash_type) * 2);
             status = CL_EARG;
             goto done;
         }
@@ -5737,12 +5860,12 @@ static cl_error_t scan_common(
         }
         // Set the fmap hash for the given algorithm.
         if (CL_SUCCESS != fmap_set_hash(map, hash, requested_hash_type)) {
-            cli_errmsg("scan_common: Failed to set fmap hash for %s.\n", hash_alg);
+            cli_errmsg("scan_common: Failed to set fmap hash for %s.\n", hash_name);
             status = CL_EARG;
             goto done;
         }
 
-        cli_dbgmsg("scan_common: recorded %s hash hint: %s\n", cli_hash_name(requested_hash_type), hash_hint);
+        cli_dbgmsg("scan_common: recorded %s hash hint: %s\n", hash_name, hash_hint);
     }
 
     ctx.engine  = engine;
@@ -5917,7 +6040,17 @@ static cl_error_t scan_common(
     /*
      * DO THE SCAN!
      */
-    status = cli_magic_scan(&ctx, file_type);
+    if ((ctx.engine->maxfilesize > 0) && ((uint64_t)ctx.fmap->len > ctx.engine->maxfilesize)) {
+        cli_dbgmsg("scan_common: File too large (%zu bytes), ignoring\n", ctx.fmap->len);
+        cli_append_potentially_unwanted_if_heur_exceedsmax(&ctx, "Heuristics.Limits.Exceeded.MaxFileSize");
+        emax_reached(&ctx);
+        top_level_maxfilesize_exceeded = true;
+        status = CL_SUCCESS;
+    } else {
+        status = cli_magic_scan(&ctx, file_type);
+    }
+
+    scan_report_potentially_unwanted_alerts(&ctx);
 
     if (ctx.options->general & CL_SCAN_GENERAL_COLLECT_METADATA && (ctx.metadata_json != NULL)) {
         json_object *jobj;
@@ -5949,9 +6082,16 @@ static cl_error_t scan_common(
 
         cli_dbgmsg("%s\n", jstring);
 
-        if (status != CL_VIRUS) {
+        /*
+         * A top-level MaxFileSize hit intentionally skips scanning the file
+         * content. Do not run metadata preclass scans as a substitute scan
+         * surface, but still serialize metadata and run file props below.
+         */
+        if ((status != CL_VIRUS) && !top_level_maxfilesize_exceeded) {
             /*
-             * Run bytecode preclass hook.
+             * Delayed PUA alert callbacks have already run. The metadata
+             * preclass hook is not a PUA alert source, so this block does not
+             * need a second scan_report_potentially_unwanted_alerts() pass.
              */
             struct cli_matcher *iroot = ctx.engine->root[13];
 
@@ -6011,71 +6151,15 @@ static cl_error_t scan_common(
         }
     }
 
+    scan_update_verdict_from_evidence(&ctx);
+
     // If any alerts occurred, set the output pointer to the "latest" alert signature name.
     if (0 < evidence_num_alerts(ctx.this_layer_evidence)) {
         *last_alert_out = cli_get_last_virus_str(&ctx);
     }
 
     *verdict_out = ctx.recursion_stack[ctx.recursion_level].verdict;
-
-    /*
-     * Report PUA alerts here.
-     */
-    num_potentially_unwanted_indicators = evidence_num_indicators_type(
-        ctx.this_layer_evidence,
-        IndicatorType_PotentiallyUnwanted);
-    if (0 != num_potentially_unwanted_indicators) {
-        // We have "potentially unwanted" indicators that would not have been reported yet.
-        // We may wish to report them now, ... depending ....
-
-        if (ctx.options->general & CL_SCAN_GENERAL_ALLMATCHES) {
-            // We're in allmatch mode, so report all "potentially unwanted" matches now.
-
-            size_t i;
-
-            for (i = 0; i < num_potentially_unwanted_indicators; i++) {
-                const char *pua_alert = evidence_get_indicator(
-                    ctx.this_layer_evidence,
-                    IndicatorType_PotentiallyUnwanted,
-                    i,
-                    NULL, // Don't need to get the depth here.
-                    NULL  // Don't need to get the object ID here.
-                );
-
-                if (NULL != pua_alert) {
-                    // We don't know exactly which layer the alert happened at.
-                    // There's a decent chance it wasn't at this layer, and in that case we wouldn't
-                    // even have access to that file anymore (it's gone!). So we'll pass back -1 for the
-                    // file descriptor rather than using `cli_virus_found_cb() which would pass back
-                    // The top level file descriptor.
-                    if (ctx.engine->cb_virus_found) {
-                        ctx.engine->cb_virus_found(
-                            -1,
-                            pua_alert,
-                            ctx.cb_ctx);
-                    }
-                }
-            }
-
-        } else {
-            // Not allmatch mode. Only want to report one thing...
-            if (0 == evidence_num_indicators_type(ctx.this_layer_evidence, IndicatorType_Strong)) {
-                // And it looks like we haven't reported anything else, so report the last "potentially unwanted" one.
-                // cli_get_last_virus() will do that, grabbing the last alerting indicator of any type.
-                cl_error_t callback_ret = CL_SUCCESS;
-
-                while ((CL_SUCCESS == callback_ret) &&
-                       (0 < evidence_num_indicators_type(ctx.this_layer_evidence, IndicatorType_PotentiallyUnwanted))) {
-                    callback_ret = cli_virus_found_cb(
-                        &ctx,
-                        cli_get_last_virus(&ctx),
-                        IndicatorType_PotentiallyUnwanted);
-                    // If the callback returned CL_SUCCESS then it will have also removed the indicator from evidence
-                    // And we must loop around and report the next one.
-                }
-            }
-        }
-    }
+    status       = scan_normalize_status_for_verdict(status, *verdict_out);
 
     /*
      * If the caller requested a hash, we need to get it from the fmap.
@@ -6186,7 +6270,7 @@ cl_error_t cl_scandesc(
     struct cl_scan_options *scanoptions)
 {
     cl_error_t status;
-    uint64_t scanned_out;
+    uint64_t scanned_out      = 0;
     cl_verdict_t verdict_out = CL_VERDICT_NOTHING_FOUND;
 
     status = cl_scandesc_ex(
@@ -6214,7 +6298,7 @@ cl_error_t cl_scandesc(
         }
     }
 
-    if (verdict_out == CL_VERDICT_STRONG_INDICATOR || verdict_out == CL_VERDICT_POTENTIALLY_UNWANTED) {
+    if (scan_verdict_is_alert(verdict_out)) {
         // Reporting "CL_VIRUS" is more important than reporting an error,
         // because... unfortunately we can only do one with this API.
         status = CL_VIRUS;
@@ -6233,7 +6317,7 @@ cl_error_t cl_scandesc_callback(
     void *context)
 {
     cl_error_t status;
-    uint64_t scanned_bytes;
+    uint64_t scanned_bytes   = 0;
     cl_verdict_t verdict_out = CL_VERDICT_NOTHING_FOUND;
 
     status = cl_scandesc_ex(
@@ -6261,7 +6345,7 @@ cl_error_t cl_scandesc_callback(
         }
     }
 
-    if (verdict_out == CL_VERDICT_STRONG_INDICATOR || verdict_out == CL_VERDICT_POTENTIALLY_UNWANTED) {
+    if (scan_verdict_is_alert(verdict_out)) {
         // Reporting "CL_VIRUS" is more important than reporting an error,
         // because... unfortunately we can only do one with this API.
         status = CL_VIRUS;
@@ -6289,6 +6373,16 @@ cl_error_t cl_scandesc_ex(
     cl_fmap_t *map    = NULL;
     STATBUF sb;
     char *filename_base = NULL;
+    const char *last_alert        = NULL;
+    const char **effective_last_alert_out;
+
+    scan_init_outputs(verdict_out, last_alert_out, scanned_out, hash_out, file_type_out);
+
+    if (NULL == scanoptions || NULL == verdict_out || NULL == engine) {
+        return CL_ENULLARG;
+    }
+
+    effective_last_alert_out = (NULL != last_alert_out) ? last_alert_out : &last_alert;
 
     if (FSTAT(desc, &sb) == -1) {
         cli_errmsg("cl_scandesc_callback: Can't fstat descriptor %d\n", desc);
@@ -6300,22 +6394,6 @@ cl_error_t cl_scandesc_ex(
         status = CL_SUCCESS;
         goto done;
     }
-    if ((engine->maxfilesize > 0) && ((uint64_t)sb.st_size > engine->maxfilesize)) {
-        cli_dbgmsg("cl_scandesc_callback: File too large (" STDu64 " bytes), ignoring\n", (uint64_t)sb.st_size);
-        if (scanoptions->heuristic & CL_SCAN_HEURISTIC_EXCEEDS_MAX) {
-            if (engine->cb_virus_found) {
-                engine->cb_virus_found(desc, "Heuristics.Limits.Exceeded.MaxFileSize", context);
-                if (last_alert_out) {
-                    *last_alert_out = "Heuristics.Limits.Exceeded.MaxFileSize";
-                }
-            }
-            status = CL_VIRUS;
-        } else {
-            status = CL_SUCCESS;
-        }
-        goto done;
-    }
-
     if (NULL != filename) {
         (void)cli_basename(filename, strlen(filename), &filename_base, true /* posix_support_backslash_pathsep */);
     }
@@ -6330,7 +6408,7 @@ cl_error_t cl_scandesc_ex(
         map,
         filename,
         verdict_out,
-        last_alert_out,
+        effective_last_alert_out,
         scanned_out,
         engine,
         scanoptions,
@@ -6362,7 +6440,7 @@ cl_error_t cl_scanmap_callback(
     void *context)
 {
     cl_error_t status;
-    uint64_t scanned_bytes;
+    uint64_t scanned_bytes   = 0;
     cl_verdict_t verdict_out = CL_VERDICT_NOTHING_FOUND;
 
     status = cl_scanmap_ex(
@@ -6390,7 +6468,7 @@ cl_error_t cl_scanmap_callback(
         }
     }
 
-    if (verdict_out == CL_VERDICT_STRONG_INDICATOR || verdict_out == CL_VERDICT_POTENTIALLY_UNWANTED) {
+    if (scan_verdict_is_alert(verdict_out)) {
         // Reporting "CL_VIRUS" is more important than reporting an error,
         // because... unfortunately we can only do one with this API.
         status = CL_VIRUS;
@@ -6414,18 +6492,19 @@ cl_error_t cl_scanmap_ex(
     const char *file_type_hint,
     char **file_type_out)
 {
-    if ((engine->maxfilesize > 0) && (map->len > engine->maxfilesize)) {
-        cli_dbgmsg("cl_scandesc_callback: File too large (%zu bytes), ignoring\n", map->len);
-        if (scanoptions->heuristic & CL_SCAN_HEURISTIC_EXCEEDS_MAX) {
-            if (engine->cb_virus_found) {
-                engine->cb_virus_found(fmap_fd(map), "Heuristics.Limits.Exceeded.MaxFileSize", context);
-                if (last_alert_out) {
-                    *last_alert_out = "Heuristics.Limits.Exceeded.MaxFileSize";
-                }
-            }
-            return CL_VIRUS;
-        }
-        return CL_SUCCESS;
+    const char *last_alert = NULL;
+    const char **effective_last_alert_out;
+
+    scan_init_outputs(verdict_out, last_alert_out, scanned_out, hash_out, file_type_out);
+
+    if (NULL == scanoptions || NULL == verdict_out || NULL == engine) {
+        return CL_ENULLARG;
+    }
+
+    effective_last_alert_out = (NULL != last_alert_out) ? last_alert_out : &last_alert;
+
+    if (NULL == map) {
+        return CL_ENULLARG;
     }
 
     if (NULL != filename && map->name == NULL) {
@@ -6437,7 +6516,7 @@ cl_error_t cl_scanmap_ex(
         map,
         filename,
         verdict_out,
-        last_alert_out,
+        effective_last_alert_out,
         scanned_out,
         engine,
         scanoptions,
@@ -6478,7 +6557,7 @@ cl_error_t cl_scanfile(
     struct cl_scan_options *scanoptions)
 {
     cl_error_t status;
-    uint64_t scanned_bytes;
+    uint64_t scanned_bytes   = 0;
     cl_verdict_t verdict_out = CL_VERDICT_NOTHING_FOUND;
 
     status = cl_scanfile_ex(
@@ -6504,7 +6583,7 @@ cl_error_t cl_scanfile(
         }
     }
 
-    if (verdict_out == CL_VERDICT_STRONG_INDICATOR || verdict_out == CL_VERDICT_POTENTIALLY_UNWANTED) {
+    if (scan_verdict_is_alert(verdict_out)) {
         // Reporting "CL_VIRUS" is more important than reporting an error,
         // because... unfortunately we can only do one with this API.
         status = CL_VIRUS;
@@ -6522,7 +6601,7 @@ cl_error_t cl_scanfile_callback(
     void *context)
 {
     cl_error_t status;
-    uint64_t scanned_out;
+    uint64_t scanned_out     = 0;
     cl_verdict_t verdict_out = CL_VERDICT_NOTHING_FOUND;
 
     status = cl_scanfile_ex(
@@ -6548,7 +6627,7 @@ cl_error_t cl_scanfile_callback(
         }
     }
 
-    if (verdict_out == CL_VERDICT_STRONG_INDICATOR || verdict_out == CL_VERDICT_POTENTIALLY_UNWANTED) {
+    if (scan_verdict_is_alert(verdict_out)) {
         // Reporting "CL_VIRUS" is more important than reporting an error,
         // because... unfortunately we can only do one with this API.
         status = CL_VIRUS;
@@ -6571,15 +6650,33 @@ cl_error_t cl_scanfile_ex(
     const char *file_type_hint,
     char **file_type_out)
 {
-    int fd;
-    cl_error_t ret;
-    const char *fname = cli_to_utf8_maybe_alloc(filename);
+    int fd            = -1;
+    cl_error_t ret    = CL_SUCCESS;
+    const char *fname = NULL;
 
-    if (!fname)
+    scan_init_outputs(verdict_out, last_alert_out, scanned_out, hash_out, file_type_out);
+
+    if (NULL == scanoptions || NULL == verdict_out || NULL == engine) {
+        return CL_ENULLARG;
+    }
+
+    if (NULL == filename) {
         return CL_EARG;
+    }
+
+    fname = cli_to_utf8_maybe_alloc(filename);
+    if (!fname) {
+        return CL_EARG;
+    }
 
     if ((fd = safe_open(fname, O_RDONLY | O_BINARY)) == -1) {
-        if (errno == EACCES) {
+        int open_errno = errno;
+
+        if (fname != filename) {
+            free((char *)fname);
+        }
+
+        if (open_errno == EACCES) {
             return CL_EACCES;
         } else {
             return CL_EOPEN;
@@ -6604,7 +6701,9 @@ cl_error_t cl_scanfile_ex(
         file_type_hint,
         file_type_out);
 
-    close(fd);
+    if (fd >= 0) {
+        close(fd);
+    }
 
     return ret;
 }

--- a/unit_tests/check_clamav.c
+++ b/unit_tests/check_clamav.c
@@ -5,6 +5,7 @@
 #include <stdio.h>
 
 #include <stdlib.h>
+#include <inttypes.h>
 #include <limits.h>
 #include <fcntl.h>
 #include <string.h>
@@ -776,6 +777,445 @@ START_TEST(test_cl_scanmap_callback_mem_allscan)
 END_TEST
 #endif
 
+static cl_error_t ignore_alert_callback(cl_scan_layer_t *layer, void *context)
+{
+    (void)layer;
+    (void)context;
+
+    return CL_CLEAN;
+}
+
+static int legacy_virus_found_fd;
+static unsigned legacy_virus_found_count;
+static const char *legacy_virus_found_name;
+static void *legacy_virus_found_context;
+
+static void record_legacy_virus_found_callback(int fd, const char *virname, void *context)
+{
+    legacy_virus_found_fd = fd;
+    legacy_virus_found_name = virname;
+    legacy_virus_found_context = context;
+    legacy_virus_found_count++;
+}
+
+struct file_props_capture {
+    char *json;
+    int status;
+    unsigned count;
+};
+
+static int capture_file_props_callback(const char *j_propstr, int rc, void *context)
+{
+    struct file_props_capture *capture = (struct file_props_capture *)context;
+
+    if (NULL == capture) {
+        return CL_ENULLARG;
+    }
+
+    capture->count++;
+    capture->status = rc;
+    free(capture->json);
+    capture->json = NULL;
+
+    if (NULL != j_propstr) {
+        capture->json = strdup(j_propstr);
+        if (NULL == capture->json) {
+            return CL_EMEM;
+        }
+    }
+
+    return CL_SUCCESS;
+}
+
+struct allmatch_pua_metadata_capture {
+    struct file_props_capture metadata;
+    unsigned alert_count;
+};
+
+static cl_error_t ignore_first_alert_callback(cl_scan_layer_t *layer, void *context)
+{
+    struct allmatch_pua_metadata_capture *capture = (struct allmatch_pua_metadata_capture *)context;
+
+    (void)layer;
+
+    if (NULL == capture) {
+        return CL_ENULLARG;
+    }
+
+    capture->alert_count++;
+
+    return (1 == capture->alert_count) ? CL_CLEAN : CL_VIRUS;
+}
+
+static int capture_allmatch_pua_file_props_callback(const char *j_propstr, int rc, void *context)
+{
+    struct allmatch_pua_metadata_capture *capture = (struct allmatch_pua_metadata_capture *)context;
+
+    if (NULL == capture) {
+        return CL_ENULLARG;
+    }
+
+    return capture_file_props_callback(j_propstr, rc, &capture->metadata);
+}
+
+static bool metadata_json_named_object_has_key(const char *json, const char *name, const char *key)
+{
+    const char *name_pos;
+    const char *object_end;
+    const char *key_pos;
+
+    if ((NULL == json) || (NULL == name) || (NULL == key)) {
+        return false;
+    }
+
+    name_pos = strstr(json, name);
+    if (NULL == name_pos) {
+        return false;
+    }
+
+    object_end = strchr(name_pos, '}');
+    if (NULL == object_end) {
+        return false;
+    }
+
+    key_pos = strstr(name_pos, key);
+
+    return (NULL != key_pos) && (key_pos < object_end);
+}
+
+static bool metadata_json_array_has_name(const char *json, const char *array_name, const char *name)
+{
+    char array_key[64];
+    const char *array_pos;
+    const char *array_end;
+    const char *name_pos;
+    int key_len;
+
+    if ((NULL == json) || (NULL == array_name) || (NULL == name)) {
+        return false;
+    }
+
+    key_len = snprintf(array_key, sizeof(array_key), "\"%s\"", array_name);
+    if ((key_len < 0) || (key_len >= (int)sizeof(array_key))) {
+        return false;
+    }
+
+    array_pos = strstr(json, array_key);
+    if (NULL == array_pos) {
+        return false;
+    }
+
+    array_end = strchr(array_pos, ']');
+    if (NULL == array_end) {
+        return false;
+    }
+
+    name_pos = strstr(array_pos, name);
+
+    return (NULL != name_pos) && (name_pos < array_end);
+}
+
+START_TEST(test_cl_scanfile_ex_signature_match)
+{
+    const char *alert = "stale";
+    char file[256];
+    unsigned long size;
+    uint64_t scanned = 0;
+    cl_verdict_t verdict = CL_VERDICT_TRUSTED;
+    cl_error_t ret;
+    struct cl_scan_options options;
+
+    memset(&options, 0, sizeof(struct cl_scan_options));
+    options.parse |= ~0;
+
+    int fd = get_test_file(_i, file, sizeof(file), &size);
+    close(fd);
+
+    ret = cl_scanfile_ex(file, &verdict, &alert, &scanned, g_engine, &options, NULL,
+                         NULL, NULL, NULL, NULL, NULL);
+
+    if (!FALSE_NEGATIVE) {
+        ck_assert_msg(ret == CL_SUCCESS, "cl_scanfile_ex returned %s", cl_strerror(ret));
+        ck_assert_msg(verdict == CL_VERDICT_STRONG_INDICATOR, "unexpected verdict: %d", verdict);
+        ck_assert_msg(alert && !strcmp(alert, "ClamAV-Test-File.UNOFFICIAL"), "alert: %s", alert);
+        ck_assert_msg(scanned > 0, "scanned: %" PRIu64, scanned);
+    }
+}
+END_TEST
+
+START_TEST(test_cl_scanfile_ex_ignored_strong_alert)
+{
+    const char *alert = "stale";
+    char file[256];
+    unsigned long size;
+    uint64_t scanned = 0;
+    cl_verdict_t verdict = CL_VERDICT_TRUSTED;
+    cl_error_t ret;
+    struct cl_scan_options options;
+    int fd;
+
+    memset(&options, 0, sizeof(struct cl_scan_options));
+    options.parse |= ~0;
+
+    fd = get_test_file(_i, file, sizeof(file), &size);
+    close(fd);
+
+    cl_engine_set_scan_callback(g_engine, ignore_alert_callback, CL_SCAN_CALLBACK_ALERT);
+    ret = cl_scanfile_ex(file, &verdict, &alert, &scanned, g_engine, &options, NULL,
+                         NULL, NULL, NULL, NULL, NULL);
+    cl_engine_set_scan_callback(g_engine, NULL, CL_SCAN_CALLBACK_ALERT);
+
+    if (!FALSE_NEGATIVE) {
+        ck_assert_msg(ret == CL_SUCCESS, "cl_scanfile_ex returned %s", cl_strerror(ret));
+        ck_assert_msg(verdict == CL_VERDICT_NOTHING_FOUND, "unexpected verdict: %d", verdict);
+        ck_assert_msg(alert == NULL, "alert: %s", alert ? alert : "(null)");
+        ck_assert_msg(scanned > 0, "scanned: %" PRIu64, scanned);
+    }
+}
+END_TEST
+
+START_TEST(test_cl_scanmap_ex_allmatch_ignored_pua_metadata)
+{
+    const char map_data[] = "alpha beta";
+    const char *ignored_pua = "PUA.Test.IgnoreFirst.UNOFFICIAL";
+    const char *kept_pua = "PUA.Test.KeepSecond.UNOFFICIAL";
+    const char *alert = "stale";
+    char dbfile[PATH_MAX];
+    struct cl_engine *pua_engine = NULL;
+    cl_fmap_t *map = NULL;
+    FILE *db = NULL;
+    char *dbdir = NULL;
+    unsigned int sigs = 0;
+    uint64_t scanned = 0;
+    cl_verdict_t verdict = CL_VERDICT_TRUSTED;
+    cl_error_t ret;
+    struct cl_scan_options options;
+    struct allmatch_pua_metadata_capture capture;
+    int path_len;
+
+    memset(&options, 0, sizeof(options));
+    memset(&capture, 0, sizeof(capture));
+    options.general |= CL_SCAN_GENERAL_ALLMATCHES | CL_SCAN_GENERAL_COLLECT_METADATA;
+
+    dbdir = cli_gentemp(NULL);
+    ck_assert_msg(NULL != dbdir, "cli_gentemp failed");
+    ck_assert_msg(0 == mkdir(dbdir, 0700), "mkdir(%s) failed", dbdir);
+
+    path_len = snprintf(dbfile, sizeof(dbfile), "%s" PATHSEP "pua.ndb", dbdir);
+    ck_assert_msg((path_len > 0) && (path_len < (int)sizeof(dbfile)),
+                  "temporary database path is too long");
+    db = fopen(dbfile, "wb");
+    ck_assert_msg(NULL != db, "failed to create %s", dbfile);
+    ck_assert_msg(0 <= fputs("PUA.Test.IgnoreFirst:0:*:616c706861\n", db),
+                  "failed to write first PUA signature");
+    ck_assert_msg(0 <= fputs("PUA.Test.KeepSecond:0:*:62657461\n", db),
+                  "failed to write second PUA signature");
+    ck_assert_msg(0 == fclose(db), "failed to close %s", dbfile);
+    db = NULL;
+
+    pua_engine = cl_engine_new();
+    ck_assert_msg(NULL != pua_engine, "cl_engine_new failed");
+    ret = cl_load(dbfile, pua_engine, &sigs, CL_DB_STDOPT | CL_DB_PUA);
+    ck_assert_msg(CL_SUCCESS == ret, "cl_load(%s) returned %s", dbfile, cl_strerror(ret));
+    ck_assert_msg(2 == sigs, "unexpected signature count: %u", sigs);
+    ret = cl_engine_compile(pua_engine);
+    ck_assert_msg(CL_SUCCESS == ret, "cl_engine_compile returned %s", cl_strerror(ret));
+
+    map = cl_fmap_open_memory((const void *)map_data, sizeof(map_data) - 1);
+    ck_assert_msg(NULL != map, "cl_fmap_open_memory failed");
+
+    cl_engine_set_scan_callback(pua_engine, ignore_first_alert_callback, CL_SCAN_CALLBACK_ALERT);
+    cl_engine_set_clcb_file_props(pua_engine, capture_allmatch_pua_file_props_callback);
+    ret = cl_scanmap_ex(map, "two-pua-alerts", &verdict, &alert, &scanned, pua_engine, &options, &capture,
+                        NULL, NULL, NULL, NULL, NULL);
+    cl_engine_set_clcb_file_props(pua_engine, NULL);
+    cl_engine_set_scan_callback(pua_engine, NULL, CL_SCAN_CALLBACK_ALERT);
+
+    ck_assert_msg(CL_SUCCESS == ret, "cl_scanmap_ex returned %s", cl_strerror(ret));
+    ck_assert_msg(CL_VERDICT_POTENTIALLY_UNWANTED == verdict, "unexpected verdict: %d", verdict);
+    ck_assert_msg(NULL != alert && 0 == strcmp(alert, kept_pua), "alert: %s", alert ? alert : "(null)");
+    ck_assert_msg(scanned > 0, "scanned: %" PRIu64, scanned);
+    ck_assert_msg(capture.alert_count >= 2, "alert callback count: %u", capture.alert_count);
+    ck_assert_msg(1 == capture.metadata.count, "metadata callback count: %u", capture.metadata.count);
+    ck_assert_msg(CL_SUCCESS == capture.metadata.status, "metadata callback status: %s",
+                  cl_strerror(capture.metadata.status));
+    ck_assert_msg(NULL != capture.metadata.json, "metadata callback did not provide JSON");
+
+    ck_assert_msg(metadata_json_array_has_name(capture.metadata.json, "Alerts", kept_pua),
+                  "metadata Alerts array did not keep the accepted PUA: %s", capture.metadata.json);
+    ck_assert_msg(!metadata_json_array_has_name(capture.metadata.json, "Alerts", ignored_pua),
+                  "metadata Alerts array kept the ignored PUA: %s", capture.metadata.json);
+    ck_assert_msg(!metadata_json_named_object_has_key(capture.metadata.json, kept_pua, "\"Ignored\""),
+                  "metadata marked the accepted PUA ignored: %s", capture.metadata.json);
+    ck_assert_msg(metadata_json_named_object_has_key(capture.metadata.json, ignored_pua, "\"Ignored\""),
+                  "metadata did not mark the ignored PUA ignored: %s", capture.metadata.json);
+
+    cl_fmap_close(map);
+    cl_engine_free(pua_engine);
+    free(capture.metadata.json);
+    cli_unlink(dbfile);
+    cli_rmdirs(dbdir);
+    free(dbdir);
+}
+END_TEST
+
+START_TEST(test_cl_scanmap_ex_alert_exceeds_max_filesize)
+{
+    char map_data[6] = {'a', 'b', 'c', 'd', 'e', 'f'};
+    cl_fmap_t *map;
+    struct cl_scan_options options;
+    cl_verdict_t verdict = CL_VERDICT_TRUSTED;
+    const char *alert    = "stale";
+    uint64_t scanned     = 42;
+    char *hash           = (char *)1;
+    char *file_type      = (char *)1;
+    cl_error_t ret;
+    struct file_props_capture metadata_capture;
+
+    memset(&options, 0, sizeof(struct cl_scan_options));
+    memset(&metadata_capture, 0, sizeof(metadata_capture));
+    options.heuristic |= CL_SCAN_HEURISTIC_EXCEEDS_MAX;
+
+    ck_assert_msg(cl_engine_set_num(g_engine, CL_ENGINE_MAX_FILESIZE, sizeof(map_data) - 1) == CL_SUCCESS,
+                  "cl_engine_set_num(CL_ENGINE_MAX_FILESIZE)");
+
+    map = cl_fmap_open_memory(map_data, sizeof(map_data));
+    ck_assert_msg(!!map, "cl_fmap_open_memory failed");
+
+    ret = cl_scanmap_ex(map, "big-file", &verdict, &alert, &scanned, g_engine, &options, NULL,
+                        NULL, NULL, NULL, NULL, NULL);
+
+    ck_assert_msg(ret == CL_SUCCESS, "cl_scanmap_ex returned %s", cl_strerror(ret));
+    ck_assert_msg(verdict == CL_VERDICT_POTENTIALLY_UNWANTED, "unexpected verdict: %d", verdict);
+    ck_assert_msg(alert && !strcmp(alert, "Heuristics.Limits.Exceeded.MaxFileSize"), "alert: %s", alert);
+    ck_assert_msg(scanned == 0, "scanned: %" PRIu64, scanned);
+
+    options.general |= CL_SCAN_GENERAL_HEURISTIC_PRECEDENCE;
+    verdict = CL_VERDICT_TRUSTED;
+    alert   = "stale";
+    scanned = 42;
+
+    ret = cl_scanmap_ex(map, "big-file", &verdict, &alert, &scanned, g_engine, &options, NULL,
+                        NULL, NULL, NULL, NULL, NULL);
+
+    ck_assert_msg(ret == CL_SUCCESS, "cl_scanmap_ex with heuristic precedence returned %s", cl_strerror(ret));
+    ck_assert_msg(verdict == CL_VERDICT_STRONG_INDICATOR, "unexpected verdict with heuristic precedence: %d", verdict);
+    ck_assert_msg(alert && !strcmp(alert, "Heuristics.Limits.Exceeded.MaxFileSize"), "alert with heuristic precedence: %s", alert);
+    ck_assert_msg(scanned == 0, "scanned with heuristic precedence: %" PRIu64, scanned);
+
+    options.general &= ~CL_SCAN_GENERAL_HEURISTIC_PRECEDENCE;
+    verdict = CL_VERDICT_TRUSTED;
+    scanned = 42;
+
+    ret = cl_scanmap_ex(map, "big-file", &verdict, NULL, &scanned, g_engine, &options, NULL,
+                        NULL, NULL, NULL, NULL, NULL);
+
+    ck_assert_msg(ret == CL_SUCCESS, "cl_scanmap_ex with NULL alert returned %s", cl_strerror(ret));
+    ck_assert_msg(verdict == CL_VERDICT_POTENTIALLY_UNWANTED, "unexpected verdict with NULL alert: %d", verdict);
+    ck_assert_msg(scanned == 0, "scanned with NULL alert: %" PRIu64, scanned);
+
+    cl_engine_set_scan_callback(g_engine, ignore_alert_callback, CL_SCAN_CALLBACK_ALERT);
+    verdict = CL_VERDICT_TRUSTED;
+    alert   = "stale";
+    scanned = 42;
+
+    ret = cl_scanmap_ex(map, "big-file", &verdict, &alert, &scanned, g_engine, &options, NULL,
+                        NULL, NULL, NULL, NULL, NULL);
+    cl_engine_set_scan_callback(g_engine, NULL, CL_SCAN_CALLBACK_ALERT);
+
+    ck_assert_msg(ret == CL_SUCCESS, "cl_scanmap_ex with ignored alert returned %s", cl_strerror(ret));
+    ck_assert_msg(verdict == CL_VERDICT_NOTHING_FOUND, "unexpected verdict with ignored alert: %d", verdict);
+    ck_assert_msg(alert == NULL, "alert with ignored alert: %s", alert);
+    ck_assert_msg(scanned == 0, "scanned with ignored alert: %" PRIu64, scanned);
+
+    options.general |= CL_SCAN_GENERAL_COLLECT_METADATA;
+    cl_engine_set_scan_callback(g_engine, ignore_alert_callback, CL_SCAN_CALLBACK_ALERT);
+    cl_engine_set_clcb_file_props(g_engine, capture_file_props_callback);
+    verdict = CL_VERDICT_TRUSTED;
+    alert   = "stale";
+    scanned = 42;
+
+    ret = cl_scanmap_ex(map, "big-file", &verdict, &alert, &scanned, g_engine, &options, &metadata_capture,
+                        NULL, NULL, NULL, NULL, NULL);
+    cl_engine_set_clcb_file_props(g_engine, NULL);
+    cl_engine_set_scan_callback(g_engine, NULL, CL_SCAN_CALLBACK_ALERT);
+    options.general &= ~CL_SCAN_GENERAL_COLLECT_METADATA;
+
+    ck_assert_msg(ret == CL_SUCCESS, "cl_scanmap_ex with ignored metadata alert returned %s", cl_strerror(ret));
+    ck_assert_msg(verdict == CL_VERDICT_NOTHING_FOUND, "unexpected verdict with ignored metadata alert: %d", verdict);
+    ck_assert_msg(alert == NULL, "alert with ignored metadata alert: %s", alert ? alert : "(null)");
+    ck_assert_msg(scanned == 0, "scanned with ignored metadata alert: %" PRIu64, scanned);
+    ck_assert_msg(metadata_capture.count == 1, "metadata callback count: %u", metadata_capture.count);
+    ck_assert_msg(metadata_capture.status == CL_SUCCESS, "metadata callback status: %s", cl_strerror(metadata_capture.status));
+    ck_assert_msg(metadata_capture.json != NULL, "metadata callback did not provide JSON");
+    ck_assert_msg(strstr(metadata_capture.json, "\"Alerts\"") == NULL, "metadata JSON still has Alerts: %s", metadata_capture.json);
+    ck_assert_msg(strstr(metadata_capture.json, "Heuristics.Limits.Exceeded.MaxFileSize") != NULL,
+                  "metadata JSON is missing ignored indicator: %s", metadata_capture.json);
+    ck_assert_msg(strstr(metadata_capture.json, "\"Ignored\"") != NULL,
+                  "metadata JSON did not mark ignored indicator: %s", metadata_capture.json);
+    free(metadata_capture.json);
+    metadata_capture.json = NULL;
+
+    options.general |= CL_SCAN_GENERAL_ALLMATCHES;
+    cl_engine_set_scan_callback(g_engine, ignore_alert_callback, CL_SCAN_CALLBACK_ALERT);
+    verdict = CL_VERDICT_TRUSTED;
+    alert   = "stale";
+    scanned = 42;
+
+    ret = cl_scanmap_ex(map, "big-file", &verdict, &alert, &scanned, g_engine, &options, NULL,
+                        NULL, NULL, NULL, NULL, NULL);
+    cl_engine_set_scan_callback(g_engine, NULL, CL_SCAN_CALLBACK_ALERT);
+
+    ck_assert_msg(ret == CL_SUCCESS, "cl_scanmap_ex with ignored allmatch alert returned %s", cl_strerror(ret));
+    ck_assert_msg(verdict == CL_VERDICT_NOTHING_FOUND, "unexpected verdict with ignored allmatch alert: %d", verdict);
+    ck_assert_msg(alert == NULL, "alert with ignored allmatch alert: %s", alert);
+    ck_assert_msg(scanned == 0, "scanned with ignored allmatch alert: %" PRIu64, scanned);
+
+    legacy_virus_found_fd      = 1234;
+    legacy_virus_found_count   = 0;
+    legacy_virus_found_name    = NULL;
+    legacy_virus_found_context = NULL;
+    verdict                    = CL_VERDICT_TRUSTED;
+    alert                      = "stale";
+    scanned                    = 42;
+
+    cl_engine_set_clcb_virus_found(g_engine, record_legacy_virus_found_callback);
+    ret = cl_scanmap_ex(map, "big-file", &verdict, &alert, &scanned, g_engine, &options, &legacy_virus_found_fd,
+                        NULL, NULL, NULL, NULL, NULL);
+    cl_engine_set_clcb_virus_found(g_engine, NULL);
+
+    ck_assert_msg(ret == CL_SUCCESS, "cl_scanmap_ex with legacy callback returned %s", cl_strerror(ret));
+    ck_assert_msg(verdict == CL_VERDICT_POTENTIALLY_UNWANTED, "unexpected verdict with legacy callback: %d", verdict);
+    ck_assert_msg(alert && !strcmp(alert, "Heuristics.Limits.Exceeded.MaxFileSize"), "alert with legacy callback: %s", alert);
+    ck_assert_msg(scanned == 0, "scanned with legacy callback: %" PRIu64, scanned);
+    ck_assert_msg(legacy_virus_found_count == 1, "legacy virus callback count: %u", legacy_virus_found_count);
+    ck_assert_msg(legacy_virus_found_fd == -1, "legacy virus callback fd: %d", legacy_virus_found_fd);
+    ck_assert_msg(legacy_virus_found_name && !strcmp(legacy_virus_found_name, "Heuristics.Limits.Exceeded.MaxFileSize"),
+                  "legacy virus callback name: %s", legacy_virus_found_name);
+    ck_assert_msg(legacy_virus_found_context == &legacy_virus_found_fd,
+                  "legacy virus callback context: %p", legacy_virus_found_context);
+
+    options.general &= ~CL_SCAN_GENERAL_ALLMATCHES;
+    verdict   = CL_VERDICT_TRUSTED;
+    alert     = "stale";
+    scanned   = 42;
+    hash      = (char *)1;
+    file_type = (char *)1;
+
+    ret = cl_scanmap_ex(map, "big-file", &verdict, &alert, &scanned, NULL, &options, NULL,
+                        NULL, &hash, NULL, NULL, &file_type);
+
+    ck_assert_msg(ret == CL_ENULLARG, "cl_scanmap_ex with NULL engine returned %s", cl_strerror(ret));
+    ck_assert_msg(verdict == CL_VERDICT_NOTHING_FOUND, "unexpected verdict with NULL engine: %d", verdict);
+    ck_assert_msg(alert == NULL, "alert with NULL engine: %s", alert);
+    ck_assert_msg(scanned == 0, "scanned with NULL engine: %" PRIu64, scanned);
+    ck_assert_msg(hash == NULL, "hash with NULL engine: %p", (void *)hash);
+    ck_assert_msg(file_type == NULL, "file type with NULL engine: %p", (void *)file_type);
+
+    cl_fmap_close(map);
+}
+END_TEST
+
 START_TEST(test_fmap_duplicate)
 {
     cl_fmap_t *map;
@@ -1339,6 +1779,8 @@ static Suite *test_cl_suite(void)
     tcase_add_loop_test(tc_cl_scan, test_cl_scandesc_callback_allscan, 0, expect);
     tcase_add_loop_test(tc_cl_scan, test_cl_scanfile_callback, 0, expect);
     tcase_add_loop_test(tc_cl_scan, test_cl_scanfile_callback_allscan, 0, expect);
+    tcase_add_loop_test(tc_cl_scan, test_cl_scanfile_ex_signature_match, 0, expect);
+    tcase_add_loop_test(tc_cl_scan, test_cl_scanfile_ex_ignored_strong_alert, 0, expect);
 #ifndef _WIN32
     tcase_add_loop_test(tc_cl_scan, test_cl_scanmap_callback_handle, 0, expect);
     tcase_add_loop_test(tc_cl_scan, test_cl_scanmap_callback_handle_allscan, 0, expect);
@@ -1347,6 +1789,8 @@ static Suite *test_cl_suite(void)
     tcase_add_loop_test(tc_cl_scan, test_cl_scanmap_callback_mem, 0, expect);
     tcase_add_loop_test(tc_cl_scan, test_cl_scanmap_callback_mem_allscan, 0, expect);
 #endif
+    tcase_add_test(tc_cl_scan, test_cl_scanmap_ex_alert_exceeds_max_filesize);
+    tcase_add_test(tc_cl_scan, test_cl_scanmap_ex_allmatch_ignored_pua_metadata);
     tcase_add_loop_test(tc_cl_scan, test_fmap_duplicate, 0, expect);
     tcase_add_loop_test(tc_cl_scan, test_fmap_duplicate_out_of_bounds, 0, expect);
     tcase_add_loop_test(tc_cl_scan, test_fmap_assorted_api, 0, expect);

--- a/unit_tests/clamscan/_basic_test.py
+++ b/unit_tests/clamscan/_basic_test.py
@@ -94,3 +94,31 @@ class TC(testcase.TestCase):
         expected_results.append('Infected files: 0')
         unexpected_results = ['{}: ClamAV-Test-File.UNOFFICIAL FOUND'.format(testpath.name) for testpath in TC.testpaths]
         self.verify_output(output.out, expected=expected_results, unexpected=unexpected_results)
+
+    def test_alert_exceeds_max_filesize(self):
+        self.step_name('Test that --alert-exceeds-max reports MaxFileSize as an alert')
+
+        big_file = TC.path_tmp / 'big_file'
+        big_file.write_bytes(b'\x00' * 501)
+
+        command = '{valgrind} {valgrind_args} {clamscan} -d {path_db} --max-filesize=500 --alert-exceeds-max {testfile}'.format(
+            valgrind=TC.valgrind, valgrind_args=TC.valgrind_args,
+            clamscan=TC.clamscan,
+            path_db=TC.path_db / 'clamav.hdb',
+            testfile=big_file,
+        )
+        output = self.execute_command(command)
+
+        assert output.ec == 1  # alert found
+
+        expected_results = [
+            'big_file: Heuristics.Limits.Exceeded.MaxFileSize FOUND',
+            'Scanned files: 1',
+            'Infected files: 1',
+        ]
+        unexpected_results = [
+            'Virus(es) detected ERROR',
+            'Total errors:',
+            'OK',
+        ]
+        self.verify_output(output.out, expected=expected_results, unexpected=unexpected_results)

--- a/unit_tests/examples/ex_scan_callbacks_test.py
+++ b/unit_tests/examples/ex_scan_callbacks_test.py
@@ -193,8 +193,8 @@ class TC(testcase.TestCase):
     def test_cl_scan_callbacks_clam_zip_basic_one_match(self):
         self.step_name('Same as basic test with clam.zip that just keeps scanning--but disables allmatch mode.')
 
-        # Notably, the return code at the end should be CL_VIRUS (1) instead of CL_SUCCESS (0).
-        # This is because the reason the scan ended "early" is because of the alert in the clam.exe file.
+        # The extended API reports the alert through the verdict and keeps the
+        # scan status at CL_SUCCESS.
 
         path_db = TC.path_source / 'unit_tests' / 'input' / 'clamav.hdb'
 
@@ -282,7 +282,7 @@ class TC(testcase.TestCase):
                 'Hash:         21495c3a579d537dc63b0df710f63e60a0bfbc74d1c2739a313dbd42dd31e1fa',
                 'File Type:    CL_TYPE_ZIP',
                 'Verdict:      CL_VERDICT_STRONG_INDICATOR',
-                'Return Code:  CL_VIRUS (1)',
+                'Return Code:  CL_SUCCESS (0)',
             ]
 
         command = '{valgrind} {valgrind_args} {example} -d {database} -f {target} --script {script} --one-match'.format(
@@ -293,8 +293,8 @@ class TC(testcase.TestCase):
         )
         output = self.execute_command(command)
 
-        # Check for CL_VIRUS return code
-        assert output.ec == 1
+        # Check for CL_SUCCESS return code
+        assert output.ec == 0
 
         # Custom logic to verify the output making sure that all expected results are found in the output in order.
         #


### PR DESCRIPTION
## Summary

This updates extended scan result handling so signature detections are reported
through the scan verdict rather than as hard errors. Large top-level files that
exceed MaxFileSize now use the same evidence, callback, verdict, and output
propagation as ordinary alerts.

## Details

- Record detection-only results in verdict_out and normalize CL_VIRUS to
  CL_SUCCESS for extended scan APIs after final verdict derivation.
- Preserve legacy scan APIs by translating alert verdicts back to CL_VIRUS.
- Keep delayed allmatch PUA legacy callback fd behavior at -1.
- Skip metadata preclass scans after a top-level MaxFileSize stop so metadata
  collection cannot become a replacement scan path.
- Pass IndicatorType through internal alert callback helpers and evidence
  removal.
- Centralize scan output initialization and clarify optional last_alert_out
  documentation.
- Harden alert metadata error handling and FFI error cleanup.
- Log hash-hint validation errors with the resolved hash name.

## Impact

This keeps the extended API contract consistent: callers check verdict_out for
detections while CL_SUCCESS means the scan completed without an operational
error. Existing legacy APIs continue to return CL_VIRUS for alert verdicts.

## Validation

- cmake --build build --target check_clamav
- cmake --build build --target clamscan
- cmake --build build --target ex_scan_callbacks
- cmake --build build --target tgt_clamav_hdb_scanfiles_clam.split.oneseg.zip
- ctest --test-dir build -V -R '^(libclamav|libclamav_rust)$'\n- ctest --test-dir build -V -R '^clamscan$'\n- ctest --test-dir build -V -R '^examples$'\n- git -C clamav --no-optional-locks diff --check\n\nCLAM-3013