### PR TITLE
Raise minimum CMake version to 3.17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,8 @@
 
 # Copyright (C) 2019-2026 Cisco Systems, Inc. and/or its affiliates. All rights reserved.
 
-if(WIN32)
-    cmake_minimum_required( VERSION 3.16 ) # For file(GET_RUNTIME_DEPENDENCIES)
-else()
-    cmake_minimum_required( VERSION 3.14 )
-endif()
+# CMake 3.17 preserves link directories from private static dependencies.
+cmake_minimum_required( VERSION 3.17 )
 
 set(CMAKE_C_STANDARD 90)
 set(CMAKE_C_STANDARD_REQUIRED ON)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -76,7 +76,7 @@ As of ClamAV 0.104, CMake is required to build ClamAV.
 The Windows Visual Studio and Autotools build systems have been removed.
 
 You will need:
-- CMake (3.14+ for Unix/Linux; 3.16+ for Windows)
+- CMake 3.17 or newer
 - A C compiler toolchain such as `gcc`, `clang`, or Microsoft Visual Studio.
 - The Rust compiler toolchain.
 


### PR DESCRIPTION
## Summary

Raise ClamAV's minimum CMake version to 3.17 for all platforms.

## Problem

Static dependency packages can export private dependencies as bare `-l` flags with link directories carried separately through imported targets. In CMake policy modes older than 3.17, those interface link directories are not propagated through private dependencies of static libraries, which can produce linker failures for libraries such as libssh2, OpenSSL, and nghttp2.

## Solution

Use a single `cmake_minimum_required(VERSION 3.17)` so CMake policy CMP0099 is set to `NEW` on every platform.

## Validation

Configured locally until dependency discovery failed on missing JSON-C, after top-level CMake parsing completed.
