### PR TITLE
libclamav: update bundled YARA parser behavior

### DIFF
--- a/libclamav/filtering.c
+++ b/libclamav/filtering.c
@@ -298,6 +298,7 @@ static inline unsigned char spec_ith_char(const struct char_spec *spec, unsigned
         cc0   = spec0->negative ? 0 : c0;            \
         cc1   = spec1->negative ? 0 : c1;            \
         for (; cc0 <= c0end; cc0++) {                \
+            cc1 = spec1->negative ? 0 : c1;          \
             for (; cc1 <= c1end; cc1++) {            \
                 uint16_t a = cc0 | (cc1 << 8);       \
                 if (spec0->negative && cc0 == c0)    \

--- a/libclamav/filtering.c
+++ b/libclamav/filtering.c
@@ -524,6 +524,21 @@ int filter_add_acpatt(struct filter *m, const struct cli_ac_patt *pat)
                 spec->end   = 0xf0 | spec->start;
                 spec->step  = 0x10;
                 break;
+            case CLI_MATCH_NOT_BYTE:
+                spec->start = spec->end = (uint8_t)p;
+                spec->step              = 1;
+                spec->negative          = 1;
+                break;
+            case CLI_MATCH_NOT_NIBBLE_HIGH:
+            case CLI_MATCH_NOT_NIBBLE_LOW:
+                /*
+                 * The filter may over-approximate, but must not reject a
+                 * candidate accepted by the full matcher.
+                 */
+                spec->start = 0x00;
+                spec->end   = 0xff;
+                spec->step  = 1;
+                break;
             default:
                 cli_errmsg("filtering: unknown wildcard character: %d\n", p);
                 return -1;

--- a/libclamav/matcher-ac.c
+++ b/libclamav/matcher-ac.c
@@ -463,11 +463,7 @@ cl_error_t cli_ac_addpatt(struct cli_matcher *root, struct cli_ac_patt *pattern)
         }
     }
 
-    /*
-     * Negation may separate every literal byte, as in 41~0042. In that case,
-     * use one literal trie transition and verify the full predicate pattern.
-     */
-    if (len < root->ac_mindepth && !(pattern->has_negation && len == 1)) {
+    if (len < root->ac_mindepth) {
         /* cli_errmsg("cli_ac_addpatt: Signature for %s is too short\n", pattern->virname); */
         return CL_EMALFDB;
     }
@@ -623,17 +619,6 @@ static int ac_maketrans(struct cli_matcher *root)
                     return ret;
             }
         }
-    }
-
-    /*
-     * A negated pattern may use a one-byte literal anchor when no multi-byte
-     * literal window is available. These final root children were leaves throughout
-     * transition construction, so connect them only after the BFS is done.
-     */
-    for (i = 0; i < 256; i++) {
-        node = ac_root->trans[i];
-        if (node != ac_root && IS_FINAL(node) && IS_LEAF(node))
-            node->trans = node->fail->trans;
     }
 
     return CL_SUCCESS;
@@ -2396,149 +2381,55 @@ inline static int ac_analyze_expr(char *hexstr, int *fixed_len, int *sub_len)
     return numexpr;
 }
 
+static inline int ac_alt_unit_matches(uint16_t unit, unsigned char byte)
+{
+    switch (unit & CLI_MATCH_METADATA) {
+        case CLI_MATCH_CHAR:
+            return (unit & 0xff) == byte;
+        case CLI_MATCH_NOCASE:
+            return CLI_NOCASE(unit & 0xff) == CLI_NOCASE(byte);
+        case CLI_MATCH_IGNORE:
+            return 1;
+        case CLI_MATCH_NIBBLE_HIGH:
+            return (unit & 0xf0) == (byte & 0xf0);
+        case CLI_MATCH_NIBBLE_LOW:
+            return (unit & 0x0f) == (byte & 0x0f);
+        case CLI_MATCH_NOT_BYTE:
+            return (unit & 0xff) != byte;
+        case CLI_MATCH_NOT_NIBBLE_HIGH:
+            return (unit & 0xf0) != (byte & 0xf0);
+        case CLI_MATCH_NOT_NIBBLE_LOW:
+            return (unit & 0x0f) != (byte & 0x0f);
+        default:
+            /* Unknown units are handled conservatively as overlapping. */
+            return 1;
+    }
+}
+
+/* Return zero when two alternate strings can match the same bytes. */
 inline static int ac_uicmp(uint16_t *a, size_t alen, uint16_t *b, size_t blen, int *wild)
 {
-    uint16_t awild, bwild, side_wild;
     size_t i, minlen = MIN(alen, blen);
-
-    side_wild = 0;
+    int differs = alen != blen;
 
     for (i = 0; i < minlen; i++) {
-        awild = a[i] & CLI_MATCH_WILDCARD;
-        bwild = b[i] & CLI_MATCH_WILDCARD;
+        unsigned int byte;
 
-        if (awild == bwild) {
-            switch (awild) {
-                case CLI_MATCH_CHAR:
-                    if ((a[i] & 0xff) != (b[i] & 0xff)) {
-                        return (b[i] & 0xff) - (a[i] & 0xff);
-                    }
-                    break;
-                case CLI_MATCH_IGNORE:
-                    break;
-                case CLI_MATCH_NIBBLE_HIGH:
-                    if ((a[i] & 0xf0) != (b[i] & 0xf0)) {
-                        return (b[i] & 0xf0) - (a[i] & 0xf0);
-                    }
-                    break;
-                case CLI_MATCH_NIBBLE_LOW:
-                    if ((a[i] & 0x0f) != (b[i] & 0x0f)) {
-                        return (b[i] & 0x0f) - (a[i] & 0x0f);
-                    }
-                    break;
-                case CLI_MATCH_NOT_BYTE:
-                    if ((a[i] & 0xff) != (b[i] & 0xff)) {
-                        return (b[i] & 0xff) - (a[i] & 0xff);
-                    }
-                    break;
-                case CLI_MATCH_NOT_NIBBLE_HIGH:
-                    if ((a[i] & 0xf0) != (b[i] & 0xf0)) {
-                        return (b[i] & 0xf0) - (a[i] & 0xf0);
-                    }
-                    break;
-                case CLI_MATCH_NOT_NIBBLE_LOW:
-                    if ((a[i] & 0x0f) != (b[i] & 0x0f)) {
-                        return (b[i] & 0x0f) - (a[i] & 0x0f);
-                    }
-                    break;
-                default:
-                    cli_errmsg("ac_uicmp: unhandled wildcard type\n");
-                    return 1;
-            }
-        } else {                           /* not identical wildcard types */
-            if (awild == CLI_MATCH_CHAR) { /* b is only wild */
-                switch (bwild) {
-                    case CLI_MATCH_IGNORE:
-                        side_wild |= 2;
-                        break;
-                    case CLI_MATCH_NIBBLE_HIGH:
-                        if ((a[i] & 0xf0) != (b[i] & 0xf0)) {
-                            return (b[i] & 0xf0) - (a[i] & 0xff);
-                        }
-                        side_wild |= 2;
-                        break;
-                    case CLI_MATCH_NIBBLE_LOW:
-                        if ((a[i] & 0x0f) != (b[i] & 0x0f)) {
-                            return (b[i] & 0x0f) - (a[i] & 0xff);
-                        }
-                        side_wild |= 2;
-                        break;
-                    case CLI_MATCH_NOT_BYTE:
-                        if ((a[i] & 0xff) == (b[i] & 0xff))
-                            return 1;
-                        side_wild |= 2;
-                        break;
-                    case CLI_MATCH_NOT_NIBBLE_HIGH:
-                        if ((a[i] & 0xf0) == (b[i] & 0xf0))
-                            return 1;
-                        side_wild |= 2;
-                        break;
-                    case CLI_MATCH_NOT_NIBBLE_LOW:
-                        if ((a[i] & 0x0f) == (b[i] & 0x0f))
-                            return 1;
-                        side_wild |= 2;
-                        break;
-                    default:
-                        cli_errmsg("ac_uicmp: unhandled wildcard type\n");
-                        return -1;
-                }
-            } else if (bwild == CLI_MATCH_CHAR) { /* a is only wild */
-                switch (awild) {
-                    case CLI_MATCH_IGNORE:
-                        side_wild |= 1;
-                        break;
-                    case CLI_MATCH_NIBBLE_HIGH:
-                        if ((a[i] & 0xf0) != (b[i] & 0xf0)) {
-                            return (b[i] & 0xff) - (a[i] & 0xf0);
-                        }
-                        side_wild |= 1;
-                        break;
-                    case CLI_MATCH_NIBBLE_LOW:
-                        if ((a[i] & 0x0f) != (b[i] & 0x0f)) {
-                            return (b[i] & 0xff) - (a[i] & 0x0f);
-                        }
-                        side_wild |= 1;
-                        break;
-                    case CLI_MATCH_NOT_BYTE:
-                        if ((a[i] & 0xff) == (b[i] & 0xff))
-                            return 1;
-                        side_wild |= 1;
-                        break;
-                    case CLI_MATCH_NOT_NIBBLE_HIGH:
-                        if ((a[i] & 0xf0) == (b[i] & 0xf0))
-                            return 1;
-                        side_wild |= 1;
-                        break;
-                    case CLI_MATCH_NOT_NIBBLE_LOW:
-                        if ((a[i] & 0x0f) == (b[i] & 0x0f))
-                            return 1;
-                        side_wild |= 1;
-                        break;
-                    default:
-                        cli_errmsg("ac_uicmp: unhandled wild typing\n");
-                        return 1;
-                }
-            } else { /* not identical, both wildcards */
-                if (awild == CLI_MATCH_IGNORE || bwild == CLI_MATCH_IGNORE) {
-                    if (awild == CLI_MATCH_IGNORE) {
-                        side_wild |= 1;
-                    } else if (bwild == CLI_MATCH_IGNORE) {
-                        side_wild |= 2;
-                    }
-                } else {
-                    /* only high and low nibbles should be left here */
-                    side_wild |= 3;
-                }
-            }
+        if (a[i] != b[i])
+            differs = 1;
+
+        for (byte = 0; byte <= 0xff; byte++) {
+            if (ac_alt_unit_matches(a[i], (unsigned char)byte) &&
+                ac_alt_unit_matches(b[i], (unsigned char)byte))
+                break;
         }
 
-        /* both sides contain a wildcard that contains the other, therefore unique by wildcards */
-        if (side_wild == 3)
+        if (byte > 0xff)
             return 1;
     }
 
     if (wild)
-        *wild = side_wild;
+        *wild = differs;
     return 0;
 }
 
@@ -2603,6 +2494,10 @@ inline static int ac_addspecial_add_alt_node(const char *subexpr, uint8_t sigopt
                 MPOOL_FREE(root->mempool, newnode->str);
                 MPOOL_FREE(root->mempool, newnode);
                 return CL_SUCCESS;
+            } else {
+                /* Overlapping alternatives of equal length still need suffix backtracking. */
+                newnode->unique = 0;
+                ins->unique     = 0;
             }
         } /* TODO - possible sorting of altstr uniques and derivative groups? */
 
@@ -3159,12 +3054,6 @@ cl_error_t cli_ac_addsig(struct cli_matcher *root, const char *virname, const ch
     for (i = 0, j = 0; i < new->length[0]; i++) {
         uint16_t metadata = new->pattern[i] & CLI_MATCH_METADATA;
 
-        if (metadata == CLI_MATCH_NOT_BYTE ||
-            metadata == CLI_MATCH_NOT_NIBBLE_HIGH ||
-            metadata == CLI_MATCH_NOT_NIBBLE_LOW) {
-            new->has_negation = 1;
-        }
-
         if (metadata == CLI_MATCH_SPECIAL) {
             new->length[1] += new->special_table[j]->len[0];
             new->length[2] += new->special_table[j]->len[1];
@@ -3282,11 +3171,7 @@ cl_error_t cli_ac_addsig(struct cli_matcher *root, const char *virname, const ch
             ppos = nzpos;
         }
 
-        /*
-         * A negated pattern may have no adjacent literal pair. One literal is
-         * still a valid anchor because the remaining units are verified later.
-         */
-        if (plen < root->ac_mindepth && !(new->has_negation && plen == 1)) {
+        if (plen < root->ac_mindepth) {
             cli_errmsg("cli_ac_addsig: Can't find a static subpattern of length %u\n", root->ac_mindepth);
             mpool_ac_free_special(root->mempool, new);
             MPOOL_FREE(root->mempool, new->pattern);

--- a/libclamav/matcher-ac.c
+++ b/libclamav/matcher-ac.c
@@ -2639,7 +2639,7 @@ inline static int ac_special_altstr(const char *hexpr, uint8_t sigopts, struct c
 
     num = ac_analyze_expr(hexprcpy, &fixed, &slen);
 
-    if (!sigopts && fixed) {
+    if (!(sigopts & ~(ACPATT_OPTION_ONCE | ACPATT_OPTION_ASCII)) && fixed) {
         special->num    = 0;
         special->len[0] = special->len[1] = slen / 2;
         /* single-bytes are len 2 in hex */

--- a/libclamav/matcher-ac.c
+++ b/libclamav/matcher-ac.c
@@ -463,7 +463,11 @@ cl_error_t cli_ac_addpatt(struct cli_matcher *root, struct cli_ac_patt *pattern)
         }
     }
 
-    if (len < root->ac_mindepth) {
+    /*
+     * Negation may separate every literal byte, as in 41~0042. In that case,
+     * use one literal trie transition and verify the full predicate pattern.
+     */
+    if (len < root->ac_mindepth && !(pattern->has_negation && len == 1)) {
         /* cli_errmsg("cli_ac_addpatt: Signature for %s is too short\n", pattern->virname); */
         return CL_EMALFDB;
     }
@@ -619,6 +623,17 @@ static int ac_maketrans(struct cli_matcher *root)
                     return ret;
             }
         }
+    }
+
+    /*
+     * A negated pattern may use a one-byte literal anchor when no multi-byte
+     * literal window is available. These final root children were leaves throughout
+     * transition construction, so connect them only after the BFS is done.
+     */
+    for (i = 0; i < 256; i++) {
+        node = ac_root->trans[i];
+        if (node != ac_root && IS_FINAL(node) && IS_LEAF(node))
+            node->trans = node->fail->trans;
     }
 
     return CL_SUCCESS;
@@ -1047,6 +1062,21 @@ static int ac_forward_match_branch(const unsigned char *buffer, uint32_t bp, uin
                 match = 0;                                           \
             break;                                                   \
                                                                      \
+        case CLI_MATCH_NOT_BYTE:                                     \
+            if ((unsigned char)(p & 0x00ff) == b)                    \
+                match = 0;                                           \
+            break;                                                   \
+                                                                     \
+        case CLI_MATCH_NOT_NIBBLE_HIGH:                              \
+            if ((unsigned char)(p & 0x00f0) == (b & 0xf0))           \
+                match = 0;                                           \
+            break;                                                   \
+                                                                     \
+        case CLI_MATCH_NOT_NIBBLE_LOW:                               \
+            if ((unsigned char)(p & 0x000f) == (b & 0x0f))           \
+                match = 0;                                           \
+            break;                                                   \
+                                                                     \
         default:                                                     \
             cli_errmsg("ac_findmatch: Unknown metatype 0x%x\n", wc); \
             match = 0;                                               \
@@ -1091,6 +1121,21 @@ static int ac_forward_match_branch(const unsigned char *buffer, uint32_t bp, uin
                                                                                               \
         case CLI_MATCH_NIBBLE_LOW:                                                            \
             if ((unsigned char)(p & 0x000f) != (b & 0x0f))                                    \
+                match = 0;                                                                    \
+            break;                                                                            \
+                                                                                              \
+        case CLI_MATCH_NOT_BYTE:                                                              \
+            if ((unsigned char)(p & 0x00ff) == b)                                             \
+                match = 0;                                                                    \
+            break;                                                                            \
+                                                                                              \
+        case CLI_MATCH_NOT_NIBBLE_HIGH:                                                       \
+            if ((unsigned char)(p & 0x00f0) == (b & 0xf0))                                    \
+                match = 0;                                                                    \
+            break;                                                                            \
+                                                                                              \
+        case CLI_MATCH_NOT_NIBBLE_LOW:                                                        \
+            if ((unsigned char)(p & 0x000f) == (b & 0x0f))                                    \
                 match = 0;                                                                    \
             break;                                                                            \
                                                                                               \
@@ -1283,7 +1328,11 @@ static int ac_backward_match_branch(const unsigned char *buffer, uint32_t bp, ui
     }
 
     /* bp is shifted for left anchor check, thus invalidated as pattern start */
-    if (!(pattern->ch[0] & CLI_MATCH_IGNORE)) {
+    /*
+     * Compare the complete tag: negation tags share bits with
+     * CLI_MATCH_IGNORE but must still be verified after a gap.
+     */
+    if ((pattern->ch[0] & CLI_MATCH_METADATA) != CLI_MATCH_IGNORE) {
         if (pattern->ch_mindist[0] + (uint32_t)1 > bp)
             return 0;
 
@@ -1362,7 +1411,11 @@ static int ac_forward_match_branch(const unsigned char *buffer, uint32_t bp, uin
     }
 
     /* bp is shifted for right anchor check, thus invalidated as pattern right-side */
-    if (!(pattern->ch[1] & CLI_MATCH_IGNORE)) {
+    /*
+     * Compare the complete tag: negation tags share bits with
+     * CLI_MATCH_IGNORE but must still be verified after a gap.
+     */
+    if ((pattern->ch[1] & CLI_MATCH_METADATA) != CLI_MATCH_IGNORE) {
         bp += pattern->ch_mindist[1];
 
         for (i = pattern->ch_mindist[1]; i <= pattern->ch_maxdist[1]; i++) {
@@ -2318,7 +2371,11 @@ inline static int ac_analyze_expr(char *hexstr, int *fixed_len, int *sub_len)
             len = 0;
             numexpr++;
         } else {
-            if (hexstr[i] == '?')
+            /*
+             * A negated token has fixed width, but not a fixed value. Route
+             * alternates containing it through predicate-aware verification.
+             */
+            if (hexstr[i] == '?' || hexstr[i] == '~')
                 flen = 0;
             len++;
         }
@@ -2369,6 +2426,21 @@ inline static int ac_uicmp(uint16_t *a, size_t alen, uint16_t *b, size_t blen, i
                         return (b[i] & 0x0f) - (a[i] & 0x0f);
                     }
                     break;
+                case CLI_MATCH_NOT_BYTE:
+                    if ((a[i] & 0xff) != (b[i] & 0xff)) {
+                        return (b[i] & 0xff) - (a[i] & 0xff);
+                    }
+                    break;
+                case CLI_MATCH_NOT_NIBBLE_HIGH:
+                    if ((a[i] & 0xf0) != (b[i] & 0xf0)) {
+                        return (b[i] & 0xf0) - (a[i] & 0xf0);
+                    }
+                    break;
+                case CLI_MATCH_NOT_NIBBLE_LOW:
+                    if ((a[i] & 0x0f) != (b[i] & 0x0f)) {
+                        return (b[i] & 0x0f) - (a[i] & 0x0f);
+                    }
+                    break;
                 default:
                     cli_errmsg("ac_uicmp: unhandled wildcard type\n");
                     return 1;
@@ -2391,6 +2463,21 @@ inline static int ac_uicmp(uint16_t *a, size_t alen, uint16_t *b, size_t blen, i
                         }
                         side_wild |= 2;
                         break;
+                    case CLI_MATCH_NOT_BYTE:
+                        if ((a[i] & 0xff) == (b[i] & 0xff))
+                            return 1;
+                        side_wild |= 2;
+                        break;
+                    case CLI_MATCH_NOT_NIBBLE_HIGH:
+                        if ((a[i] & 0xf0) == (b[i] & 0xf0))
+                            return 1;
+                        side_wild |= 2;
+                        break;
+                    case CLI_MATCH_NOT_NIBBLE_LOW:
+                        if ((a[i] & 0x0f) == (b[i] & 0x0f))
+                            return 1;
+                        side_wild |= 2;
+                        break;
                     default:
                         cli_errmsg("ac_uicmp: unhandled wildcard type\n");
                         return -1;
@@ -2410,6 +2497,21 @@ inline static int ac_uicmp(uint16_t *a, size_t alen, uint16_t *b, size_t blen, i
                         if ((a[i] & 0x0f) != (b[i] & 0x0f)) {
                             return (b[i] & 0xff) - (a[i] & 0x0f);
                         }
+                        side_wild |= 1;
+                        break;
+                    case CLI_MATCH_NOT_BYTE:
+                        if ((a[i] & 0xff) == (b[i] & 0xff))
+                            return 1;
+                        side_wild |= 1;
+                        break;
+                    case CLI_MATCH_NOT_NIBBLE_HIGH:
+                        if ((a[i] & 0xf0) == (b[i] & 0xf0))
+                            return 1;
+                        side_wild |= 1;
+                        break;
+                    case CLI_MATCH_NOT_NIBBLE_LOW:
+                        if ((a[i] & 0x0f) == (b[i] & 0x0f))
+                            return 1;
                         side_wild |= 1;
                         break;
                     default:
@@ -2461,14 +2563,22 @@ inline static int ac_addspecial_add_alt_node(const char *subexpr, uint8_t sigopt
         return CL_EMEM;
     }
 
-    s = CLI_MPOOL_HEX2UI(root->mempool, subexpr);
+    {
+        size_t decoded_len = 0;
+
+        s = CLI_MPOOL_HEX2UI_LEN(root->mempool, subexpr, &decoded_len);
+        if (decoded_len > UINT16_MAX) {
+            MPOOL_FREE(root->mempool, s);
+            s = NULL;
+        }
+        newnode->len = (uint16_t)decoded_len;
+    }
     if (!s) {
         MPOOL_FREE(root->mempool, newnode);
         return CL_EMALFDB;
     }
 
     newnode->str    = s;
-    newnode->len    = (uint16_t)strlen(subexpr) / 2;
     newnode->unique = 1;
 
     /* setting nocase match */
@@ -2639,7 +2749,7 @@ inline static int ac_special_altstr(const char *hexpr, uint8_t sigopts, struct c
 
     num = ac_analyze_expr(hexprcpy, &fixed, &slen);
 
-    if (!(sigopts & ~(ACPATT_OPTION_ONCE | ACPATT_OPTION_ASCII)) && fixed) {
+    if (!sigopts && fixed) {
         special->num    = 0;
         special->len[0] = special->len[1] = slen / 2;
         /* single-bytes are len 2 in hex */
@@ -2725,6 +2835,7 @@ cl_error_t cli_ac_addsig(struct cli_matcher *root, const char *virname, const ch
     struct cli_ac_patt *new;
     char *pt, *pt2, *hex = NULL, *hexcpy = NULL;
     uint16_t i, j, ppos = 0, pend, *dec, nzpos = 0;
+    size_t decoded_len;
     uint8_t wprefix = 0, zprefix = 1, plen = 0, nzplen = 0;
     struct cli_ac_special *newspecial, **newtable;
     int ret, error = CL_SUCCESS;
@@ -2796,14 +2907,15 @@ cl_error_t cli_ac_addsig(struct cli_matcher *root, const char *virname, const ch
                 break;
             }
 
-            if (strlen(hex) == 2) {
+            if (strlen(hex) == 2 || strlen(hex) == 3) {
                 if (i) {
                     error = CL_EMALFDB;
                     break;
                 }
 
-                dec = cli_hex2ui(hex);
-                if (!dec) {
+                dec = cli_hex2ui_len(hex, &decoded_len);
+                if (!dec || decoded_len != 1) {
+                    free(dec);
                     error = CL_EMALFDB;
                     break;
                 }
@@ -2816,10 +2928,11 @@ cl_error_t cli_ac_addsig(struct cli_matcher *root, const char *virname, const ch
                 new->ch_mindist[i] = n1;
                 new->ch_maxdist[i] = n2;
                 hex                = pt2;
-            } else if (strlen(pt2) == 2) {
+            } else if (strlen(pt2) == 2 || strlen(pt2) == 3) {
                 i   = 1;
-                dec = cli_hex2ui(pt2);
-                if (!dec) {
+                dec = cli_hex2ui_len(pt2, &decoded_len);
+                if (!dec || decoded_len != 1) {
+                    free(dec);
                     error = CL_EMALFDB;
                     break;
                 }
@@ -3011,7 +3124,7 @@ cl_error_t cli_ac_addsig(struct cli_matcher *root, const char *virname, const ch
     /*
      * Convert the hex string pattern to a uint16_t* pattern (flags + byte) patterns.
      */
-    new->pattern = CLI_MPOOL_HEX2UI(root->mempool, hex ? hex : hexsig);
+    new->pattern = CLI_MPOOL_HEX2UI_LEN(root->mempool, hex ? hex : hexsig, &decoded_len);
     if (new->pattern == NULL) {
         if (new->special)
             mpool_ac_free_special(root->mempool, new);
@@ -3021,7 +3134,17 @@ cl_error_t cli_ac_addsig(struct cli_matcher *root, const char *virname, const ch
         return CL_EMALFDB;
     }
 
-    new->length[0] = (uint16_t)strlen(hex ? hex : hexsig) / 2;
+    if (decoded_len > UINT16_MAX) {
+        if (new->special)
+            mpool_ac_free_special(root->mempool, new);
+
+        MPOOL_FREE(root->mempool, new->pattern);
+        MPOOL_FREE(root->mempool, new);
+        free(hex);
+        return CL_EMALFDB;
+    }
+
+    new->length[0] = (uint16_t)decoded_len;
     if (new->length[0] < root->ac_mindepth) {
         cli_errmsg("cli_ac_addsig: Subpattern in signature is shorter than the minimum depth of the AC trie. (%u < %u)\n", new->length[0], root->ac_mindepth);
         if (new->special)
@@ -3034,7 +3157,15 @@ cl_error_t cli_ac_addsig(struct cli_matcher *root, const char *virname, const ch
     }
 
     for (i = 0, j = 0; i < new->length[0]; i++) {
-        if ((new->pattern[i] & CLI_MATCH_METADATA) == CLI_MATCH_SPECIAL) {
+        uint16_t metadata = new->pattern[i] & CLI_MATCH_METADATA;
+
+        if (metadata == CLI_MATCH_NOT_BYTE ||
+            metadata == CLI_MATCH_NOT_NIBBLE_HIGH ||
+            metadata == CLI_MATCH_NOT_NIBBLE_LOW) {
+            new->has_negation = 1;
+        }
+
+        if (metadata == CLI_MATCH_SPECIAL) {
             new->length[1] += new->special_table[j]->len[0];
             new->length[2] += new->special_table[j]->len[1];
             j++;
@@ -3151,7 +3282,11 @@ cl_error_t cli_ac_addsig(struct cli_matcher *root, const char *virname, const ch
             ppos = nzpos;
         }
 
-        if (plen < root->ac_mindepth) {
+        /*
+         * A negated pattern may have no adjacent literal pair. One literal is
+         * still a valid anchor because the remaining units are verified later.
+         */
+        if (plen < root->ac_mindepth && !(new->has_negation && plen == 1)) {
             cli_errmsg("cli_ac_addsig: Can't find a static subpattern of length %u\n", root->ac_mindepth);
             mpool_ac_free_special(root->mempool, new);
             MPOOL_FREE(root->mempool, new->pattern);

--- a/libclamav/matcher-ac.h
+++ b/libclamav/matcher-ac.h
@@ -104,6 +104,8 @@ struct cli_ac_patt {
     uint32_t boundary;
     uint8_t depth;
     uint8_t sigopts;
+    /* Allows an isolated literal to anchor a pattern whose other units are negated predicates. */
+    uint8_t has_negation;
 };
 
 struct cli_ac_list {

--- a/libclamav/matcher-ac.h
+++ b/libclamav/matcher-ac.h
@@ -104,8 +104,6 @@ struct cli_ac_patt {
     uint32_t boundary;
     uint8_t depth;
     uint8_t sigopts;
-    /* Allows an isolated literal to anchor a pattern whose other units are negated predicates. */
-    uint8_t has_negation;
 };
 
 struct cli_ac_list {

--- a/libclamav/matcher.h
+++ b/libclamav/matcher.h
@@ -71,6 +71,10 @@ void cli_targetinfo_destroy(struct cli_target_info *info);
 #define CLI_MATCH_SPECIAL     0x0200
 #define CLI_MATCH_NIBBLE_HIGH 0x0300
 #define CLI_MATCH_NIBBLE_LOW  0x0400
+/* Negated predicates are wildcard-class units; the low byte stores the excluded value. */
+#define CLI_MATCH_NOT_BYTE        0x0500
+#define CLI_MATCH_NOT_NIBBLE_HIGH 0x0600
+#define CLI_MATCH_NOT_NIBBLE_LOW  0x0700
 
 typedef enum tdb_type {
     CLI_TDB_UINT,

--- a/libclamav/mpool.c
+++ b/libclamav/mpool.c
@@ -863,27 +863,30 @@ char *cli_mpool_virname(mpool_t *mp, const char *virname, unsigned int official)
     return newname;
 }
 
-uint16_t *cli_mpool_hex2ui(mpool_t *mp, const char *hex)
+uint16_t *cli_mpool_hex2ui_len(mpool_t *mp, const char *hex, size_t *decoded_len)
 {
     uint16_t *str;
     size_t len;
 
-    len = strlen(hex);
+    if (decoded_len)
+        *decoded_len = 0;
 
-    if (len % 2 != 0) {
-        cli_errmsg("cli_mpool_hex2ui(): Malformed hexstring: %s (length: %lu)\n", hex, (unsigned long)len);
-        return NULL;
-    }
+    len = strlen(hex);
 
     str = mpool_calloc(mp, (len / 2) + 1, sizeof(uint16_t));
     if (!str)
         return NULL;
 
-    if (cli_realhex2ui(hex, str, len))
+    if (cli_realhex2ui(hex, str, len, decoded_len))
         return str;
 
     mpool_free(mp, str);
     return NULL;
+}
+
+uint16_t *cli_mpool_hex2ui(mpool_t *mp, const char *hex)
+{
+    return cli_mpool_hex2ui_len(mp, hex, NULL);
 }
 
 #ifdef DEBUGMPOOL

--- a/libclamav/mpool.h
+++ b/libclamav/mpool.h
@@ -46,6 +46,7 @@ char *cli_mpool_strdup(mpool_t *mpool, const char *s);
 char *cli_mpool_strndup(mpool_t *mpool, const char *s, size_t n);
 char *cli_mpool_virname(mpool_t *mpool, const char *virname, unsigned int official);
 uint16_t *cli_mpool_hex2ui(mpool_t *mpool, const char *hex);
+uint16_t *cli_mpool_hex2ui_len(mpool_t *mpool, const char *hex, size_t *decoded_len);
 void mpool_flush(mpool_t *mpool);
 int mpool_getstats(const struct cl_engine *engine, size_t *used, size_t *total);
 
@@ -59,6 +60,7 @@ int mpool_getstats(const struct cl_engine *engine, size_t *used, size_t *total);
 #define CLI_MPOOL_STRNDUP(mpool, s, n) cli_mpool_strndup(mpool, s, n)
 #define CLI_MPOOL_VIRNAME(mpool, a, b) cli_mpool_virname(mpool, a, b)
 #define CLI_MPOOL_HEX2UI(mpool, hex) cli_mpool_hex2ui(mpool, hex)
+#define CLI_MPOOL_HEX2UI_LEN(mpool, hex, decoded_len) cli_mpool_hex2ui_len(mpool, hex, decoded_len)
 #define MPOOL_FLUSH(val) mpool_flush(val)
 #define MPOOL_GETSTATS(mpool, used, total) mpool_getstats(mpool, used, total)
 
@@ -76,6 +78,7 @@ typedef void mpool_t;
 #define CLI_MPOOL_STRNDUP(mpool, s, n) cli_safer_strdup(s, n)
 #define CLI_MPOOL_VIRNAME(mpool, a, b) cli_virname(a, b)
 #define CLI_MPOOL_HEX2UI(mpool, hex) cli_hex2ui(hex)
+#define CLI_MPOOL_HEX2UI_LEN(mpool, hex, decoded_len) cli_hex2ui_len(hex, decoded_len)
 #define MPOOL_FLUSH(val)
 #define MPOOL_GETSTATS(mpool, used, total) -1
 

--- a/libclamav/readdb.c
+++ b/libclamav/readdb.c
@@ -3593,6 +3593,16 @@ static char *parse_yara_hex_string(YR_STRING *string, int *ret)
             case '\n':
             case '}': /* end of hex string */
                 break;
+            case '~':
+                if ((i + 2 >= slen - 1) ||
+                    !isxdigit((unsigned char)str[i + 1]) ||
+                    !isxdigit((unsigned char)str[i + 2])) {
+                    if (ret) *ret = CL_EMALFDB;
+                    return NULL;
+                }
+                reslen += 5;
+                i += 2;
+                break;
             default:
                 reslen++;
                 break;
@@ -3645,6 +3655,21 @@ static char *parse_yara_hex_string(YR_STRING *string, int *ret)
                 break;
             case ']':
                 res[j++] = '}';
+                break;
+            case '~':
+                if ((i + 2 >= slen - 1) ||
+                    !isxdigit((unsigned char)str[i + 1]) ||
+                    !isxdigit((unsigned char)str[i + 2])) {
+                    free(res);
+                    if (ret) *ret = CL_EMALFDB;
+                    return NULL;
+                }
+                res[j++] = '!';
+                res[j++] = '(';
+                res[j++] = str[i + 1];
+                res[j++] = str[i + 2];
+                res[j++] = ')';
+                i += 2;
                 break;
             default:
                 res[j++] = str[i];

--- a/libclamav/readdb.c
+++ b/libclamav/readdb.c
@@ -3567,6 +3567,25 @@ static char *parse_yara_hex_string(YR_STRING *string, int *ret)
     str = strchr(str, '{') + 1;
 
     for (i = 0; i < slen - 1; i++) {
+        if (str[i] == '/' && i + 1 < slen - 1) {
+            if (str[i + 1] == '*') {
+                i += 2;
+                while (i + 1 < slen - 1 && !(str[i] == '*' && str[i + 1] == '/'))
+                    i++;
+                if (i + 1 >= slen - 1) {
+                    if (ret) *ret = CL_EMALFDB;
+                    return NULL;
+                }
+                i++;
+                continue;
+            } else if (str[i + 1] == '/') {
+                i += 2;
+                while (i < slen - 1 && str[i] != '\n' && str[i] != '\r')
+                    i++;
+                continue;
+            }
+        }
+
         switch (str[i]) {
             case ' ':
             case '\t':
@@ -3588,6 +3607,26 @@ static char *parse_yara_hex_string(YR_STRING *string, int *ret)
     }
 
     for (i = 0, j = 0; i < slen - 1 && j < reslen; i++) {
+        if (str[i] == '/' && i + 1 < slen - 1) {
+            if (str[i + 1] == '*') {
+                i += 2;
+                while (i + 1 < slen - 1 && !(str[i] == '*' && str[i + 1] == '/'))
+                    i++;
+                if (i + 1 >= slen - 1) {
+                    free(res);
+                    if (ret) *ret = CL_EMALFDB;
+                    return NULL;
+                }
+                i++;
+                continue;
+            } else if (str[i + 1] == '/') {
+                i += 2;
+                while (i < slen - 1 && str[i] != '\n' && str[i] != '\r')
+                    i++;
+                continue;
+            }
+        }
+
         switch (str[i]) {
             case ' ':
             case '\t':

--- a/libclamav/readdb.c
+++ b/libclamav/readdb.c
@@ -208,6 +208,13 @@ cl_error_t cli_sigopts_handler(struct cli_matcher *root, const char *virname, co
         return ret;
     }
 
+    /* Nocase folding does not apply to negated matcher units. */
+    if ((sigopts & ACPATT_OPTION_NOCASE) && strchr(hexcpy, '~')) {
+        cli_errmsg("cli_sigopts_handler: nocase modifier [i] is not supported for negated hex units\n");
+        free(hexcpy);
+        return CL_EMALFDB;
+    }
+
     /* NORMAL HEXSIG sigopt handling */
     /* FULLWORD sigopt handling - only happens once */
     if (sigopts & ACPATT_OPTION_FULLWORD) {
@@ -270,6 +277,24 @@ cl_error_t cli_sigopts_handler(struct cli_matcher *root, const char *virname, co
                     hexovr[len++] = hexcpy[i++];
 
                 hexovr[len] = '}';
+            } else if (hexcpy[i] == '~') {
+                /* A negated unit is three source characters and must remain atomic. */
+                if (i + 2 >= hexcpylen ||
+                    (!isxdigit((unsigned char)hexcpy[i + 1]) && hexcpy[i + 1] != '?') ||
+                    (!isxdigit((unsigned char)hexcpy[i + 2]) && hexcpy[i + 2] != '?') ||
+                    (hexcpy[i + 1] == '?' && hexcpy[i + 2] == '?')) {
+                    cli_errmsg("cli_sigopts_handler: invalid negated hex unit in %s\n", virname);
+                    free(hexcpy);
+                    free(hexovr);
+                    return CL_EMALFDB;
+                }
+
+                hexovr[len++] = hexcpy[i];
+                hexovr[len++] = hexcpy[i + 1];
+                hexovr[len++] = hexcpy[i + 2];
+                hexovr[len++] = '0';
+                hexovr[len]   = '0';
+                i += 2;
             } else if (hexcpy[i] == '!' || hexcpy[i] == '(') {
                 if (hexcpy[i] == '!')
                     hexovr[len++] = hexcpy[i++];

--- a/libclamav/readdb.c
+++ b/libclamav/readdb.c
@@ -703,6 +703,29 @@ done:
  * @param options   Database options.  See CL_DB_* macros in clamav.h.
  * @return cl_error_t
  */
+static bool cli_valid_hex_negations(const char *hexsig)
+{
+    size_t i;
+    size_t len = strlen(hexsig);
+
+    for (i = 0; i < len; i++) {
+        if (hexsig[i] != '~')
+            continue;
+
+        if (i + 2 >= len ||
+            (!isxdigit((unsigned char)hexsig[i + 1]) && hexsig[i + 1] != '?') ||
+            (!isxdigit((unsigned char)hexsig[i + 2]) && hexsig[i + 2] != '?') ||
+            (hexsig[i + 1] == '?' && hexsig[i + 2] == '?')) {
+            cli_errmsg("cli_add_content_match_pattern: Invalid hex negation near: %s\n", &hexsig[i]);
+            return false;
+        }
+
+        i += 2;
+    }
+
+    return true;
+}
+
 cl_error_t cli_add_content_match_pattern(struct cli_matcher *root, const char *virname, const char *hexsig,
                                          uint8_t sigopts, uint16_t rtype, uint16_t type,
                                          const char *offset, const uint32_t *lsigid, unsigned int options)
@@ -717,6 +740,9 @@ cl_error_t cli_add_content_match_pattern(struct cli_matcher *root, const char *v
     char *start = NULL;
 
     hexlen = strlen(hexsig);
+
+    if (!cli_valid_hex_negations(hexsig))
+        return CL_EMALFDB;
 
     if ((wild = strchr(hexsig, '{'))) {
         /*
@@ -928,7 +954,7 @@ cl_error_t cli_add_content_match_pattern(struct cli_matcher *root, const char *v
             free(pt);
         }
 
-    } else if (root->ac_only || type || lsigid || sigopts || strpbrk(hexsig, "?([") || (root->bm_offmode && (!strcmp(offset, "*") || strchr(offset, ','))) || strstr(offset, "VI") || strchr(offset, '$')) {
+    } else if (root->ac_only || type || lsigid || sigopts || strpbrk(hexsig, "?([~") || (root->bm_offmode && (!strcmp(offset, "*") || strchr(offset, ','))) || strstr(offset, "VI") || strchr(offset, '$')) {
         /*
          * format seems like it must be handled with the Aho-Corasick (AC) pattern matcher.
          */
@@ -3532,8 +3558,6 @@ static int cli_loadopenioc(FILE *fs, const char *dbname, struct cl_engine *engin
 
 #ifdef HAVE_YARA
 #define YARA_DEBUG 1
-/* 15 two-character alternatives, 14 separators, and 2 parentheses. */
-#define YARA_NEGATED_NIBBLE_EXPANSION_LENGTH 46
 #if (YARA_DEBUG == 2)
 #define cli_yaramsg(...) cli_errmsg(__VA_ARGS__)
 #elif (YARA_DEBUG == 1)
@@ -3546,7 +3570,6 @@ static char *parse_yara_hex_string(YR_STRING *string, int *ret);
 
 static char *parse_yara_hex_string(YR_STRING *string, int *ret)
 {
-    static const char hex_digits[] = "0123456789ABCDEF";
     char *res, *str, *ovr;
     size_t slen, reslen = 0, i, j;
 
@@ -3601,12 +3624,12 @@ static char *parse_yara_hex_string(YR_STRING *string, int *ret)
                     (!isxdigit((unsigned char)str[i + 1]) && str[i + 1] != '?') ||
                     (!isxdigit((unsigned char)str[i + 2]) && str[i + 2] != '?') ||
                     (str[i + 1] == '?' && str[i + 2] == '?')) {
+                    cli_errmsg("parse_yara_hex_string: Invalid YARA hex negation near: %.*s\n",
+                               (int)MIN((size_t)3, slen - 1 - i), &str[i]);
                     if (ret) *ret = CL_EMALFDB;
                     return NULL;
                 }
-                /* A negated nibble wildcard is expanded to the 15 nibble values
-                 * that don't match it. Each alternative is two characters. */
-                reslen += (str[i + 1] == '?' || str[i + 2] == '?') ? YARA_NEGATED_NIBBLE_EXPANSION_LENGTH : 5;
+                reslen += 3;
                 i += 2;
                 break;
             default:
@@ -3667,36 +3690,19 @@ static char *parse_yara_hex_string(YR_STRING *string, int *ret)
                     (!isxdigit((unsigned char)str[i + 1]) && str[i + 1] != '?') ||
                     (!isxdigit((unsigned char)str[i + 2]) && str[i + 2] != '?') ||
                     (str[i + 1] == '?' && str[i + 2] == '?')) {
+                    cli_errmsg("parse_yara_hex_string: Invalid YARA hex negation near: %.*s\n",
+                               (int)MIN((size_t)3, slen - 1 - i), &str[i]);
                     free(res);
                     if (ret) *ret = CL_EMALFDB;
                     return NULL;
                 }
-                if (str[i + 1] == '?' || str[i + 2] == '?') {
-                    char excluded = (char)toupper((unsigned char)(str[i + 1] == '?' ? str[i + 2] : str[i + 1]));
-                    int nibble;
-
-                    res[j++] = '(';
-                    for (nibble = 0; nibble < 16; nibble++) {
-                        if (hex_digits[nibble] == excluded)
-                            continue;
-                        if (j > 0 && res[j - 1] != '(')
-                            res[j++] = '|';
-                        if (str[i + 1] == '?') {
-                            res[j++] = '?';
-                            res[j++] = hex_digits[nibble];
-                        } else {
-                            res[j++] = hex_digits[nibble];
-                            res[j++] = '?';
-                        }
-                    }
-                    res[j++] = ')';
-                } else {
-                    res[j++] = '!';
-                    res[j++] = '(';
-                    res[j++] = str[i + 1];
-                    res[j++] = str[i + 2];
-                    res[j++] = ')';
-                }
+                /*
+                 * Preserve the native matcher token instead of expanding it
+                 * into positive alternatives.
+                 */
+                res[j++] = str[i];
+                res[j++] = str[i + 1];
+                res[j++] = str[i + 2];
                 i += 2;
                 break;
             default:

--- a/libclamav/readdb.c
+++ b/libclamav/readdb.c
@@ -3532,6 +3532,8 @@ static int cli_loadopenioc(FILE *fs, const char *dbname, struct cl_engine *engin
 
 #ifdef HAVE_YARA
 #define YARA_DEBUG 1
+/* 15 two-character alternatives, 14 separators, and 2 parentheses. */
+#define YARA_NEGATED_NIBBLE_EXPANSION_LENGTH 46
 #if (YARA_DEBUG == 2)
 #define cli_yaramsg(...) cli_errmsg(__VA_ARGS__)
 #elif (YARA_DEBUG == 1)
@@ -3544,6 +3546,7 @@ static char *parse_yara_hex_string(YR_STRING *string, int *ret);
 
 static char *parse_yara_hex_string(YR_STRING *string, int *ret)
 {
+    static const char hex_digits[] = "0123456789ABCDEF";
     char *res, *str, *ovr;
     size_t slen, reslen = 0, i, j;
 
@@ -3595,12 +3598,15 @@ static char *parse_yara_hex_string(YR_STRING *string, int *ret)
                 break;
             case '~':
                 if ((i + 2 >= slen - 1) ||
-                    !isxdigit((unsigned char)str[i + 1]) ||
-                    !isxdigit((unsigned char)str[i + 2])) {
+                    (!isxdigit((unsigned char)str[i + 1]) && str[i + 1] != '?') ||
+                    (!isxdigit((unsigned char)str[i + 2]) && str[i + 2] != '?') ||
+                    (str[i + 1] == '?' && str[i + 2] == '?')) {
                     if (ret) *ret = CL_EMALFDB;
                     return NULL;
                 }
-                reslen += 5;
+                /* A negated nibble wildcard is expanded to the 15 nibble values
+                 * that don't match it. Each alternative is two characters. */
+                reslen += (str[i + 1] == '?' || str[i + 2] == '?') ? YARA_NEGATED_NIBBLE_EXPANSION_LENGTH : 5;
                 i += 2;
                 break;
             default:
@@ -3658,17 +3664,39 @@ static char *parse_yara_hex_string(YR_STRING *string, int *ret)
                 break;
             case '~':
                 if ((i + 2 >= slen - 1) ||
-                    !isxdigit((unsigned char)str[i + 1]) ||
-                    !isxdigit((unsigned char)str[i + 2])) {
+                    (!isxdigit((unsigned char)str[i + 1]) && str[i + 1] != '?') ||
+                    (!isxdigit((unsigned char)str[i + 2]) && str[i + 2] != '?') ||
+                    (str[i + 1] == '?' && str[i + 2] == '?')) {
                     free(res);
                     if (ret) *ret = CL_EMALFDB;
                     return NULL;
                 }
-                res[j++] = '!';
-                res[j++] = '(';
-                res[j++] = str[i + 1];
-                res[j++] = str[i + 2];
-                res[j++] = ')';
+                if (str[i + 1] == '?' || str[i + 2] == '?') {
+                    char excluded = (char)toupper((unsigned char)(str[i + 1] == '?' ? str[i + 2] : str[i + 1]));
+                    int nibble;
+
+                    res[j++] = '(';
+                    for (nibble = 0; nibble < 16; nibble++) {
+                        if (hex_digits[nibble] == excluded)
+                            continue;
+                        if (j > 0 && res[j - 1] != '(')
+                            res[j++] = '|';
+                        if (str[i + 1] == '?') {
+                            res[j++] = '?';
+                            res[j++] = hex_digits[nibble];
+                        } else {
+                            res[j++] = hex_digits[nibble];
+                            res[j++] = '?';
+                        }
+                    }
+                    res[j++] = ')';
+                } else {
+                    res[j++] = '!';
+                    res[j++] = '(';
+                    res[j++] = str[i + 1];
+                    res[j++] = str[i + 2];
+                    res[j++] = ')';
+                }
                 i += 2;
                 break;
             default:

--- a/libclamav/str.c
+++ b/libclamav/str.c
@@ -72,77 +72,116 @@ static inline int cli_hex2int(const char c)
     return hex_chars[(const unsigned char)c];
 }
 
-int cli_realhex2ui(const char *hex, uint16_t *ptr, unsigned int len)
+int cli_realhex2ui(const char *hex, uint16_t *ptr, unsigned int len, size_t *decoded_len)
 {
     uint16_t val;
-    unsigned int i;
+    size_t count   = 0;
+    unsigned int i = 0;
     int c;
 
-    for (i = 0; i < len; i += 2) {
+    while (i < len) {
         val = 0;
 
-        if (hex[i] == '?' && hex[i + 1] == '?') {
-            val |= CLI_MATCH_IGNORE;
+        if (hex[i] == '~') {
+            int high, low;
 
-        } else if (hex[i + 1] == '?') {
-            if ((c = cli_hex2int(hex[i])) >= 0) {
-                val = c << 4;
-            } else {
+            if (i + 2 >= len || (hex[i + 1] == '?' && hex[i + 2] == '?')) {
+                cli_errmsg("cli_realhex2ui(): Invalid hex negation near: %s\n", &hex[i]);
                 return 0;
             }
-            val |= CLI_MATCH_NIBBLE_HIGH;
 
-        } else if (hex[i] == '?') {
-            if ((c = cli_hex2int(hex[i + 1])) >= 0) {
-                val = c;
+            high = cli_hex2int(hex[i + 1]);
+            low  = cli_hex2int(hex[i + 2]);
+
+            if (hex[i + 1] == '?' && low >= 0) {
+                val = CLI_MATCH_NOT_NIBBLE_LOW | low;
+            } else if (high >= 0 && hex[i + 2] == '?') {
+                val = CLI_MATCH_NOT_NIBBLE_HIGH | (high << 4);
+            } else if (high >= 0 && low >= 0) {
+                val = CLI_MATCH_NOT_BYTE | (high << 4) | low;
             } else {
+                cli_errmsg("cli_realhex2ui(): Invalid hex negation near: %s\n", &hex[i]);
                 return 0;
             }
-            val |= CLI_MATCH_NIBBLE_LOW;
 
-        } else if (hex[i] == '(') {
-            val |= CLI_MATCH_SPECIAL;
-
+            i += 3;
         } else {
-            if ((c = cli_hex2int(hex[i])) >= 0) {
-                val = c;
-                if ((c = cli_hex2int(hex[i + 1])) >= 0) {
-                    val = (val << 4) + c;
+            if (i + 1 >= len) {
+                cli_errmsg("cli_realhex2ui(): Incomplete hex byte near: %s\n", &hex[i]);
+                return 0;
+            }
+
+            if (hex[i] == '?' && hex[i + 1] == '?') {
+                val |= CLI_MATCH_IGNORE;
+
+            } else if (hex[i + 1] == '?') {
+                if ((c = cli_hex2int(hex[i])) >= 0) {
+                    val = c << 4;
                 } else {
                     return 0;
                 }
+                val |= CLI_MATCH_NIBBLE_HIGH;
+
+            } else if (hex[i] == '?') {
+                if ((c = cli_hex2int(hex[i + 1])) >= 0) {
+                    val = c;
+                } else {
+                    return 0;
+                }
+                val |= CLI_MATCH_NIBBLE_LOW;
+
+            } else if (hex[i] == '(') {
+                val |= CLI_MATCH_SPECIAL;
+
             } else {
-                return 0;
+                if ((c = cli_hex2int(hex[i])) >= 0) {
+                    val = c;
+                    if ((c = cli_hex2int(hex[i + 1])) >= 0) {
+                        val = (val << 4) + c;
+                    } else {
+                        return 0;
+                    }
+                } else {
+                    return 0;
+                }
             }
+
+            i += 2;
         }
 
-        *ptr++ = val;
+        ptr[count++] = val;
     }
+
+    if (decoded_len)
+        *decoded_len = count;
+
     return 1;
 }
 
-uint16_t *cli_hex2ui(const char *hex)
+uint16_t *cli_hex2ui_len(const char *hex, size_t *decoded_len)
 {
     uint16_t *str;
     unsigned int len;
 
-    len = strlen(hex);
+    if (decoded_len)
+        *decoded_len = 0;
 
-    if (len % 2 != 0) {
-        cli_errmsg("cli_hex2ui(): Malformed hexstring: %s (length: %u)\n", hex,
-                   len);
-        return NULL;
-    }
+    len = strlen(hex);
 
     str = cli_max_calloc((len / 2) + 1, sizeof(uint16_t));
     if (!str)
         return NULL;
 
-    if (cli_realhex2ui(hex, str, len))
+    if (cli_realhex2ui(hex, str, len, decoded_len))
         return str;
 
     free(str);
     return NULL;
+}
+
+uint16_t *cli_hex2ui(const char *hex)
+{
+    return cli_hex2ui_len(hex, NULL);
 }
 
 char *cli_hex2str(const char *hex)

--- a/libclamav/str.h
+++ b/libclamav/str.h
@@ -71,8 +71,13 @@ char *__cli_strnstr(const char *s, const char *find, size_t slen);
 int cli_strbcasestr(const char *haystack, const char *needle);
 int cli_chomp(char *string);
 char *cli_strtok(const char *line, int field, const char *delim);
-int cli_realhex2ui(const char *hex, uint16_t *ptr, unsigned int len);
+/*
+ * Hex patterns contain two-character byte tokens and three-character negated
+ * tokens. decoded_len reports the number of uint16_t matcher units produced.
+ */
+int cli_realhex2ui(const char *hex, uint16_t *ptr, unsigned int len, size_t *decoded_len);
 uint16_t *cli_hex2ui(const char *hex);
+uint16_t *cli_hex2ui_len(const char *hex, size_t *decoded_len);
 int cli_hex2str_to(const char *hex, char *ptr, size_t len);
 char *cli_hex2str(const char *hex);
 int cli_hex2num(const char *hex);

--- a/libclamav/yara_arena.c
+++ b/libclamav/yara_arena.c
@@ -1,17 +1,17 @@
 /*
-Copyright (c) 2013. The YARA Authors. All Rights Reserved.
+Copyright (c) 2007-2016. The YARA Authors. All Rights Reserved.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-   http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 /*

--- a/libclamav/yara_arena.h
+++ b/libclamav/yara_arena.h
@@ -1,17 +1,17 @@
 /*
-Copyright (c) 2013. The YARA Authors. All Rights Reserved.
+Copyright (c) 2007-2016. The YARA Authors. All Rights Reserved.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-   http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #ifndef YR_ARENA_H

--- a/libclamav/yara_clam.h
+++ b/libclamav/yara_clam.h
@@ -75,6 +75,7 @@ limitations under the License.
 #define STRING_GFLAGS_CHAIN_PART        0x2000
 #define STRING_GFLAGS_CHAIN_TAIL        0x4000
 #define STRING_GFLAGS_REGEXP_DOT_ALL    0x8000
+#define STRING_GFLAGS_PRIVATE           0x100000
 
 #define STRING_IS_HEX(x) \
     (((x)->g_flags) & STRING_GFLAGS_HEXADECIMAL)
@@ -117,6 +118,9 @@ limitations under the License.
 
 #define STRING_IS_CHAIN_TAIL(x) \
     (((x)->g_flags) & STRING_GFLAGS_CHAIN_TAIL)
+
+#define STRING_IS_PRIVATE(x) \
+    (((x)->g_flags) & STRING_GFLAGS_PRIVATE)
 
 #define STRING_IS_NULL(x) \
     ((x) == NULL || ((x)->g_flags) & STRING_GFLAGS_NULL)
@@ -293,6 +297,11 @@ typedef struct _SIZED_STRING
 #define ERROR_INVALID_FORMAT                    38
 #define ERROR_TOO_MANY_ARGUMENTS                39
 #define ERROR_WRONG_NUMBER_OF_ARGUMENTS         40
+#define ERROR_INTEGER_OVERFLOW                  52
+#define ERROR_INVALID_MODIFIER                  59
+#define ERROR_DUPLICATED_MODIFIER               60
+
+#define ERROR_INSUFFICIENT_MEMORY ERROR_INSUFICIENT_MEMORY
 
 #define FAIL_ON_ERROR(x) { \
     int result = (x); \

--- a/libclamav/yara_clam.h
+++ b/libclamav/yara_clam.h
@@ -23,19 +23,19 @@
  * other YARA header files. Following is the YARA copyright. */
 
 /*
-Copyright (c) 2007-2013. The YARA Authors. All Rights Reserved.
+Copyright (c) 2007-2016. The YARA Authors. All Rights Reserved.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-   http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #ifndef _YARA_CLAM_H_

--- a/libclamav/yara_compiler.c
+++ b/libclamav/yara_compiler.c
@@ -1,17 +1,17 @@
 /*
-Copyright (c) 2013. The YARA Authors. All Rights Reserved.
+Copyright (c) 2007-2016. The YARA Authors. All Rights Reserved.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-   http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include <stddef.h>

--- a/libclamav/yara_compiler.c
+++ b/libclamav/yara_compiler.c
@@ -759,6 +759,7 @@ char* yr_compiler_get_error_message(
             break;
         case ERROR_INVALID_HEX_STRING:
         case ERROR_INVALID_REGULAR_EXPRESSION:
+        case ERROR_INVALID_MODIFIER:
         case ERROR_SYNTAX_ERROR:
         case ERROR_WRONG_TYPE:
         case ERROR_WRONG_NUMBER_OF_ARGUMENTS:
@@ -766,6 +767,16 @@ char* yr_compiler_get_error_message(
                 buffer,
                 buffer_size,
                 "%s",
+                compiler->last_error_extra_info);
+            break;
+        case ERROR_DUPLICATED_MODIFIER:
+            snprintf(buffer, buffer_size, "duplicated string modifier");
+            break;
+        case ERROR_INTEGER_OVERFLOW:
+            snprintf(
+                buffer,
+                buffer_size,
+                "integer overflow \"%s\"",
                 compiler->last_error_extra_info);
             break;
         case ERROR_INTERNAL_FATAL_ERROR:

--- a/libclamav/yara_compiler.h
+++ b/libclamav/yara_compiler.h
@@ -1,17 +1,17 @@
 /*
-Copyright (c) 2013. The YARA Authors. All Rights Reserved.
+Copyright (c) 2007-2016. The YARA Authors. All Rights Reserved.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-   http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #ifndef YR_COMPILER_H

--- a/libclamav/yara_exec.c
+++ b/libclamav/yara_exec.c
@@ -97,7 +97,7 @@ typedef struct _YR_MATCH
     int64_t read_##type(fmap_t * fmap, size_t offset) \
     { \
       const void *data;                                         \
-      if (offset + sizeof(type) >= fmap->len)                   \
+      if (offset > fmap->len || sizeof(type) > fmap->len - offset) \
           return UNDEFINED;                                     \
       data = fmap_need_off_once(fmap, offset, sizeof(type));    \
       if (!data)                                                \
@@ -393,13 +393,21 @@ int yr_execute_code(
       case OP_DIV:
         pop(r2);
         pop(r1);
-        push(operation(/, r1, r2));
+        if (IS_UNDEFINED(r1) || IS_UNDEFINED(r2) ||
+            r2 == 0 || (r1 == INT64_MIN && r2 == -1))
+          push(UNDEFINED);
+        else
+          push(r1 / r2);
         break;
 
       case OP_MOD:
         pop(r2);
         pop(r1);
-        push(operation(%, r1, r2));
+        if (IS_UNDEFINED(r1) || IS_UNDEFINED(r2) ||
+            r2 == 0 || (r1 == INT64_MIN && r2 == -1))
+          push(UNDEFINED);
+        else
+          push(r1 % r2);
         break;
 
       case OP_NEG:
@@ -410,13 +418,23 @@ int yr_execute_code(
       case OP_SHR:
         pop(r2);
         pop(r1);
-        push(operation(>>, r1, r2));
+        if (IS_UNDEFINED(r1) || IS_UNDEFINED(r2) || r2 < 0)
+          push(UNDEFINED);
+        else if (r2 < 64)
+          push(r1 >> r2);
+        else
+          push(0);
         break;
 
       case OP_SHL:
         pop(r2);
         pop(r1);
-        push(operation(<<, r1, r2));
+        if (IS_UNDEFINED(r1) || IS_UNDEFINED(r2) || r2 < 0)
+          push(UNDEFINED);
+        else if (r2 < 64)
+          push(r1 << r2);
+        else
+          push(0);
         break;
 
       case OP_XOR:
@@ -773,10 +791,12 @@ int yr_execute_code(
 
         pop(r2);
 
-        if (r2 != UNDEFINED)
-          push(found >= r2 ? 1 : 0);
-        else
+        if (r2 == UNDEFINED)
           push(found >= count ? 1 : 0);
+        else if (r2 == 0)
+          push(found == 0 ? 1 : 0);
+        else
+          push(found >= r2 ? 1 : 0);
 
         break;
 
@@ -853,8 +873,11 @@ int yr_execute_code(
       case OP_CONTAINS:
         pop(r2);
         pop(r1);
-        push(strstr(UINT64_TO_PTR(char*, r1),
-                    UINT64_TO_PTR(char*, r2)) != NULL);
+        if (IS_UNDEFINED(r1) || IS_UNDEFINED(r2))
+          push(UNDEFINED);
+        else
+          push(strstr(UINT64_TO_PTR(char*, r1),
+                      UINT64_TO_PTR(char*, r2)) != NULL);
         break;
 
 
@@ -873,6 +896,12 @@ int yr_execute_code(
       case OP_MATCHES:
         pop(r2);
         pop(r1);
+
+        if (IS_UNDEFINED(r1) || IS_UNDEFINED(r2))
+        {
+          push(UNDEFINED);
+          break;
+        }
 
         count = strlen(UINT64_TO_PTR(char*, r1));
 

--- a/libclamav/yara_exec.c
+++ b/libclamav/yara_exec.c
@@ -1,17 +1,17 @@
 /*
-Copyright (c) 2013. The YARA Authors. All Rights Reserved.
+Copyright (c) 2007-2016. The YARA Authors. All Rights Reserved.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-   http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include <string.h>
@@ -320,6 +320,17 @@ int yr_execute_code(
         pop(r2);
         pop(r1);
         push(comparison(<=, r1, r2));
+        break;
+
+      case OP_OF_COUNT:
+        pop(r2);
+        pop(r1);
+        if (IS_UNDEFINED(r1) || IS_UNDEFINED(r2))
+          push(0);
+        else if (r1 == 0)
+          push(r2 == 0 ? 1 : 0);
+        else
+          push(r1 <= r2 ? 1 : 0);
         break;
 
       case OP_GE:

--- a/libclamav/yara_exec.h
+++ b/libclamav/yara_exec.h
@@ -1,17 +1,17 @@
 /*
-Copyright (c) 2013. The YARA Authors. All Rights Reserved.
+Copyright (c) 2007-2016. The YARA Authors. All Rights Reserved.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-   http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #ifndef YR_EXEC_H
@@ -84,6 +84,7 @@ limitations under the License.
 #define OP_CONTAINS       53
 #define OP_MATCHES        54
 #define OP_IMPORT         55
+#define OP_OF_COUNT       56
 
 
 int yr_execute_code(

--- a/libclamav/yara_grammar.c
+++ b/libclamav/yara_grammar.c
@@ -2567,7 +2567,7 @@ yyreduce:
             yr_parser_emit_with_arg(
                 yyscanner, OP_PUSH_M, mem_offset + 1, NULL);
 
-            yr_parser_emit(yyscanner, OP_LE, NULL);
+            yr_parser_emit(yyscanner, OP_OF_COUNT, NULL);
 
             compiler->loop_identifier[compiler->loop_depth] = NULL;
             yr_free((yyvsp[-8].c_string));
@@ -2654,7 +2654,7 @@ yyreduce:
             yr_parser_emit_with_arg(
                 yyscanner, OP_PUSH_M, mem_offset + 1, NULL);
 
-            yr_parser_emit(yyscanner, OP_LE, NULL);
+            yr_parser_emit(yyscanner, OP_OF_COUNT, NULL);
             (yyval.expression_type) = EXPRESSION_TYPE_BOOLEAN;
 
         }

--- a/libclamav/yara_grammar.c
+++ b/libclamav/yara_grammar.c
@@ -1,3 +1,19 @@
+/*
+Copyright (c) 2007-2016. The YARA Authors. All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
 /* A Bison parser, made by GNU Bison 3.8.2.  */
 
 /* Bison implementation for Yacc-like parsers in C

--- a/libclamav/yara_grammar.c
+++ b/libclamav/yara_grammar.c
@@ -1,8 +1,8 @@
-/* A Bison parser, made by GNU Bison 3.5.1.  */
+/* A Bison parser, made by GNU Bison 3.8.2.  */
 
 /* Bison implementation for Yacc-like parsers in C
 
-   Copyright (C) 1984, 1989-1990, 2000-2015, 2018-2020 Free Software Foundation,
+   Copyright (C) 1984, 1989-1990, 2000-2015, 2018-2021 Free Software Foundation,
    Inc.
 
    This program is free software: you can redistribute it and/or modify
@@ -16,7 +16,7 @@
    GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License
-   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.  */
 
 /* As a special exception, you may create a larger work that contains
    part or all of the Bison parser skeleton and distribute that work
@@ -34,6 +34,10 @@
 /* C LALR(1) parser skeleton written by Richard Stallman, by
    simplifying the original so-called "semantic" parser.  */
 
+/* DO NOT RELY ON FEATURES THAT ARE NOT DOCUMENTED in the manual,
+   especially those whose name start with YY_ or yy_.  They are
+   private implementation details that can be changed or removed.  */
+
 /* All symbols defined below should begin with yy or YY, to avoid
    infringing on user name space.  This should be done even for local
    variables, as they might otherwise be expanded by user macros.
@@ -41,14 +45,11 @@
    define necessary library symbols; they are noted "INFRINGES ON
    USER NAME SPACE" below.  */
 
-/* Undocumented macros, especially those whose name start with YY_,
-   are private implementation details.  Do not rely on them.  */
+/* Identify Bison output, and Bison version.  */
+#define YYBISON 30802
 
-/* Identify Bison output.  */
-#define YYBISON 1
-
-/* Bison version.  */
-#define YYBISON_VERSION "3.5.1"
+/* Bison version string.  */
+#define YYBISON_VERSION "3.8.2"
 
 /* Skeleton name.  */
 #define YYSKELETON_NAME "yacc.c"
@@ -62,17 +63,15 @@
 /* Pull parsers.  */
 #define YYPULL 1
 
-
 /* Substitute the variable and function names.  */
-#define yyparse         yara_yyparse
-#define yylex           yara_yylex
-#define yyerror         yara_yyerror
-#define yydebug         yara_yydebug
-#define yynerrs         yara_yynerrs
+#define yyparse yara_yyparse
+#define yylex yara_yylex
+#define yyerror yara_yyerror
+#define yydebug yara_yydebug
+#define yynerrs yara_yynerrs
 
 /* First part of user prologue.  */
 #line 43 "yara_grammar.y"
-
 
 #include <assert.h>
 #include <stdio.h>
@@ -103,189 +102,198 @@
 
 #define YYERROR_VERBOSE
 
-#define INTEGER_SET_ENUMERATION   1
-#define INTEGER_SET_RANGE         2
+#define INTEGER_SET_ENUMERATION 1
+#define INTEGER_SET_RANGE 2
 
-#define EXPRESSION_TYPE_BOOLEAN   1
-#define EXPRESSION_TYPE_INTEGER   2
-#define EXPRESSION_TYPE_STRING    3
-#define EXPRESSION_TYPE_REGEXP    4
+#define EXPRESSION_TYPE_BOOLEAN 1
+#define EXPRESSION_TYPE_INTEGER 2
+#define EXPRESSION_TYPE_STRING 3
+#define EXPRESSION_TYPE_REGEXP 4
 
+#define ERROR_IF(x)                         \
+    if (x) {                                \
+        yyerror(yyscanner, compiler, NULL); \
+        YYERROR;                            \
+    }
 
-#define ERROR_IF(x) \
-    if (x) \
-    { \
-      yyerror(yyscanner, compiler, NULL); \
-      YYERROR; \
-    } \
-
-#define CHECK_TYPE_WITH_CLEANUP(actual_type, expected_type, op, cleanup) \
-    if (actual_type != expected_type) \
-    { \
-      switch(actual_type) \
-      { \
-        case EXPRESSION_TYPE_INTEGER: \
-          yr_compiler_set_error_extra_info( \
-              compiler, "wrong type \"integer\" for " op " operator"); \
-          break; \
-        case EXPRESSION_TYPE_STRING: \
-          yr_compiler_set_error_extra_info( \
-              compiler, "wrong type \"string\" for \"" op "\" operator"); \
-          break; \
-      } \
-      compiler->last_result = ERROR_WRONG_TYPE; \
-      cleanup; \
-      yyerror(yyscanner, compiler, NULL); \
-      YYERROR; \
+#define CHECK_TYPE_WITH_CLEANUP(actual_type, expected_type, op, cleanup)        \
+    if (actual_type != expected_type) {                                         \
+        switch (actual_type) {                                                  \
+            case EXPRESSION_TYPE_INTEGER:                                       \
+                yr_compiler_set_error_extra_info(                               \
+                    compiler, "wrong type \"integer\" for " op " operator");    \
+                break;                                                          \
+            case EXPRESSION_TYPE_STRING:                                        \
+                yr_compiler_set_error_extra_info(                               \
+                    compiler, "wrong type \"string\" for \"" op "\" operator"); \
+                break;                                                          \
+        }                                                                       \
+        compiler->last_result = ERROR_WRONG_TYPE;                               \
+        cleanup;                                                                \
+        yyerror(yyscanner, compiler, NULL);                                     \
+        YYERROR;                                                                \
     }
 
 #define CHECK_TYPE(actual_type, expected_type, op) \
-    CHECK_TYPE_WITH_CLEANUP(actual_type, expected_type, op, ) \
+    CHECK_TYPE_WITH_CLEANUP(actual_type, expected_type, op, )
 
+#define MSG(op) "wrong type \"string\" for \"" op "\" operator"
 
-#define MSG(op)  "wrong type \"string\" for \"" op "\" operator"
+#define UNSUPPORTED_STRING_MODIFIER(modifier)                          \
+    do {                                                               \
+        yr_compiler_set_error_extra_info(                              \
+            compiler, "unsupported string modifier \"" modifier "\""); \
+        compiler->last_result = ERROR_INVALID_MODIFIER;                \
+        yyerror(yyscanner, compiler, NULL);                            \
+        YYERROR;                                                       \
+    } while (0)
 
+#line 160 "yara_grammar.c"
 
-#line 150 "yara_grammar.c"
-
-# ifndef YY_CAST
-#  ifdef __cplusplus
-#   define YY_CAST(Type, Val) static_cast<Type> (Val)
-#   define YY_REINTERPRET_CAST(Type, Val) reinterpret_cast<Type> (Val)
-#  else
-#   define YY_CAST(Type, Val) ((Type) (Val))
-#   define YY_REINTERPRET_CAST(Type, Val) ((Type) (Val))
-#  endif
-# endif
-# ifndef YY_NULLPTR
-#  if defined __cplusplus
-#   if 201103L <= __cplusplus
-#    define YY_NULLPTR nullptr
-#   else
-#    define YY_NULLPTR 0
-#   endif
-#  else
-#   define YY_NULLPTR ((void*)0)
-#  endif
-# endif
-
-/* Enabling verbose error messages.  */
-#ifdef YYERROR_VERBOSE
-# undef YYERROR_VERBOSE
-# define YYERROR_VERBOSE 1
+#ifndef YY_CAST
+#ifdef __cplusplus
+#define YY_CAST(Type, Val) static_cast<Type>(Val)
+#define YY_REINTERPRET_CAST(Type, Val) reinterpret_cast<Type>(Val)
 #else
-# define YYERROR_VERBOSE 0
+#define YY_CAST(Type, Val) ((Type)(Val))
+#define YY_REINTERPRET_CAST(Type, Val) ((Type)(Val))
+#endif
+#endif
+#ifndef YY_NULLPTR
+#if defined __cplusplus
+#if 201103L <= __cplusplus
+#define YY_NULLPTR nullptr
+#else
+#define YY_NULLPTR 0
+#endif
+#else
+#define YY_NULLPTR ((void*)0)
+#endif
 #endif
 
-/* Use api.header.include to #include this header
-   instead of duplicating it here.  */
-#ifndef YY_YARA_YY_YARA_GRAMMAR_H_INCLUDED
-# define YY_YARA_YY_YARA_GRAMMAR_H_INCLUDED
-/* Debug traces.  */
-#ifndef YYDEBUG
-# define YYDEBUG 0
-#endif
-#if YYDEBUG
-extern int yara_yydebug;
-#endif
-/* "%code requires" blocks.  */
-#line 39 "yara_grammar.y"
-
-#include "yara_compiler.h"
-
-#line 197 "yara_grammar.c"
-
-/* Token type.  */
-#ifndef YYTOKENTYPE
-# define YYTOKENTYPE
-  enum yytokentype
-  {
-    _RULE_ = 258,
-    _PRIVATE_ = 259,
-    _GLOBAL_ = 260,
-    _META_ = 261,
-    _STRINGS_ = 262,
-    _CONDITION_ = 263,
-    _IDENTIFIER_ = 264,
-    _STRING_IDENTIFIER_ = 265,
-    _STRING_COUNT_ = 266,
-    _STRING_OFFSET_ = 267,
-    _STRING_IDENTIFIER_WITH_WILDCARD_ = 268,
-    _NUMBER_ = 269,
-    _TEXT_STRING_ = 270,
-    _HEX_STRING_ = 271,
-    _REGEXP_ = 272,
-    _ASCII_ = 273,
-    _WIDE_ = 274,
-    _NOCASE_ = 275,
-    _FULLWORD_ = 276,
-    _AT_ = 277,
-    _FILESIZE_ = 278,
-    _ENTRYPOINT_ = 279,
-    _ALL_ = 280,
-    _ANY_ = 281,
-    _IN_ = 282,
-    _OF_ = 283,
-    _FOR_ = 284,
-    _THEM_ = 285,
-    _INT8_ = 286,
-    _INT16_ = 287,
-    _INT32_ = 288,
-    _UINT8_ = 289,
-    _UINT16_ = 290,
-    _UINT32_ = 291,
-    _MATCHES_ = 292,
-    _CONTAINS_ = 293,
-    _IMPORT_ = 294,
-    _TRUE_ = 295,
-    _FALSE_ = 296,
-    _OR_ = 297,
-    _AND_ = 298,
-    _LT_ = 299,
-    _LE_ = 300,
-    _GT_ = 301,
-    _GE_ = 302,
-    _EQ_ = 303,
-    _NEQ_ = 304,
-    _IS_ = 305,
-    _SHIFT_LEFT_ = 306,
-    _SHIFT_RIGHT_ = 307,
-    _NOT_ = 308
-  };
-#endif
-
-/* Value type.  */
-#if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
-union YYSTYPE
-{
-#line 219 "yara_grammar.y"
-
-  SIZED_STRING*   sized_string;
-  char*           c_string;
-  int8_t          expression_type;
-  int64_t         integer;
-  YR_STRING*      string;
-  YR_META*        meta;
-  YR_OBJECT*      object;
-
-#line 272 "yara_grammar.c"
-
+#include "yara_grammar.h"
+/* Symbol kind.  */
+enum yysymbol_kind_t {
+    YYSYMBOL_YYEMPTY                           = -2,
+    YYSYMBOL_YYEOF                             = 0,   /* "end of file"  */
+    YYSYMBOL_YYerror                           = 1,   /* error  */
+    YYSYMBOL_YYUNDEF                           = 2,   /* "invalid token"  */
+    YYSYMBOL__RULE_                            = 3,   /* _RULE_  */
+    YYSYMBOL__PRIVATE_                         = 4,   /* _PRIVATE_  */
+    YYSYMBOL__GLOBAL_                          = 5,   /* _GLOBAL_  */
+    YYSYMBOL__META_                            = 6,   /* _META_  */
+    YYSYMBOL__STRINGS_                         = 7,   /* _STRINGS_  */
+    YYSYMBOL__CONDITION_                       = 8,   /* _CONDITION_  */
+    YYSYMBOL__IDENTIFIER_                      = 9,   /* _IDENTIFIER_  */
+    YYSYMBOL__STRING_IDENTIFIER_               = 10,  /* _STRING_IDENTIFIER_  */
+    YYSYMBOL__STRING_COUNT_                    = 11,  /* _STRING_COUNT_  */
+    YYSYMBOL__STRING_OFFSET_                   = 12,  /* _STRING_OFFSET_  */
+    YYSYMBOL__STRING_IDENTIFIER_WITH_WILDCARD_ = 13,  /* _STRING_IDENTIFIER_WITH_WILDCARD_  */
+    YYSYMBOL__NUMBER_                          = 14,  /* _NUMBER_  */
+    YYSYMBOL__TEXT_STRING_                     = 15,  /* _TEXT_STRING_  */
+    YYSYMBOL__HEX_STRING_                      = 16,  /* _HEX_STRING_  */
+    YYSYMBOL__REGEXP_                          = 17,  /* _REGEXP_  */
+    YYSYMBOL__ASCII_                           = 18,  /* _ASCII_  */
+    YYSYMBOL__WIDE_                            = 19,  /* _WIDE_  */
+    YYSYMBOL__XOR_                             = 20,  /* _XOR_  */
+    YYSYMBOL__BASE64_                          = 21,  /* _BASE64_  */
+    YYSYMBOL__BASE64_WIDE_                     = 22,  /* _BASE64_WIDE_  */
+    YYSYMBOL__NOCASE_                          = 23,  /* _NOCASE_  */
+    YYSYMBOL__FULLWORD_                        = 24,  /* _FULLWORD_  */
+    YYSYMBOL__AT_                              = 25,  /* _AT_  */
+    YYSYMBOL__FILESIZE_                        = 26,  /* _FILESIZE_  */
+    YYSYMBOL__ENTRYPOINT_                      = 27,  /* _ENTRYPOINT_  */
+    YYSYMBOL__ALL_                             = 28,  /* _ALL_  */
+    YYSYMBOL__ANY_                             = 29,  /* _ANY_  */
+    YYSYMBOL__IN_                              = 30,  /* _IN_  */
+    YYSYMBOL__OF_                              = 31,  /* _OF_  */
+    YYSYMBOL__FOR_                             = 32,  /* _FOR_  */
+    YYSYMBOL__THEM_                            = 33,  /* _THEM_  */
+    YYSYMBOL__INT8_                            = 34,  /* _INT8_  */
+    YYSYMBOL__INT16_                           = 35,  /* _INT16_  */
+    YYSYMBOL__INT32_                           = 36,  /* _INT32_  */
+    YYSYMBOL__UINT8_                           = 37,  /* _UINT8_  */
+    YYSYMBOL__UINT16_                          = 38,  /* _UINT16_  */
+    YYSYMBOL__UINT32_                          = 39,  /* _UINT32_  */
+    YYSYMBOL__MATCHES_                         = 40,  /* _MATCHES_  */
+    YYSYMBOL__CONTAINS_                        = 41,  /* _CONTAINS_  */
+    YYSYMBOL__IMPORT_                          = 42,  /* _IMPORT_  */
+    YYSYMBOL__TRUE_                            = 43,  /* _TRUE_  */
+    YYSYMBOL__FALSE_                           = 44,  /* _FALSE_  */
+    YYSYMBOL__OR_                              = 45,  /* _OR_  */
+    YYSYMBOL__AND_                             = 46,  /* _AND_  */
+    YYSYMBOL_47_                               = 47,  /* '&'  */
+    YYSYMBOL_48_                               = 48,  /* '|'  */
+    YYSYMBOL_49_                               = 49,  /* '^'  */
+    YYSYMBOL__LT_                              = 50,  /* _LT_  */
+    YYSYMBOL__LE_                              = 51,  /* _LE_  */
+    YYSYMBOL__GT_                              = 52,  /* _GT_  */
+    YYSYMBOL__GE_                              = 53,  /* _GE_  */
+    YYSYMBOL__EQ_                              = 54,  /* _EQ_  */
+    YYSYMBOL__NEQ_                             = 55,  /* _NEQ_  */
+    YYSYMBOL__IS_                              = 56,  /* _IS_  */
+    YYSYMBOL__SHIFT_LEFT_                      = 57,  /* _SHIFT_LEFT_  */
+    YYSYMBOL__SHIFT_RIGHT_                     = 58,  /* _SHIFT_RIGHT_  */
+    YYSYMBOL_59_                               = 59,  /* '+'  */
+    YYSYMBOL_60_                               = 60,  /* '-'  */
+    YYSYMBOL_61_                               = 61,  /* '*'  */
+    YYSYMBOL_62_                               = 62,  /* '\\'  */
+    YYSYMBOL_63_                               = 63,  /* '%'  */
+    YYSYMBOL__NOT_                             = 64,  /* _NOT_  */
+    YYSYMBOL_65_                               = 65,  /* '~'  */
+    YYSYMBOL_66_include_                       = 66,  /* "include"  */
+    YYSYMBOL_67_                               = 67,  /* '{'  */
+    YYSYMBOL_68_                               = 68,  /* '}'  */
+    YYSYMBOL_69_                               = 69,  /* ':'  */
+    YYSYMBOL_70_                               = 70,  /* '='  */
+    YYSYMBOL_71_                               = 71,  /* '('  */
+    YYSYMBOL_72_                               = 72,  /* ')'  */
+    YYSYMBOL_73_                               = 73,  /* '.'  */
+    YYSYMBOL_74_                               = 74,  /* '['  */
+    YYSYMBOL_75_                               = 75,  /* ']'  */
+    YYSYMBOL_76_                               = 76,  /* ','  */
+    YYSYMBOL_YYACCEPT                          = 77,  /* $accept  */
+    YYSYMBOL_rules                             = 78,  /* rules  */
+    YYSYMBOL_import                            = 79,  /* import  */
+    YYSYMBOL_rule                              = 80,  /* rule  */
+    YYSYMBOL_meta                              = 81,  /* meta  */
+    YYSYMBOL_strings                           = 82,  /* strings  */
+    YYSYMBOL_condition                         = 83,  /* condition  */
+    YYSYMBOL_rule_modifiers                    = 84,  /* rule_modifiers  */
+    YYSYMBOL_rule_modifier                     = 85,  /* rule_modifier  */
+    YYSYMBOL_tags                              = 86,  /* tags  */
+    YYSYMBOL_tag_list                          = 87,  /* tag_list  */
+    YYSYMBOL_meta_declarations                 = 88,  /* meta_declarations  */
+    YYSYMBOL_meta_declaration                  = 89,  /* meta_declaration  */
+    YYSYMBOL_string_declarations               = 90,  /* string_declarations  */
+    YYSYMBOL_string_declaration                = 91,  /* string_declaration  */
+    YYSYMBOL_92_1                              = 92,  /* $@1  */
+    YYSYMBOL_string_modifiers                  = 93,  /* string_modifiers  */
+    YYSYMBOL_string_modifier                   = 94,  /* string_modifier  */
+    YYSYMBOL_hex_modifiers                     = 95,  /* hex_modifiers  */
+    YYSYMBOL_hex_modifier                      = 96,  /* hex_modifier  */
+    YYSYMBOL_identifier                        = 97,  /* identifier  */
+    YYSYMBOL_arguments_list                    = 98,  /* arguments_list  */
+    YYSYMBOL_regexp                            = 99,  /* regexp  */
+    YYSYMBOL_boolean_expression                = 100, /* boolean_expression  */
+    YYSYMBOL_expression                        = 101, /* expression  */
+    YYSYMBOL_102_2                             = 102, /* $@2  */
+    YYSYMBOL_103_3                             = 103, /* $@3  */
+    YYSYMBOL_104_4                             = 104, /* $@4  */
+    YYSYMBOL_integer_set                       = 105, /* integer_set  */
+    YYSYMBOL_range                             = 106, /* range  */
+    YYSYMBOL_integer_enumeration               = 107, /* integer_enumeration  */
+    YYSYMBOL_string_set                        = 108, /* string_set  */
+    YYSYMBOL_109_5                             = 109, /* $@5  */
+    YYSYMBOL_string_enumeration                = 110, /* string_enumeration  */
+    YYSYMBOL_string_enumeration_item           = 111, /* string_enumeration_item  */
+    YYSYMBOL_for_expression                    = 112, /* for_expression  */
+    YYSYMBOL_primary_expression                = 113  /* primary_expression  */
 };
-typedef union YYSTYPE YYSTYPE;
-# define YYSTYPE_IS_TRIVIAL 1
-# define YYSTYPE_IS_DECLARED 1
-#endif
-
-
-
-int yara_yyparse (void *yyscanner, YR_COMPILER* compiler);
-
-#endif /* !YY_YARA_YY_YARA_GRAMMAR_H_INCLUDED  */
-
-
+typedef enum yysymbol_kind_t yysymbol_kind_t;
 
 #ifdef short
-# undef short
+#undef short
 #endif
 
 /* On compilers that do not define __PTRDIFF_MAX__ etc., make sure
@@ -293,11 +301,11 @@ int yara_yyparse (void *yyscanner, YR_COMPILER* compiler);
    so that the code can choose integer types of a good width.  */
 
 #ifndef __PTRDIFF_MAX__
-# include <limits.h> /* INFRINGES ON USER NAME SPACE */
-# if defined __STDC_VERSION__ && 199901 <= __STDC_VERSION__
-#  include <stdint.h> /* INFRINGES ON USER NAME SPACE */
-#  define YY_STDINT_H
-# endif
+#include <limits.h> /* INFRINGES ON USER NAME SPACE */
+#if defined __STDC_VERSION__ && 199901 <= __STDC_VERSION__
+#include <stdint.h> /* INFRINGES ON USER NAME SPACE */
+#define YY_STDINT_H
+#endif
 #endif
 
 /* Narrow types that promote to a signed type and that can represent a
@@ -321,10 +329,19 @@ typedef int_least16_t yytype_int16;
 typedef short yytype_int16;
 #endif
 
+/* Work around bug in HP-UX 11.23, which defines these macros
+   incorrectly for preprocessor constants. See Table 2 of
+   <https://h20195.www2.hpe.com/V2/getpdf.aspx/4AA4-7673ENW.pdf>.  */
+#ifdef __hpux
+#undef UINT_LEAST8_MAX
+#undef UINT_LEAST16_MAX
+#define UINT_LEAST8_MAX 255
+#define UINT_LEAST16_MAX 65535
+#endif
+
 #if defined __UINT_LEAST8_MAX__ && __UINT_LEAST8_MAX__ <= __INT_MAX__
 typedef __UINT_LEAST8_TYPE__ yytype_uint8;
-#elif (!defined __UINT_LEAST8_MAX__ && defined YY_STDINT_H \
-       && UINT_LEAST8_MAX <= INT_MAX)
+#elif (!defined __UINT_LEAST8_MAX__ && defined YY_STDINT_H && UINT_LEAST8_MAX <= INT_MAX)
 typedef uint_least8_t yytype_uint8;
 #elif !defined __UINT_LEAST8_MAX__ && UCHAR_MAX <= INT_MAX
 typedef unsigned char yytype_uint8;
@@ -334,8 +351,7 @@ typedef short yytype_uint8;
 
 #if defined __UINT_LEAST16_MAX__ && __UINT_LEAST16_MAX__ <= __INT_MAX__
 typedef __UINT_LEAST16_TYPE__ yytype_uint16;
-#elif (!defined __UINT_LEAST16_MAX__ && defined YY_STDINT_H \
-       && UINT_LEAST16_MAX <= INT_MAX)
+#elif (!defined __UINT_LEAST16_MAX__ && defined YY_STDINT_H && UINT_LEAST16_MAX <= INT_MAX)
 typedef uint_least16_t yytype_uint16;
 #elif !defined __UINT_LEAST16_MAX__ && USHRT_MAX <= INT_MAX
 typedef unsigned short yytype_uint16;
@@ -344,41 +360,41 @@ typedef int yytype_uint16;
 #endif
 
 #ifndef YYPTRDIFF_T
-# if defined __PTRDIFF_TYPE__ && defined __PTRDIFF_MAX__
-#  define YYPTRDIFF_T __PTRDIFF_TYPE__
-#  define YYPTRDIFF_MAXIMUM __PTRDIFF_MAX__
-# elif defined PTRDIFF_MAX
-#  ifndef ptrdiff_t
-#   include <stddef.h> /* INFRINGES ON USER NAME SPACE */
-#  endif
-#  define YYPTRDIFF_T ptrdiff_t
-#  define YYPTRDIFF_MAXIMUM PTRDIFF_MAX
-# else
-#  define YYPTRDIFF_T long
-#  define YYPTRDIFF_MAXIMUM LONG_MAX
-# endif
+#if defined __PTRDIFF_TYPE__ && defined __PTRDIFF_MAX__
+#define YYPTRDIFF_T __PTRDIFF_TYPE__
+#define YYPTRDIFF_MAXIMUM __PTRDIFF_MAX__
+#elif defined PTRDIFF_MAX
+#ifndef ptrdiff_t
+#include <stddef.h> /* INFRINGES ON USER NAME SPACE */
+#endif
+#define YYPTRDIFF_T ptrdiff_t
+#define YYPTRDIFF_MAXIMUM PTRDIFF_MAX
+#else
+#define YYPTRDIFF_T long
+#define YYPTRDIFF_MAXIMUM LONG_MAX
+#endif
 #endif
 
 #ifndef YYSIZE_T
-# ifdef __SIZE_TYPE__
-#  define YYSIZE_T __SIZE_TYPE__
-# elif defined size_t
-#  define YYSIZE_T size_t
-# elif defined __STDC_VERSION__ && 199901 <= __STDC_VERSION__
-#  include <stddef.h> /* INFRINGES ON USER NAME SPACE */
-#  define YYSIZE_T size_t
-# else
-#  define YYSIZE_T unsigned
-# endif
+#ifdef __SIZE_TYPE__
+#define YYSIZE_T __SIZE_TYPE__
+#elif defined size_t
+#define YYSIZE_T size_t
+#elif defined __STDC_VERSION__ && 199901 <= __STDC_VERSION__
+#include <stddef.h> /* INFRINGES ON USER NAME SPACE */
+#define YYSIZE_T size_t
+#else
+#define YYSIZE_T unsigned
+#endif
 #endif
 
-#define YYSIZE_MAXIMUM                                  \
-  YY_CAST (YYPTRDIFF_T,                                 \
-           (YYPTRDIFF_MAXIMUM < YY_CAST (YYSIZE_T, -1)  \
-            ? YYPTRDIFF_MAXIMUM                         \
-            : YY_CAST (YYSIZE_T, -1)))
+#define YYSIZE_MAXIMUM                                 \
+    YY_CAST(YYPTRDIFF_T,                               \
+            (YYPTRDIFF_MAXIMUM < YY_CAST(YYSIZE_T, -1) \
+                 ? YYPTRDIFF_MAXIMUM                   \
+                 : YY_CAST(YYSIZE_T, -1)))
 
-#define YYSIZEOF(X) YY_CAST (YYPTRDIFF_T, sizeof (X))
+#define YYSIZEOF(X) YY_CAST(YYPTRDIFF_T, sizeof(X))
 
 /* Stored state numbers (used for stacks). */
 typedef yytype_uint8 yy_state_t;
@@ -387,674 +403,653 @@ typedef yytype_uint8 yy_state_t;
 typedef int yy_state_fast_t;
 
 #ifndef YY_
-# if defined YYENABLE_NLS && YYENABLE_NLS
-#  if ENABLE_NLS
-#   include <libintl.h> /* INFRINGES ON USER NAME SPACE */
-#   define YY_(Msgid) dgettext ("bison-runtime", Msgid)
-#  endif
-# endif
-# ifndef YY_
-#  define YY_(Msgid) Msgid
-# endif
+#if defined YYENABLE_NLS && YYENABLE_NLS
+#if ENABLE_NLS
+#include <libintl.h> /* INFRINGES ON USER NAME SPACE */
+#define YY_(Msgid) dgettext("bison-runtime", Msgid)
+#endif
+#endif
+#ifndef YY_
+#define YY_(Msgid) Msgid
+#endif
 #endif
 
 #ifndef YY_ATTRIBUTE_PURE
-# if defined __GNUC__ && 2 < __GNUC__ + (96 <= __GNUC_MINOR__)
-#  define YY_ATTRIBUTE_PURE __attribute__ ((__pure__))
-# else
-#  define YY_ATTRIBUTE_PURE
-# endif
+#if defined __GNUC__ && 2 < __GNUC__ + (96 <= __GNUC_MINOR__)
+#define YY_ATTRIBUTE_PURE __attribute__((__pure__))
+#else
+#define YY_ATTRIBUTE_PURE
+#endif
 #endif
 
 #ifndef YY_ATTRIBUTE_UNUSED
-# if defined __GNUC__ && 2 < __GNUC__ + (7 <= __GNUC_MINOR__)
-#  define YY_ATTRIBUTE_UNUSED __attribute__ ((__unused__))
-# else
-#  define YY_ATTRIBUTE_UNUSED
-# endif
+#if defined __GNUC__ && 2 < __GNUC__ + (7 <= __GNUC_MINOR__)
+#define YY_ATTRIBUTE_UNUSED __attribute__((__unused__))
+#else
+#define YY_ATTRIBUTE_UNUSED
+#endif
 #endif
 
 /* Suppress unused-variable warnings by "using" E.  */
-#if ! defined lint || defined __GNUC__
-# define YYUSE(E) ((void) (E))
+#if !defined lint || defined __GNUC__
+#define YY_USE(E) ((void)(E))
 #else
-# define YYUSE(E) /* empty */
+#define YY_USE(E) /* empty */
 #endif
 
-#if defined __GNUC__ && ! defined __ICC && 407 <= __GNUC__ * 100 + __GNUC_MINOR__
 /* Suppress an incorrect diagnostic about yylval being uninitialized.  */
-# define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN                            \
-    _Pragma ("GCC diagnostic push")                                     \
-    _Pragma ("GCC diagnostic ignored \"-Wuninitialized\"")              \
-    _Pragma ("GCC diagnostic ignored \"-Wmaybe-uninitialized\"")
-# define YY_IGNORE_MAYBE_UNINITIALIZED_END      \
-    _Pragma ("GCC diagnostic pop")
+#if defined __GNUC__ && !defined __ICC && 406 <= __GNUC__ * 100 + __GNUC_MINOR__
+#if __GNUC__ * 100 + __GNUC_MINOR__ < 407
+#define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN \
+    _Pragma("GCC diagnostic push")          \
+        _Pragma("GCC diagnostic ignored \"-Wuninitialized\"")
 #else
-# define YY_INITIAL_VALUE(Value) Value
+#define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN                   \
+    _Pragma("GCC diagnostic push")                            \
+        _Pragma("GCC diagnostic ignored \"-Wuninitialized\"") \
+            _Pragma("GCC diagnostic ignored \"-Wmaybe-uninitialized\"")
+#endif
+#define YY_IGNORE_MAYBE_UNINITIALIZED_END \
+    _Pragma("GCC diagnostic pop")
+#else
+#define YY_INITIAL_VALUE(Value) Value
 #endif
 #ifndef YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
-# define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
-# define YY_IGNORE_MAYBE_UNINITIALIZED_END
+#define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
+#define YY_IGNORE_MAYBE_UNINITIALIZED_END
 #endif
 #ifndef YY_INITIAL_VALUE
-# define YY_INITIAL_VALUE(Value) /* Nothing. */
+#define YY_INITIAL_VALUE(Value) /* Nothing. */
 #endif
 
-#if defined __cplusplus && defined __GNUC__ && ! defined __ICC && 6 <= __GNUC__
-# define YY_IGNORE_USELESS_CAST_BEGIN                          \
-    _Pragma ("GCC diagnostic push")                            \
-    _Pragma ("GCC diagnostic ignored \"-Wuseless-cast\"")
-# define YY_IGNORE_USELESS_CAST_END            \
-    _Pragma ("GCC diagnostic pop")
+#if defined __cplusplus && defined __GNUC__ && !defined __ICC && 6 <= __GNUC__
+#define YY_IGNORE_USELESS_CAST_BEGIN \
+    _Pragma("GCC diagnostic push")   \
+        _Pragma("GCC diagnostic ignored \"-Wuseless-cast\"")
+#define YY_IGNORE_USELESS_CAST_END \
+    _Pragma("GCC diagnostic pop")
 #endif
 #ifndef YY_IGNORE_USELESS_CAST_BEGIN
-# define YY_IGNORE_USELESS_CAST_BEGIN
-# define YY_IGNORE_USELESS_CAST_END
+#define YY_IGNORE_USELESS_CAST_BEGIN
+#define YY_IGNORE_USELESS_CAST_END
 #endif
 
+#define YY_ASSERT(E) ((void)(0 && (E)))
 
-#define YY_ASSERT(E) ((void) (0 && (E)))
-
-#if ! defined yyoverflow || YYERROR_VERBOSE
+#if !defined yyoverflow
 
 /* The parser invokes alloca or malloc; define the necessary symbols.  */
 
-# ifdef YYSTACK_USE_ALLOCA
-#  if YYSTACK_USE_ALLOCA
-#   ifdef __GNUC__
-#    define YYSTACK_ALLOC __builtin_alloca
-#   elif defined __BUILTIN_VA_ARG_INCR
-#    include <alloca.h> /* INFRINGES ON USER NAME SPACE */
-#   elif defined _AIX
-#    define YYSTACK_ALLOC __alloca
-#   elif defined _MSC_VER
-#    include <malloc.h> /* INFRINGES ON USER NAME SPACE */
-#    define alloca _alloca
-#   else
-#    define YYSTACK_ALLOC alloca
-#    if ! defined _ALLOCA_H && ! defined EXIT_SUCCESS
-#     include <stdlib.h> /* INFRINGES ON USER NAME SPACE */
-      /* Use EXIT_SUCCESS as a witness for stdlib.h.  */
-#     ifndef EXIT_SUCCESS
-#      define EXIT_SUCCESS 0
-#     endif
-#    endif
-#   endif
-#  endif
-# endif
+#ifdef YYSTACK_USE_ALLOCA
+#if YYSTACK_USE_ALLOCA
+#ifdef __GNUC__
+#define YYSTACK_ALLOC __builtin_alloca
+#elif defined __BUILTIN_VA_ARG_INCR
+#include <alloca.h> /* INFRINGES ON USER NAME SPACE */
+#elif defined _AIX
+#define YYSTACK_ALLOC __alloca
+#elif defined _MSC_VER
+#include <malloc.h> /* INFRINGES ON USER NAME SPACE */
+#define alloca _alloca
+#else
+#define YYSTACK_ALLOC alloca
+#if !defined _ALLOCA_H && !defined EXIT_SUCCESS
+#include <stdlib.h> /* INFRINGES ON USER NAME SPACE */
+/* Use EXIT_SUCCESS as a witness for stdlib.h.  */
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#endif
+#endif
+#endif
+#endif
 
-# ifdef YYSTACK_ALLOC
-   /* Pacify GCC's 'empty if-body' warning.  */
-#  define YYSTACK_FREE(Ptr) do { /* empty */; } while (0)
-#  ifndef YYSTACK_ALLOC_MAXIMUM
-    /* The OS might guarantee only one guard page at the bottom of the stack,
-       and a page size can be as small as 4096 bytes.  So we cannot safely
-       invoke alloca (N) if N exceeds 4096.  Use a slightly smaller number
-       to allow for a few compiler-allocated temporary stack slots.  */
-#   define YYSTACK_ALLOC_MAXIMUM 4032 /* reasonable circa 2006 */
-#  endif
-# else
-#  define YYSTACK_ALLOC YYMALLOC
-#  define YYSTACK_FREE YYFREE
-#  ifndef YYSTACK_ALLOC_MAXIMUM
-#   define YYSTACK_ALLOC_MAXIMUM YYSIZE_MAXIMUM
-#  endif
-#  if (defined __cplusplus && ! defined EXIT_SUCCESS \
-       && ! ((defined YYMALLOC || defined malloc) \
-             && (defined YYFREE || defined free)))
-#   include <stdlib.h> /* INFRINGES ON USER NAME SPACE */
-#   ifndef EXIT_SUCCESS
-#    define EXIT_SUCCESS 0
-#   endif
-#  endif
-#  ifndef YYMALLOC
-#   define YYMALLOC malloc
-#   if ! defined malloc && ! defined EXIT_SUCCESS
-void *malloc (YYSIZE_T); /* INFRINGES ON USER NAME SPACE */
-#   endif
-#  endif
-#  ifndef YYFREE
-#   define YYFREE free
-#   if ! defined free && ! defined EXIT_SUCCESS
-void free (void *); /* INFRINGES ON USER NAME SPACE */
-#   endif
-#  endif
-# endif
-#endif /* ! defined yyoverflow || YYERROR_VERBOSE */
+#ifdef YYSTACK_ALLOC
+/* Pacify GCC's 'empty if-body' warning.  */
+#define YYSTACK_FREE(Ptr) \
+    do { /* empty */      \
+        ;                 \
+    } while (0)
+#ifndef YYSTACK_ALLOC_MAXIMUM
+/* The OS might guarantee only one guard page at the bottom of the stack,
+   and a page size can be as small as 4096 bytes.  So we cannot safely
+   invoke alloca (N) if N exceeds 4096.  Use a slightly smaller number
+   to allow for a few compiler-allocated temporary stack slots.  */
+#define YYSTACK_ALLOC_MAXIMUM 4032 /* reasonable circa 2006 */
+#endif
+#else
+#define YYSTACK_ALLOC YYMALLOC
+#define YYSTACK_FREE YYFREE
+#ifndef YYSTACK_ALLOC_MAXIMUM
+#define YYSTACK_ALLOC_MAXIMUM YYSIZE_MAXIMUM
+#endif
+#if (defined __cplusplus && !defined EXIT_SUCCESS && !((defined YYMALLOC || defined malloc) && (defined YYFREE || defined free)))
+#include <stdlib.h> /* INFRINGES ON USER NAME SPACE */
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#endif
+#ifndef YYMALLOC
+#define YYMALLOC malloc
+#if !defined malloc && !defined EXIT_SUCCESS
+void *malloc(YYSIZE_T); /* INFRINGES ON USER NAME SPACE */
+#endif
+#endif
+#ifndef YYFREE
+#define YYFREE free
+#if !defined free && !defined EXIT_SUCCESS
+void free(void *);      /* INFRINGES ON USER NAME SPACE */
+#endif
+#endif
+#endif
+#endif /* !defined yyoverflow */
 
-
-#if (! defined yyoverflow \
-     && (! defined __cplusplus \
-         || (defined YYSTYPE_IS_TRIVIAL && YYSTYPE_IS_TRIVIAL)))
+#if (!defined yyoverflow && (!defined __cplusplus || (defined YYSTYPE_IS_TRIVIAL && YYSTYPE_IS_TRIVIAL)))
 
 /* A type that is properly aligned for any stack member.  */
-union yyalloc
-{
-  yy_state_t yyss_alloc;
-  YYSTYPE yyvs_alloc;
+union yyalloc {
+    yy_state_t yyss_alloc;
+    YYSTYPE yyvs_alloc;
 };
 
 /* The size of the maximum gap between one aligned stack and the next.  */
-# define YYSTACK_GAP_MAXIMUM (YYSIZEOF (union yyalloc) - 1)
+#define YYSTACK_GAP_MAXIMUM (YYSIZEOF(union yyalloc) - 1)
 
 /* The size of an array large to enough to hold all stacks, each with
    N elements.  */
-# define YYSTACK_BYTES(N) \
-     ((N) * (YYSIZEOF (yy_state_t) + YYSIZEOF (YYSTYPE)) \
-      + YYSTACK_GAP_MAXIMUM)
+#define YYSTACK_BYTES(N) \
+    ((N) * (YYSIZEOF(yy_state_t) + YYSIZEOF(YYSTYPE)) + YYSTACK_GAP_MAXIMUM)
 
-# define YYCOPY_NEEDED 1
+#define YYCOPY_NEEDED 1
 
 /* Relocate STACK from its old location to the new one.  The
    local variables YYSIZE and YYSTACKSIZE give the old and new number of
    elements in the stack, and YYPTR gives the new location of the
    stack.  Advance YYPTR to a properly aligned location for the next
    stack.  */
-# define YYSTACK_RELOCATE(Stack_alloc, Stack)                           \
-    do                                                                  \
-      {                                                                 \
-        YYPTRDIFF_T yynewbytes;                                         \
-        YYCOPY (&yyptr->Stack_alloc, Stack, yysize);                    \
-        Stack = &yyptr->Stack_alloc;                                    \
-        yynewbytes = yystacksize * YYSIZEOF (*Stack) + YYSTACK_GAP_MAXIMUM; \
-        yyptr += yynewbytes / YYSIZEOF (*yyptr);                        \
-      }                                                                 \
-    while (0)
+#define YYSTACK_RELOCATE(Stack_alloc, Stack)                               \
+    do {                                                                   \
+        YYPTRDIFF_T yynewbytes;                                            \
+        YYCOPY(&yyptr->Stack_alloc, Stack, yysize);                        \
+        Stack      = &yyptr->Stack_alloc;                                  \
+        yynewbytes = yystacksize * YYSIZEOF(*Stack) + YYSTACK_GAP_MAXIMUM; \
+        yyptr += yynewbytes / YYSIZEOF(*yyptr);                            \
+    } while (0)
 
 #endif
 
 #if defined YYCOPY_NEEDED && YYCOPY_NEEDED
 /* Copy COUNT objects from SRC to DST.  The source and destination do
    not overlap.  */
-# ifndef YYCOPY
-#  if defined __GNUC__ && 1 < __GNUC__
-#   define YYCOPY(Dst, Src, Count) \
-      __builtin_memcpy (Dst, Src, YY_CAST (YYSIZE_T, (Count)) * sizeof (*(Src)))
-#  else
-#   define YYCOPY(Dst, Src, Count)              \
-      do                                        \
-        {                                       \
-          YYPTRDIFF_T yyi;                      \
-          for (yyi = 0; yyi < (Count); yyi++)   \
-            (Dst)[yyi] = (Src)[yyi];            \
-        }                                       \
-      while (0)
-#  endif
-# endif
+#ifndef YYCOPY
+#if defined __GNUC__ && 1 < __GNUC__
+#define YYCOPY(Dst, Src, Count) \
+    __builtin_memcpy(Dst, Src, YY_CAST(YYSIZE_T, (Count)) * sizeof(*(Src)))
+#else
+#define YYCOPY(Dst, Src, Count)             \
+    do {                                    \
+        YYPTRDIFF_T yyi;                    \
+        for (yyi = 0; yyi < (Count); yyi++) \
+            (Dst)[yyi] = (Src)[yyi];        \
+    } while (0)
+#endif
+#endif
 #endif /* !YYCOPY_NEEDED */
 
 /* YYFINAL -- State number of the termination state.  */
-#define YYFINAL  2
+#define YYFINAL 2
 /* YYLAST -- Last index in YYTABLE.  */
-#define YYLAST   433
+#define YYLAST 440
 
 /* YYNTOKENS -- Number of terminals.  */
-#define YYNTOKENS  74
+#define YYNTOKENS 77
 /* YYNNTS -- Number of nonterminals.  */
-#define YYNNTS  35
+#define YYNNTS 37
 /* YYNRULES -- Number of rules.  */
-#define YYNRULES  115
+#define YYNRULES 126
 /* YYNSTATES -- Number of states.  */
-#define YYNSTATES  216
+#define YYNSTATES 235
 
-#define YYUNDEFTOK  2
-#define YYMAXUTOK   309
-
+/* YYMAXUTOK -- Last valid token kind.  */
+#define YYMAXUTOK 312
 
 /* YYTRANSLATE(TOKEN-NUM) -- Symbol number corresponding to TOKEN-NUM
    as returned by yylex, with out-of-bounds checking.  */
-#define YYTRANSLATE(YYX)                                                \
-  (0 <= (YYX) && (YYX) <= YYMAXUTOK ? yytranslate[YYX] : YYUNDEFTOK)
+#define YYTRANSLATE(YYX)                              \
+    (0 <= (YYX) && (YYX) <= YYMAXUTOK                 \
+         ? YY_CAST(yysymbol_kind_t, yytranslate[YYX]) \
+         : YYSYMBOL_YYUNDEF)
 
 /* YYTRANSLATE[TOKEN-NUM] -- Symbol number corresponding to TOKEN-NUM
    as returned by yylex.  */
 static const yytype_int8 yytranslate[] =
-{
-       0,     2,     2,     2,     2,     2,     2,     2,     2,     2,
-       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
-       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
-       2,     2,     2,     2,     2,     2,     2,    60,    44,     2,
-      71,    72,    58,    56,    73,    57,    68,     2,     2,     2,
-       2,     2,     2,     2,     2,     2,     2,     2,    66,     2,
-       2,    67,     2,     2,     2,     2,     2,     2,     2,     2,
-       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
-       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
-       2,    69,    59,    70,    46,     2,     2,     2,     2,     2,
-       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
-       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
-       2,     2,     2,    64,    45,    65,    62,     2,     2,     2,
-       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
-       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
-       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
-       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
-       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
-       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
-       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
-       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
-       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
-       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
-       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
-       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
-       2,     2,     2,     2,     2,     2,     1,     2,     3,     4,
-       5,     6,     7,     8,     9,    10,    11,    12,    13,    14,
-      15,    16,    17,    18,    19,    20,    21,    22,    23,    24,
-      25,    26,    27,    28,    29,    30,    31,    32,    33,    34,
-      35,    36,    37,    38,    39,    40,    41,    42,    43,    47,
-      48,    49,    50,    51,    52,    53,    54,    55,    61,    63
-};
+    {
+        0, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+        2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+        2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+        2, 2, 2, 2, 2, 2, 2, 63, 47, 2,
+        71, 72, 61, 59, 76, 60, 73, 2, 2, 2,
+        2, 2, 2, 2, 2, 2, 2, 2, 69, 2,
+        2, 70, 2, 2, 2, 2, 2, 2, 2, 2,
+        2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+        2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+        2, 74, 62, 75, 49, 2, 2, 2, 2, 2,
+        2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+        2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+        2, 2, 2, 67, 48, 68, 65, 2, 2, 2,
+        2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+        2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+        2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+        2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+        2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+        2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+        2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+        2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+        2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+        2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+        2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+        2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+        2, 2, 2, 2, 2, 2, 1, 2, 3, 4,
+        5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
+        15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+        25, 26, 27, 28, 29, 30, 31, 32, 33, 34,
+        35, 36, 37, 38, 39, 40, 41, 42, 43, 44,
+        45, 46, 50, 51, 52, 53, 54, 55, 56, 57,
+        58, 64, 66};
 
 #if YYDEBUG
-  /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
+/* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_int16 yyrline[] =
-{
-       0,   233,   233,   234,   235,   236,   237,   242,   254,   273,
-     276,   306,   310,   338,   343,   344,   349,   350,   356,   359,
-     379,   396,   435,   436,   441,   457,   470,   483,   500,   501,
-     506,   520,   519,   536,   553,   554,   559,   560,   561,   562,
-     567,   652,   702,   725,   765,   768,   790,   823,   870,   888,
-     897,   906,   921,   935,   948,   965,   981,  1015,   980,  1126,
-    1125,  1201,  1207,  1213,  1219,  1227,  1236,  1245,  1254,  1263,
-    1290,  1317,  1344,  1348,  1356,  1357,  1362,  1384,  1396,  1412,
-    1411,  1417,  1429,  1430,  1435,  1440,  1449,  1450,  1457,  1468,
-    1472,  1481,  1496,  1507,  1518,  1529,  1540,  1551,  1562,  1571,
-    1598,  1611,  1626,  1648,  1683,  1692,  1701,  1710,  1719,  1728,
-    1737,  1746,  1755,  1763,  1772,  1781
-};
+    {
+        0, 247, 247, 248, 249, 250, 251, 256, 268, 287,
+        290, 320, 324, 352, 357, 358, 363, 364, 370, 373,
+        393, 410, 449, 450, 455, 471, 484, 497, 514, 515,
+        520, 534, 533, 550, 567, 568, 582, 583, 584, 585,
+        586, 587, 588, 593, 598, 603, 609, 614, 624, 625,
+        639, 644, 729, 779, 802, 842, 845, 867, 900, 947,
+        965, 974, 983, 998, 1012, 1025, 1042, 1058, 1092, 1057,
+        1203, 1202, 1278, 1284, 1290, 1296, 1304, 1313, 1322, 1331,
+        1340, 1367, 1394, 1421, 1425, 1433, 1434, 1439, 1461, 1473,
+        1489, 1488, 1494, 1506, 1507, 1512, 1517, 1526, 1527, 1534,
+        1545, 1549, 1558, 1573, 1584, 1595, 1606, 1617, 1628, 1639,
+        1648, 1675, 1688, 1703, 1725, 1760, 1769, 1778, 1787, 1796,
+        1805, 1814, 1823, 1832, 1840, 1849, 1858};
 #endif
 
-#if YYDEBUG || YYERROR_VERBOSE || 0
+/** Accessing symbol of state STATE.  */
+#define YY_ACCESSING_SYMBOL(State) YY_CAST(yysymbol_kind_t, yystos[State])
+
+#if YYDEBUG || 0
+/* The user-facing name of the symbol whose (internal) number is
+   YYSYMBOL.  No bounds checking.  */
+static const char* yysymbol_name(yysymbol_kind_t yysymbol) YY_ATTRIBUTE_UNUSED;
+
 /* YYTNAME[SYMBOL-NUM] -- String name of the symbol SYMBOL-NUM.
    First, the terminals, then, starting at YYNTOKENS, nonterminals.  */
-static const char *const yytname[] =
+static const char* const yytname[] =
+    {
+        "\"end of file\"", "error", "\"invalid token\"", "_RULE_", "_PRIVATE_",
+        "_GLOBAL_", "_META_", "_STRINGS_", "_CONDITION_", "_IDENTIFIER_",
+        "_STRING_IDENTIFIER_", "_STRING_COUNT_", "_STRING_OFFSET_",
+        "_STRING_IDENTIFIER_WITH_WILDCARD_", "_NUMBER_", "_TEXT_STRING_",
+        "_HEX_STRING_", "_REGEXP_", "_ASCII_", "_WIDE_", "_XOR_", "_BASE64_",
+        "_BASE64_WIDE_", "_NOCASE_", "_FULLWORD_", "_AT_", "_FILESIZE_",
+        "_ENTRYPOINT_", "_ALL_", "_ANY_", "_IN_", "_OF_", "_FOR_", "_THEM_",
+        "_INT8_", "_INT16_", "_INT32_", "_UINT8_", "_UINT16_", "_UINT32_",
+        "_MATCHES_", "_CONTAINS_", "_IMPORT_", "_TRUE_", "_FALSE_", "_OR_",
+        "_AND_", "'&'", "'|'", "'^'", "_LT_", "_LE_", "_GT_", "_GE_", "_EQ_",
+        "_NEQ_", "_IS_", "_SHIFT_LEFT_", "_SHIFT_RIGHT_", "'+'", "'-'", "'*'",
+        "'\\\\'", "'%'", "_NOT_", "'~'", "\"include\"", "'{'", "'}'", "':'",
+        "'='", "'('", "')'", "'.'", "'['", "']'", "','", "$accept", "rules",
+        "import", "rule", "meta", "strings", "condition", "rule_modifiers",
+        "rule_modifier", "tags", "tag_list", "meta_declarations",
+        "meta_declaration", "string_declarations", "string_declaration", "$@1",
+        "string_modifiers", "string_modifier", "hex_modifiers", "hex_modifier",
+        "identifier", "arguments_list", "regexp", "boolean_expression",
+        "expression", "$@2", "$@3", "$@4", "integer_set", "range",
+        "integer_enumeration", "string_set", "$@5", "string_enumeration",
+        "string_enumeration_item", "for_expression", "primary_expression", YY_NULLPTR};
+
+static const char*
+yysymbol_name(yysymbol_kind_t yysymbol)
 {
-  "$end", "error", "$undefined", "_RULE_", "_PRIVATE_", "_GLOBAL_",
-  "_META_", "_STRINGS_", "_CONDITION_", "_IDENTIFIER_",
-  "_STRING_IDENTIFIER_", "_STRING_COUNT_", "_STRING_OFFSET_",
-  "_STRING_IDENTIFIER_WITH_WILDCARD_", "_NUMBER_", "_TEXT_STRING_",
-  "_HEX_STRING_", "_REGEXP_", "_ASCII_", "_WIDE_", "_NOCASE_",
-  "_FULLWORD_", "_AT_", "_FILESIZE_", "_ENTRYPOINT_", "_ALL_", "_ANY_",
-  "_IN_", "_OF_", "_FOR_", "_THEM_", "_INT8_", "_INT16_", "_INT32_",
-  "_UINT8_", "_UINT16_", "_UINT32_", "_MATCHES_", "_CONTAINS_", "_IMPORT_",
-  "_TRUE_", "_FALSE_", "_OR_", "_AND_", "'&'", "'|'", "'^'", "_LT_",
-  "_LE_", "_GT_", "_GE_", "_EQ_", "_NEQ_", "_IS_", "_SHIFT_LEFT_",
-  "_SHIFT_RIGHT_", "'+'", "'-'", "'*'", "'\\\\'", "'%'", "_NOT_", "'~'",
-  "\"include\"", "'{'", "'}'", "':'", "'='", "'.'", "'['", "']'", "'('",
-  "')'", "','", "$accept", "rules", "import", "rule", "meta", "strings",
-  "condition", "rule_modifiers", "rule_modifier", "tags", "tag_list",
-  "meta_declarations", "meta_declaration", "string_declarations",
-  "string_declaration", "$@1", "string_modifiers", "string_modifier",
-  "identifier", "arguments_list", "regexp", "boolean_expression",
-  "expression", "$@2", "$@3", "$@4", "integer_set", "range",
-  "integer_enumeration", "string_set", "$@5", "string_enumeration",
-  "string_enumeration_item", "for_expression", "primary_expression", YY_NULLPTR
-};
+    return yytname[yysymbol];
+}
 #endif
 
-# ifdef YYPRINT
-/* YYTOKNUM[NUM] -- (External) token number corresponding to the
-   (internal) symbol number NUM (which must be that of a token).  */
-static const yytype_int16 yytoknum[] =
-{
-       0,   256,   257,   258,   259,   260,   261,   262,   263,   264,
-     265,   266,   267,   268,   269,   270,   271,   272,   273,   274,
-     275,   276,   277,   278,   279,   280,   281,   282,   283,   284,
-     285,   286,   287,   288,   289,   290,   291,   292,   293,   294,
-     295,   296,   297,   298,    38,   124,    94,   299,   300,   301,
-     302,   303,   304,   305,   306,   307,    43,    45,    42,    92,
-      37,   308,   126,   309,   123,   125,    58,    61,    46,    91,
-      93,    40,    41,    44
-};
-# endif
-
-#define YYPACT_NINF (-66)
+#define YYPACT_NINF (-67)
 
 #define yypact_value_is_default(Yyn) \
-  ((Yyn) == YYPACT_NINF)
+    ((Yyn) == YYPACT_NINF)
 
-#define YYTABLE_NINF (-87)
+#define YYTABLE_NINF (-98)
 
 #define yytable_value_is_error(Yyn) \
-  0
+    0
 
-  /* YYPACT[STATE-NUM] -- Index in YYTABLE of the portion describing
-     STATE-NUM.  */
+/* YYPACT[STATE-NUM] -- Index in YYTABLE of the portion describing
+   STATE-NUM.  */
 static const yytype_int16 yypact[] =
-{
-     -66,     6,   -66,   -59,     0,   -66,   -66,    59,   -66,   -66,
-     -66,     9,   -66,   -66,   -66,   -44,    16,   -24,   -66,    49,
-      81,   -66,    26,    88,    92,    43,   115,    54,    92,   -66,
-     116,    63,    66,    -2,   -66,    75,   116,   -66,    79,   -66,
-     -66,   -66,   -66,   -66,    82,   -66,   -66,    -8,   -66,    83,
-     -66,   -66,   -66,   -66,   -66,   -66,   -66,   113,    72,    80,
-      84,    94,    96,    97,   -66,   -66,    79,   168,    79,   -42,
-     -66,    57,   -66,   125,   205,   -66,   -66,   137,   168,    98,
-     168,   168,    -7,   372,   168,   168,   168,   168,   168,   168,
-     -66,   -66,    57,   100,   169,   161,   168,    79,    79,    79,
-     -29,   156,   168,   168,   168,   168,   168,   168,   168,   168,
-     168,   168,   168,   168,   168,   168,   168,   168,   168,   168,
-      36,   -66,   372,   168,   -66,   338,   222,   149,   -29,   229,
-     251,   258,   280,   287,   309,   -66,   -66,   -66,   345,    34,
-      74,   135,   -66,   -66,   -66,   -66,   -66,   372,   104,   104,
-     104,   372,   372,   372,   372,   372,   372,   372,   -23,   -23,
-      25,    25,   -66,   -66,   -66,   -66,   -66,   -66,   -66,   -66,
-      36,   365,   -66,   -66,   120,   -66,   -66,   -66,   -66,   -66,
-     -66,   -66,   -66,    79,    -5,   119,   110,   -66,    74,   -66,
-     -66,    60,   -66,   168,   168,   122,   -66,   118,   -66,    -5,
-     316,    62,   365,   -66,    79,   -66,   -66,   -66,   168,   123,
-     -26,   372,    79,   -66,   -19,   -66
-};
+    {
+        -67, 5, -67, -28, -1, -67, -67, 113, -67, -67,
+        -67, 35, -67, -67, -67, -21, 83, 34, -67, 100,
+        115, -67, 55, 119, 120, 63, 114, 67, 120, -67,
+        128, 70, 78, -3, -67, 79, 128, -67, 76, -67,
+        -67, -67, -67, -67, 10, -67, -67, -7, -67, 74,
+        -67, -67, -67, -67, -67, -67, -67, 116, 85, 86,
+        87, 88, 89, 90, -67, -67, 76, 183, 76, -37,
+        -67, 19, -67, 131, 218, -67, -67, 146, 183, 96,
+        183, 183, 4, 377, 183, 183, 183, 183, 183, 183,
+        -67, -67, 19, 97, 184, 76, 159, 183, 76, 76,
+        -32, 153, 183, 183, 183, 183, 183, 183, 183, 183,
+        183, 183, 183, 183, 183, 183, 183, 183, 183, 183,
+        409, 169, -67, 377, 183, -67, 235, 264, 152, -32,
+        271, 290, 297, 316, 323, 342, -67, -67, -55, 61,
+        -67, 242, 138, -67, -67, -67, -67, -67, 377, 37,
+        37, 37, 377, 377, 377, 377, 377, 377, 377, -4,
+        -4, 73, 73, -67, -67, -67, -67, -67, -67, 118,
+        125, 130, -67, -67, -67, -67, -67, 409, 117, -67,
+        -67, 133, -67, -67, -67, -67, -67, -67, -67, 76,
+        -67, 53, 171, 173, 188, 126, 134, -67, 61, -67,
+        -67, -52, -67, -53, 132, 135, 183, 183, 137, -67,
+        140, -67, 53, 172, -67, -67, -67, 349, -45, 117,
+        -67, 76, -67, 136, -67, -67, 183, 141, -42, -67,
+        377, 76, -67, -30, -67};
 
-  /* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
-     Performed when YYTABLE does not specify something else to do.  Zero
-     means the default is an error.  */
+/* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
+   Performed when YYTABLE does not specify something else to do.  Zero
+   means the default is an error.  */
 static const yytype_int8 yydefact[] =
-{
-       2,     0,     1,    14,     0,     4,     3,     0,     6,     5,
-       7,     0,    16,    17,    15,    18,     0,     0,    20,    19,
-       9,    21,     0,    11,     0,     0,     0,     0,    10,    22,
-       0,     0,     0,     0,    23,     0,    12,    28,     0,     8,
-      25,    24,    26,    27,    31,    29,    40,    53,   100,   102,
-      98,    99,    47,    90,    91,    87,    88,     0,     0,     0,
-       0,     0,     0,     0,    49,    50,     0,     0,     0,   103,
-     115,    13,    48,     0,    72,    34,    33,     0,     0,     0,
-       0,     0,     0,    86,     0,     0,     0,     0,     0,     0,
-      62,   112,     0,    48,    72,     0,     0,    44,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-      30,    34,    54,     0,    55,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,    73,    89,    41,     0,     0,
-      45,    64,    63,    81,    79,    61,    51,    52,   110,   111,
-     109,    65,    67,    66,    68,    69,    71,    70,   113,   114,
-     104,   105,   106,   107,   108,    37,    36,    38,    39,    35,
-      32,     0,   101,    56,     0,    92,    93,    94,    95,    96,
-      97,    42,    43,     0,     0,     0,     0,    59,    46,    84,
-      85,     0,    82,     0,     0,     0,    75,     0,    80,     0,
-       0,     0,    77,    57,     0,    83,    76,    74,     0,     0,
-       0,    78,     0,    60,     0,    58
-};
+    {
+        2, 0, 1, 14, 0, 4, 3, 0, 6, 5,
+        7, 0, 16, 17, 15, 18, 0, 0, 20, 19,
+        9, 21, 0, 11, 0, 0, 0, 0, 10, 22,
+        0, 0, 0, 0, 23, 0, 12, 28, 0, 8,
+        25, 24, 26, 27, 31, 29, 51, 64, 111, 113,
+        109, 110, 58, 101, 102, 98, 99, 0, 0, 0,
+        0, 0, 0, 0, 60, 61, 0, 0, 0, 114,
+        126, 13, 59, 0, 83, 34, 48, 0, 0, 0,
+        0, 0, 0, 97, 0, 0, 0, 0, 0, 0,
+        73, 123, 0, 59, 83, 55, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        30, 33, 34, 65, 0, 66, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 84, 100, 0, 56,
+        52, 0, 75, 74, 92, 90, 72, 62, 63, 121,
+        122, 120, 76, 78, 77, 79, 80, 82, 81, 124,
+        125, 115, 116, 117, 118, 119, 40, 37, 36, 41,
+        44, 46, 38, 39, 35, 50, 49, 32, 0, 112,
+        67, 0, 103, 104, 105, 106, 107, 108, 54, 0,
+        53, 0, 0, 0, 0, 0, 0, 70, 57, 95,
+        96, 0, 93, 0, 0, 0, 0, 0, 0, 86,
+        0, 91, 0, 0, 42, 45, 47, 0, 0, 88,
+        68, 0, 94, 0, 87, 85, 0, 0, 0, 43,
+        89, 0, 71, 0, 69};
 
-  /* YYPGOTO[NTERM-NUM].  */
+/* YYPGOTO[NTERM-NUM].  */
 static const yytype_int16 yypgoto[] =
-{
-     -66,   -66,   -66,   187,   -66,   -66,   -66,   -66,   -66,   -66,
-     -66,   -66,   165,   -66,   159,   -66,    77,   -66,   -66,   -66,
-      95,   -38,   -65,   -66,   -66,   -66,   -66,    19,   -66,   103,
-     -66,   -66,    10,   151,   -37
-};
+    {
+        -67, -67, -67, 210, -67, -67, -67, -67, -67, -67,
+        -67, -67, 186, -67, 180, -67, 101, -67, -67, -67,
+        -67, -67, 127, -38, -66, -67, -67, -67, -67, 30,
+        -67, 98, -67, -67, 17, 193, -35};
 
-  /* YYDEFGOTO[NTERM-NUM].  */
-static const yytype_int16 yydefgoto[] =
-{
-      -1,     1,     5,     6,    23,    26,    32,     7,    14,    17,
-      19,    28,    29,    36,    37,    77,   120,   169,    69,   139,
-      70,    92,    72,   186,   209,   197,   195,   124,   201,   145,
-     184,   191,   192,    73,    74
-};
+/* YYDEFGOTO[NTERM-NUM].  */
+static const yytype_uint8 yydefgoto[] =
+    {
+        0, 1, 5, 6, 23, 26, 32, 7, 14, 17,
+        19, 28, 29, 36, 37, 77, 120, 174, 121, 176,
+        69, 138, 70, 92, 72, 196, 227, 210, 208, 125,
+        218, 146, 191, 201, 202, 73, 74};
 
-  /* YYTABLE[YYPACT[STATE-NUM]] -- What to do in state STATE-NUM.  If
-     positive, shift that token.  If negative, reduce the rule whose
-     number is the opposite.  If YYTABLE_NINF, syntax error.  */
+/* YYTABLE[YYPACT[STATE-NUM]] -- What to do in state STATE-NUM.  If
+   positive, shift that token.  If negative, reduce the rule whose
+   number is the opposite.  If YYTABLE_NINF, syntax error.  */
 static const yytype_int16 yytable[] =
-{
-      71,   143,   127,    93,     8,   189,     2,     3,   190,   -14,
-     -14,   -14,    40,    41,    78,    10,    98,    99,    15,    79,
-      83,   128,    16,    98,    99,    18,    95,    96,    90,    97,
-      91,    94,   140,   115,   116,   117,   118,   119,    42,    43,
-      20,   122,   144,   125,   126,     4,   213,   129,   130,   131,
-     132,   133,   134,   215,   165,   166,   167,   168,    21,   138,
-     141,   142,    11,    12,    13,   147,   148,   149,   150,   151,
-     152,   153,   154,   155,   156,   157,   158,   159,   160,   161,
-     162,   163,   164,   117,   118,   119,   171,    22,    46,    47,
-      48,    49,    24,    50,    51,    25,    52,    75,    76,    98,
-      99,    27,    53,    54,    55,    56,   182,   183,    57,    30,
-      58,    59,    60,    61,    62,    63,   -48,   -48,   188,    64,
-      65,    33,    46,    31,    48,    49,    35,    50,    51,    38,
-      52,    39,   198,   199,   207,   208,    53,    54,    55,    56,
-      66,    67,    44,    84,    58,    59,    60,    61,    62,    63,
-      68,    85,    80,   100,   121,    86,   200,   202,   113,   114,
-     115,   116,   117,   118,   119,    87,   210,    88,    89,   123,
-     137,   211,   135,    52,   214,    67,   173,    46,    99,    48,
-      49,   194,    50,    51,    81,    52,   187,   193,   203,   204,
-       9,    53,    54,    34,   212,    45,   146,   -86,   170,    58,
-      59,    60,    61,    62,    63,   196,   101,   102,    82,   205,
-       0,     0,     0,   103,   104,   105,   106,   107,   108,   109,
-     110,   111,   112,   113,   114,   115,   116,   117,   118,   119,
-      67,   174,     0,   -86,     0,     0,     0,     0,     0,    81,
-       0,   136,   101,   102,     0,     0,     0,     0,     0,   103,
-     104,   105,   106,   107,   108,   109,   110,   111,   112,   113,
-     114,   115,   116,   117,   118,   119,   103,   104,   105,     0,
-       0,     0,     0,   103,   104,   105,   113,   114,   115,   116,
-     117,   118,   119,   113,   114,   115,   116,   117,   118,   119,
-       0,     0,     0,     0,   136,   103,   104,   105,     0,     0,
-       0,   175,   103,   104,   105,   113,   114,   115,   116,   117,
-     118,   119,   113,   114,   115,   116,   117,   118,   119,     0,
-       0,     0,     0,   176,   103,   104,   105,     0,     0,     0,
-     177,   103,   104,   105,   113,   114,   115,   116,   117,   118,
-     119,   113,   114,   115,   116,   117,   118,   119,     0,     0,
-       0,     0,   178,   103,   104,   105,     0,     0,     0,   179,
-     103,   104,   105,   113,   114,   115,   116,   117,   118,   119,
-     113,   114,   115,   116,   117,   118,   119,     0,     0,     0,
-       0,   180,   103,   104,   105,     0,     0,     0,   206,   103,
-     104,   105,   113,   114,   115,   116,   117,   118,   119,   113,
-     114,   115,   116,   117,   118,   119,     0,     0,   172,   103,
-     104,   105,     0,     0,     0,   181,   103,   104,   105,   113,
-     114,   115,   116,   117,   118,   119,   113,   114,   115,   116,
-     117,   118,   119,   185
-};
+    {
+        71, 144, 93, 98, 99, 2, 3, 213, -14, -14,
+        -14, 40, 41, 128, 10, 98, 99, 188, 78, 214,
+        211, 189, 83, 79, 212, 75, 76, 225, 90, 139,
+        232, 226, 91, 94, 95, 129, 96, 97, 8, 145,
+        42, 43, 234, 123, 15, 126, 127, 4, 16, 130,
+        131, 132, 133, 134, 135, 115, 116, 117, 118, 119,
+        142, 143, 141, 199, 98, 99, 200, 148, 149, 150,
+        151, 152, 153, 154, 155, 156, 157, 158, 159, 160,
+        161, 162, 163, 164, 165, 46, 47, 48, 49, 178,
+        50, 51, 18, 52, 113, 114, 115, 116, 117, 118,
+        119, 20, 53, 54, 55, 56, -59, -59, 57, 21,
+        58, 59, 60, 61, 62, 63, 11, 12, 13, 64,
+        65, 22, 31, 198, 24, 46, 25, 48, 49, 27,
+        50, 51, 30, 52, 117, 118, 119, 33, 35, 38,
+        66, 67, 53, 54, 55, 56, 39, 68, 80, 44,
+        58, 59, 60, 61, 62, 63, 84, 85, 86, 87,
+        88, 89, 100, 122, 103, 104, 105, 124, 140, 136,
+        52, 217, 219, 175, 113, 114, 115, 116, 117, 118,
+        119, 67, 180, 228, 99, 203, 223, 81, 204, 192,
+        195, 230, 46, 233, 48, 49, 193, 50, 51, 206,
+        52, 194, 197, 205, 215, 207, 220, 216, 229, 53,
+        54, 221, 231, 9, 34, -97, 45, 58, 59, 60,
+        61, 62, 63, 177, 101, 102, 209, 181, 147, 222,
+        0, 103, 104, 105, 106, 107, 108, 109, 110, 111,
+        112, 113, 114, 115, 116, 117, 118, 119, 67, -97,
+        82, 0, 0, 0, 81, 0, 137, 0, 101, 102,
+        0, 0, 0, 0, 0, 103, 104, 105, 106, 107,
+        108, 109, 110, 111, 112, 113, 114, 115, 116, 117,
+        118, 119, 103, 104, 105, 0, 0, 0, 0, 103,
+        104, 105, 113, 114, 115, 116, 117, 118, 119, 113,
+        114, 115, 116, 117, 118, 119, 0, 0, 0, 0,
+        179, 103, 104, 105, 0, 0, 0, 190, 103, 104,
+        105, 113, 114, 115, 116, 117, 118, 119, 113, 114,
+        115, 116, 117, 118, 119, 0, 137, 103, 104, 105,
+        0, 0, 0, 182, 103, 104, 105, 113, 114, 115,
+        116, 117, 118, 119, 113, 114, 115, 116, 117, 118,
+        119, 0, 183, 103, 104, 105, 0, 0, 0, 184,
+        103, 104, 105, 113, 114, 115, 116, 117, 118, 119,
+        113, 114, 115, 116, 117, 118, 119, 0, 185, 103,
+        104, 105, 0, 0, 0, 186, 103, 104, 105, 113,
+        114, 115, 116, 117, 118, 119, 113, 114, 115, 116,
+        117, 118, 119, 166, 187, 0, 0, 0, 0, 0,
+        0, 224, 0, 0, 103, 104, 105, 167, 168, 169,
+        170, 171, 172, 173, 113, 114, 115, 116, 117, 118,
+        119};
 
 static const yytype_int16 yycheck[] =
-{
-      38,    30,     9,    68,    63,    10,     0,     1,    13,     3,
-       4,     5,    14,    15,    22,    15,    42,    43,     9,    27,
-      57,    28,    66,    42,    43,     9,    68,    69,    66,    71,
-      67,    68,    97,    56,    57,    58,    59,    60,    40,    41,
-      64,    78,    71,    80,    81,    39,    72,    84,    85,    86,
-      87,    88,    89,    72,    18,    19,    20,    21,     9,    96,
-      98,    99,     3,     4,     5,   102,   103,   104,   105,   106,
-     107,   108,   109,   110,   111,   112,   113,   114,   115,   116,
-     117,   118,   119,    58,    59,    60,   123,     6,     9,    10,
-      11,    12,    66,    14,    15,     7,    17,    15,    16,    42,
-      43,     9,    23,    24,    25,    26,    72,    73,    29,    66,
-      31,    32,    33,    34,    35,    36,    42,    43,   183,    40,
-      41,    67,     9,     8,    11,    12,    10,    14,    15,    66,
-      17,    65,    72,    73,    72,    73,    23,    24,    25,    26,
-      61,    62,    67,    71,    31,    32,    33,    34,    35,    36,
-      71,    71,    69,    28,    17,    71,   193,   194,    54,    55,
-      56,    57,    58,    59,    60,    71,   204,    71,    71,    71,
-       9,   208,    72,    17,   212,    62,    27,     9,    43,    11,
-      12,    71,    14,    15,    71,    17,    66,    68,    66,    71,
-       3,    23,    24,    28,    71,    36,   101,    28,   121,    31,
-      32,    33,    34,    35,    36,   186,    37,    38,    57,   199,
-      -1,    -1,    -1,    44,    45,    46,    47,    48,    49,    50,
-      51,    52,    53,    54,    55,    56,    57,    58,    59,    60,
-      62,   128,    -1,    28,    -1,    -1,    -1,    -1,    -1,    71,
-      -1,    72,    37,    38,    -1,    -1,    -1,    -1,    -1,    44,
-      45,    46,    47,    48,    49,    50,    51,    52,    53,    54,
-      55,    56,    57,    58,    59,    60,    44,    45,    46,    -1,
-      -1,    -1,    -1,    44,    45,    46,    54,    55,    56,    57,
-      58,    59,    60,    54,    55,    56,    57,    58,    59,    60,
-      -1,    -1,    -1,    -1,    72,    44,    45,    46,    -1,    -1,
-      -1,    72,    44,    45,    46,    54,    55,    56,    57,    58,
-      59,    60,    54,    55,    56,    57,    58,    59,    60,    -1,
-      -1,    -1,    -1,    72,    44,    45,    46,    -1,    -1,    -1,
-      72,    44,    45,    46,    54,    55,    56,    57,    58,    59,
-      60,    54,    55,    56,    57,    58,    59,    60,    -1,    -1,
-      -1,    -1,    72,    44,    45,    46,    -1,    -1,    -1,    72,
-      44,    45,    46,    54,    55,    56,    57,    58,    59,    60,
-      54,    55,    56,    57,    58,    59,    60,    -1,    -1,    -1,
-      -1,    72,    44,    45,    46,    -1,    -1,    -1,    72,    44,
-      45,    46,    54,    55,    56,    57,    58,    59,    60,    54,
-      55,    56,    57,    58,    59,    60,    -1,    -1,    70,    44,
-      45,    46,    -1,    -1,    -1,    70,    44,    45,    46,    54,
-      55,    56,    57,    58,    59,    60,    54,    55,    56,    57,
-      58,    59,    60,    68
-};
+    {
+        38, 33, 68, 45, 46, 0, 1, 60, 3, 4,
+        5, 14, 15, 9, 15, 45, 46, 72, 25, 72,
+        72, 76, 57, 30, 76, 15, 16, 72, 66, 95,
+        72, 76, 67, 68, 71, 31, 73, 74, 66, 71,
+        43, 44, 72, 78, 9, 80, 81, 42, 69, 84,
+        85, 86, 87, 88, 89, 59, 60, 61, 62, 63,
+        98, 99, 97, 10, 45, 46, 13, 102, 103, 104,
+        105, 106, 107, 108, 109, 110, 111, 112, 113, 114,
+        115, 116, 117, 118, 119, 9, 10, 11, 12, 124,
+        14, 15, 9, 17, 57, 58, 59, 60, 61, 62,
+        63, 67, 26, 27, 28, 29, 45, 46, 32, 9,
+        34, 35, 36, 37, 38, 39, 3, 4, 5, 43,
+        44, 6, 8, 189, 69, 9, 7, 11, 12, 9,
+        14, 15, 69, 17, 61, 62, 63, 70, 10, 69,
+        64, 65, 26, 27, 28, 29, 68, 71, 74, 70,
+        34, 35, 36, 37, 38, 39, 71, 71, 71, 71,
+        71, 71, 31, 17, 47, 48, 49, 71, 9, 72,
+        17, 206, 207, 4, 57, 58, 59, 60, 61, 62,
+        63, 65, 30, 221, 46, 14, 14, 71, 15, 71,
+        73, 226, 9, 231, 11, 12, 71, 14, 15, 73,
+        17, 71, 69, 15, 72, 71, 69, 72, 72, 26,
+        27, 71, 71, 3, 28, 31, 36, 34, 35, 36,
+        37, 38, 39, 122, 40, 41, 196, 129, 101, 212,
+        -1, 47, 48, 49, 50, 51, 52, 53, 54, 55,
+        56, 57, 58, 59, 60, 61, 62, 63, 65, 31,
+        57, -1, -1, -1, 71, -1, 72, -1, 40, 41,
+        -1, -1, -1, -1, -1, 47, 48, 49, 50, 51,
+        52, 53, 54, 55, 56, 57, 58, 59, 60, 61,
+        62, 63, 47, 48, 49, -1, -1, -1, -1, 47,
+        48, 49, 57, 58, 59, 60, 61, 62, 63, 57,
+        58, 59, 60, 61, 62, 63, -1, -1, -1, -1,
+        75, 47, 48, 49, -1, -1, -1, 75, 47, 48,
+        49, 57, 58, 59, 60, 61, 62, 63, 57, 58,
+        59, 60, 61, 62, 63, -1, 72, 47, 48, 49,
+        -1, -1, -1, 72, 47, 48, 49, 57, 58, 59,
+        60, 61, 62, 63, 57, 58, 59, 60, 61, 62,
+        63, -1, 72, 47, 48, 49, -1, -1, -1, 72,
+        47, 48, 49, 57, 58, 59, 60, 61, 62, 63,
+        57, 58, 59, 60, 61, 62, 63, -1, 72, 47,
+        48, 49, -1, -1, -1, 72, 47, 48, 49, 57,
+        58, 59, 60, 61, 62, 63, 57, 58, 59, 60,
+        61, 62, 63, 4, 72, -1, -1, -1, -1, -1,
+        -1, 72, -1, -1, 47, 48, 49, 18, 19, 20,
+        21, 22, 23, 24, 57, 58, 59, 60, 61, 62,
+        63};
 
-  /* YYSTOS[STATE-NUM] -- The (internal number of the) accessing
-     symbol of state STATE-NUM.  */
+/* YYSTOS[STATE-NUM] -- The symbol kind of the accessing symbol of
+   state STATE-NUM.  */
 static const yytype_int8 yystos[] =
-{
-       0,    75,     0,     1,    39,    76,    77,    81,    63,    77,
-      15,     3,     4,     5,    82,     9,    66,    83,     9,    84,
-      64,     9,     6,    78,    66,     7,    79,     9,    85,    86,
-      66,     8,    80,    67,    86,    10,    87,    88,    66,    65,
-      14,    15,    40,    41,    67,    88,     9,    10,    11,    12,
-      14,    15,    17,    23,    24,    25,    26,    29,    31,    32,
-      33,    34,    35,    36,    40,    41,    61,    62,    71,    92,
-      94,    95,    96,   107,   108,    15,    16,    89,    22,    27,
-      69,    71,   107,   108,    71,    71,    71,    71,    71,    71,
-      95,   108,    95,    96,   108,    68,    69,    71,    42,    43,
-      28,    37,    38,    44,    45,    46,    47,    48,    49,    50,
-      51,    52,    53,    54,    55,    56,    57,    58,    59,    60,
-      90,    17,   108,    71,   101,   108,   108,     9,    28,   108,
-     108,   108,   108,   108,   108,    72,    72,     9,   108,    93,
-      96,    95,    95,    30,    71,   103,    94,   108,   108,   108,
-     108,   108,   108,   108,   108,   108,   108,   108,   108,   108,
-     108,   108,   108,   108,   108,    18,    19,    20,    21,    91,
-      90,   108,    70,    27,   103,    72,    72,    72,    72,    72,
-      72,    70,    72,    73,   104,    68,    97,    66,    96,    10,
-      13,   105,   106,    68,    71,   100,   101,    99,    72,    73,
-     108,   102,   108,    66,    71,   106,    72,    72,    73,    98,
-      95,   108,    71,    72,    95,    72
-};
+    {
+        0, 78, 0, 1, 42, 79, 80, 84, 66, 80,
+        15, 3, 4, 5, 85, 9, 69, 86, 9, 87,
+        67, 9, 6, 81, 69, 7, 82, 9, 88, 89,
+        69, 8, 83, 70, 89, 10, 90, 91, 69, 68,
+        14, 15, 43, 44, 70, 91, 9, 10, 11, 12,
+        14, 15, 17, 26, 27, 28, 29, 32, 34, 35,
+        36, 37, 38, 39, 43, 44, 64, 65, 71, 97,
+        99, 100, 101, 112, 113, 15, 16, 92, 25, 30,
+        74, 71, 112, 113, 71, 71, 71, 71, 71, 71,
+        100, 113, 100, 101, 113, 71, 73, 74, 45, 46,
+        31, 40, 41, 47, 48, 49, 50, 51, 52, 53,
+        54, 55, 56, 57, 58, 59, 60, 61, 62, 63,
+        93, 95, 17, 113, 71, 106, 113, 113, 9, 31,
+        113, 113, 113, 113, 113, 113, 72, 72, 98, 101,
+        9, 113, 100, 100, 33, 71, 108, 99, 113, 113,
+        113, 113, 113, 113, 113, 113, 113, 113, 113, 113,
+        113, 113, 113, 113, 113, 113, 4, 18, 19, 20,
+        21, 22, 23, 24, 94, 4, 96, 93, 113, 75,
+        30, 108, 72, 72, 72, 72, 72, 72, 72, 76,
+        75, 109, 71, 71, 71, 73, 102, 69, 101, 10,
+        13, 110, 111, 14, 15, 15, 73, 71, 105, 106,
+        104, 72, 76, 60, 72, 72, 72, 113, 107, 113,
+        69, 71, 111, 14, 72, 72, 76, 103, 100, 72,
+        113, 71, 72, 100, 72};
 
-  /* YYR1[YYN] -- Symbol number of symbol that rule YYN derives.  */
+/* YYR1[RULE-NUM] -- Symbol kind of the left-hand side of rule RULE-NUM.  */
 static const yytype_int8 yyr1[] =
-{
-       0,    74,    75,    75,    75,    75,    75,    76,    77,    78,
-      78,    79,    79,    80,    81,    81,    82,    82,    83,    83,
-      84,    84,    85,    85,    86,    86,    86,    86,    87,    87,
-      88,    89,    88,    88,    90,    90,    91,    91,    91,    91,
-      92,    92,    92,    92,    93,    93,    93,    94,    95,    96,
-      96,    96,    96,    96,    96,    96,    97,    98,    96,    99,
-      96,    96,    96,    96,    96,    96,    96,    96,    96,    96,
-      96,    96,    96,    96,   100,   100,   101,   102,   102,   104,
-     103,   103,   105,   105,   106,   106,   107,   107,   107,   108,
-     108,   108,   108,   108,   108,   108,   108,   108,   108,   108,
-     108,   108,   108,   108,   108,   108,   108,   108,   108,   108,
-     108,   108,   108,   108,   108,   108
-};
+    {
+        0, 77, 78, 78, 78, 78, 78, 79, 80, 81,
+        81, 82, 82, 83, 84, 84, 85, 85, 86, 86,
+        87, 87, 88, 88, 89, 89, 89, 89, 90, 90,
+        91, 92, 91, 91, 93, 93, 94, 94, 94, 94,
+        94, 94, 94, 94, 94, 94, 94, 94, 95, 95,
+        96, 97, 97, 97, 97, 98, 98, 98, 99, 100,
+        101, 101, 101, 101, 101, 101, 101, 102, 103, 101,
+        104, 101, 101, 101, 101, 101, 101, 101, 101, 101,
+        101, 101, 101, 101, 101, 105, 105, 106, 107, 107,
+        109, 108, 108, 110, 110, 111, 111, 112, 112, 112,
+        113, 113, 113, 113, 113, 113, 113, 113, 113, 113,
+        113, 113, 113, 113, 113, 113, 113, 113, 113, 113,
+        113, 113, 113, 113, 113, 113, 113};
 
-  /* YYR2[YYN] -- Number of symbols on the right hand side of rule YYN.  */
+/* YYR2[RULE-NUM] -- Number of symbols on the right-hand side of rule RULE-NUM.  */
 static const yytype_int8 yyr2[] =
-{
-       0,     2,     0,     2,     2,     3,     3,     2,     9,     0,
-       3,     0,     3,     3,     0,     2,     1,     1,     0,     2,
-       1,     2,     1,     2,     3,     3,     3,     3,     1,     2,
-       4,     0,     5,     3,     0,     2,     1,     1,     1,     1,
-       1,     3,     4,     4,     0,     1,     3,     1,     1,     1,
-       1,     3,     3,     1,     3,     3,     0,     0,    11,     0,
-       9,     3,     2,     3,     3,     3,     3,     3,     3,     3,
-       3,     3,     1,     3,     3,     1,     6,     1,     3,     0,
-       4,     1,     1,     3,     1,     1,     1,     1,     1,     3,
-       1,     1,     4,     4,     4,     4,     4,     4,     1,     1,
-       1,     4,     1,     1,     3,     3,     3,     3,     3,     3,
-       3,     3,     2,     3,     3,     1
-};
+    {
+        0, 2, 0, 2, 2, 3, 3, 2, 9, 0,
+        3, 0, 3, 3, 0, 2, 1, 1, 0, 2,
+        1, 2, 1, 2, 3, 3, 3, 3, 1, 2,
+        4, 0, 5, 4, 0, 2, 1, 1, 1, 1,
+        1, 1, 4, 6, 1, 4, 1, 4, 0, 2,
+        1, 1, 3, 4, 4, 0, 1, 3, 1, 1,
+        1, 1, 3, 3, 1, 3, 3, 0, 0, 11,
+        0, 9, 3, 2, 3, 3, 3, 3, 3, 3,
+        3, 3, 3, 1, 3, 3, 1, 6, 1, 3,
+        0, 4, 1, 1, 3, 1, 1, 1, 1, 1,
+        3, 1, 1, 4, 4, 4, 4, 4, 4, 1,
+        1, 1, 4, 1, 1, 3, 3, 3, 3, 3,
+        3, 3, 3, 2, 3, 3, 1};
 
+enum { YYENOMEM = -2 };
 
-#define yyerrok         (yyerrstatus = 0)
-#define yyclearin       (yychar = YYEMPTY)
-#define YYEMPTY         (-2)
-#define YYEOF           0
+#define yyerrok (yyerrstatus = 0)
+#define yyclearin (yychar = YYEMPTY)
 
-#define YYACCEPT        goto yyacceptlab
-#define YYABORT         goto yyabortlab
-#define YYERROR         goto yyerrorlab
+#define YYACCEPT goto yyacceptlab
+#define YYABORT goto yyabortlab
+#define YYERROR goto yyerrorlab
+#define YYNOMEM goto yyexhaustedlab
 
+#define YYRECOVERING() (!!yyerrstatus)
 
-#define YYRECOVERING()  (!!yyerrstatus)
+#define YYBACKUP(Token, Value)                                                 \
+    do                                                                         \
+        if (yychar == YYEMPTY) {                                               \
+            yychar = (Token);                                                  \
+            yylval = (Value);                                                  \
+            YYPOPSTACK(yylen);                                                 \
+            yystate = *yyssp;                                                  \
+            goto yybackup;                                                     \
+        } else {                                                               \
+            yyerror(yyscanner, compiler, YY_("syntax error: cannot back up")); \
+            YYERROR;                                                           \
+        }                                                                      \
+    while (0)
 
-#define YYBACKUP(Token, Value)                                    \
-  do                                                              \
-    if (yychar == YYEMPTY)                                        \
-      {                                                           \
-        yychar = (Token);                                         \
-        yylval = (Value);                                         \
-        YYPOPSTACK (yylen);                                       \
-        yystate = *yyssp;                                         \
-        goto yybackup;                                            \
-      }                                                           \
-    else                                                          \
-      {                                                           \
-        yyerror (yyscanner, compiler, YY_("syntax error: cannot back up")); \
-        YYERROR;                                                  \
-      }                                                           \
-  while (0)
-
-/* Error token number */
-#define YYTERROR        1
-#define YYERRCODE       256
-
-
+/* Backward compatibility with an undocumented macro.
+   Use YYerror or YYUNDEF. */
+#define YYERRCODE YYUNDEF
 
 /* Enable debugging if requested.  */
 #if YYDEBUG
 
-# ifndef YYFPRINTF
-#  include <stdio.h> /* INFRINGES ON USER NAME SPACE */
-#  define YYFPRINTF fprintf
-# endif
-
-# define YYDPRINTF(Args)                        \
-do {                                            \
-  if (yydebug)                                  \
-    YYFPRINTF Args;                             \
-} while (0)
-
-/* This macro is provided for backward compatibility. */
-#ifndef YY_LOCATION_PRINT
-# define YY_LOCATION_PRINT(File, Loc) ((void) 0)
+#ifndef YYFPRINTF
+#include <stdio.h> /* INFRINGES ON USER NAME SPACE */
+#define YYFPRINTF fprintf
 #endif
 
+#define YYDPRINTF(Args)     \
+    do {                    \
+        if (yydebug)        \
+            YYFPRINTF Args; \
+    } while (0)
 
-# define YY_SYMBOL_PRINT(Title, Type, Value, Location)                    \
-do {                                                                      \
-  if (yydebug)                                                            \
-    {                                                                     \
-      YYFPRINTF (stderr, "%s ", Title);                                   \
-      yy_symbol_print (stderr,                                            \
-                  Type, Value, yyscanner, compiler); \
-      YYFPRINTF (stderr, "\n");                                           \
-    }                                                                     \
-} while (0)
-
+#define YY_SYMBOL_PRINT(Title, Kind, Value, Location)          \
+    do {                                                       \
+        if (yydebug) {                                         \
+            YYFPRINTF(stderr, "%s ", Title);                   \
+            yy_symbol_print(stderr,                            \
+                            Kind, Value, yyscanner, compiler); \
+            YYFPRINTF(stderr, "\n");                           \
+        }                                                      \
+    } while (0)
 
 /*-----------------------------------.
 | Print this symbol's value on YYO.  |
 `-----------------------------------*/
 
 static void
-yy_symbol_value_print (FILE *yyo, int yytype, YYSTYPE const * const yyvaluep, void *yyscanner, YR_COMPILER* compiler)
+yy_symbol_value_print(FILE* yyo,
+                      yysymbol_kind_t yykind, YYSTYPE const* const yyvaluep, void* yyscanner, YR_COMPILER* compiler)
 {
-  FILE *yyoutput = yyo;
-  YYUSE (yyoutput);
-  YYUSE (yyscanner);
-  YYUSE (compiler);
-  if (!yyvaluep)
-    return;
-# ifdef YYPRINT
-  if (yytype < YYNTOKENS)
-    YYPRINT (yyo, yytoknum[yytype], *yyvaluep);
-# endif
-  YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
-  YYUSE (yytype);
-  YY_IGNORE_MAYBE_UNINITIALIZED_END
+    FILE* yyoutput = yyo;
+    YY_USE(yyoutput);
+    YY_USE(yyscanner);
+    YY_USE(compiler);
+    if (!yyvaluep)
+        return;
+    YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
+    YY_USE(yykind);
+    YY_IGNORE_MAYBE_UNINITIALIZED_END
 }
-
 
 /*---------------------------.
 | Print this symbol on YYO.  |
 `---------------------------*/
 
 static void
-yy_symbol_print (FILE *yyo, int yytype, YYSTYPE const * const yyvaluep, void *yyscanner, YR_COMPILER* compiler)
+yy_symbol_print(FILE* yyo,
+                yysymbol_kind_t yykind, YYSTYPE const* const yyvaluep, void* yyscanner, YR_COMPILER* compiler)
 {
-  YYFPRINTF (yyo, "%s %s (",
-             yytype < YYNTOKENS ? "token" : "nterm", yytname[yytype]);
+    YYFPRINTF(yyo, "%s %s (",
+              yykind < YYNTOKENS ? "token" : "nterm", yysymbol_name(yykind));
 
-  yy_symbol_value_print (yyo, yytype, yyvaluep, yyscanner, compiler);
-  YYFPRINTF (yyo, ")");
+    yy_symbol_value_print(yyo, yykind, yyvaluep, yyscanner, compiler);
+    YYFPRINTF(yyo, ")");
 }
 
 /*------------------------------------------------------------------.
@@ -1063,68 +1058,64 @@ yy_symbol_print (FILE *yyo, int yytype, YYSTYPE const * const yyvaluep, void *yy
 `------------------------------------------------------------------*/
 
 static void
-yy_stack_print (yy_state_t *yybottom, yy_state_t *yytop)
+yy_stack_print(yy_state_t* yybottom, yy_state_t* yytop)
 {
-  YYFPRINTF (stderr, "Stack now");
-  for (; yybottom <= yytop; yybottom++)
-    {
-      int yybot = *yybottom;
-      YYFPRINTF (stderr, " %d", yybot);
+    YYFPRINTF(stderr, "Stack now");
+    for (; yybottom <= yytop; yybottom++) {
+        int yybot = *yybottom;
+        YYFPRINTF(stderr, " %d", yybot);
     }
-  YYFPRINTF (stderr, "\n");
+    YYFPRINTF(stderr, "\n");
 }
 
-# define YY_STACK_PRINT(Bottom, Top)                            \
-do {                                                            \
-  if (yydebug)                                                  \
-    yy_stack_print ((Bottom), (Top));                           \
-} while (0)
-
+#define YY_STACK_PRINT(Bottom, Top)          \
+    do {                                     \
+        if (yydebug)                         \
+            yy_stack_print((Bottom), (Top)); \
+    } while (0)
 
 /*------------------------------------------------.
 | Report that the YYRULE is going to be reduced.  |
 `------------------------------------------------*/
 
 static void
-yy_reduce_print (yy_state_t *yyssp, YYSTYPE *yyvsp, int yyrule, void *yyscanner, YR_COMPILER* compiler)
+yy_reduce_print(yy_state_t* yyssp, YYSTYPE* yyvsp,
+                int yyrule, void* yyscanner, YR_COMPILER* compiler)
 {
-  int yylno = yyrline[yyrule];
-  int yynrhs = yyr2[yyrule];
-  int yyi;
-  YYFPRINTF (stderr, "Reducing stack by rule %d (line %d):\n",
-             yyrule - 1, yylno);
-  /* The symbols being reduced.  */
-  for (yyi = 0; yyi < yynrhs; yyi++)
-    {
-      YYFPRINTF (stderr, "   $%d = ", yyi + 1);
-      yy_symbol_print (stderr,
-                       yystos[+yyssp[yyi + 1 - yynrhs]],
-                       &yyvsp[(yyi + 1) - (yynrhs)]
-                                              , yyscanner, compiler);
-      YYFPRINTF (stderr, "\n");
+    int yylno  = yyrline[yyrule];
+    int yynrhs = yyr2[yyrule];
+    int yyi;
+    YYFPRINTF(stderr, "Reducing stack by rule %d (line %d):\n",
+              yyrule - 1, yylno);
+    /* The symbols being reduced.  */
+    for (yyi = 0; yyi < yynrhs; yyi++) {
+        YYFPRINTF(stderr, "   $%d = ", yyi + 1);
+        yy_symbol_print(stderr,
+                        YY_ACCESSING_SYMBOL(+yyssp[yyi + 1 - yynrhs]),
+                        &yyvsp[(yyi + 1) - (yynrhs)], yyscanner, compiler);
+        YYFPRINTF(stderr, "\n");
     }
 }
 
-# define YY_REDUCE_PRINT(Rule)          \
-do {                                    \
-  if (yydebug)                          \
-    yy_reduce_print (yyssp, yyvsp, Rule, yyscanner, compiler); \
-} while (0)
+#define YY_REDUCE_PRINT(Rule)                                         \
+    do {                                                              \
+        if (yydebug)                                                  \
+            yy_reduce_print(yyssp, yyvsp, Rule, yyscanner, compiler); \
+    } while (0)
 
 /* Nonzero means print parse trace.  It is left uninitialized so that
    multiple parsers can coexist.  */
 int yydebug;
 #else /* !YYDEBUG */
-# define YYDPRINTF(Args)
-# define YY_SYMBOL_PRINT(Title, Type, Value, Location)
-# define YY_STACK_PRINT(Bottom, Top)
-# define YY_REDUCE_PRINT(Rule)
+#define YYDPRINTF(Args) ((void)0)
+#define YY_SYMBOL_PRINT(Title, Kind, Value, Location)
+#define YY_STACK_PRINT(Bottom, Top)
+#define YY_REDUCE_PRINT(Rule)
 #endif /* !YYDEBUG */
-
 
 /* YYINITDEPTH -- initial size of the parser's stacks.  */
 #ifndef YYINITDEPTH
-# define YYINITDEPTH 200
+#define YYINITDEPTH 200
 #endif
 
 /* YYMAXDEPTH -- maximum size the stacks can grow to (effective only
@@ -1135,2668 +1126,2447 @@ int yydebug;
    evaluated with infinite-precision integer arithmetic.  */
 
 #ifndef YYMAXDEPTH
-# define YYMAXDEPTH 10000
+#define YYMAXDEPTH 10000
 #endif
-
-
-#if YYERROR_VERBOSE
-
-# ifndef yystrlen
-#  if defined __GLIBC__ && defined _STRING_H
-#   define yystrlen(S) (YY_CAST (YYPTRDIFF_T, strlen (S)))
-#  else
-/* Return the length of YYSTR.  */
-static YYPTRDIFF_T
-yystrlen (const char *yystr)
-{
-  YYPTRDIFF_T yylen;
-  for (yylen = 0; yystr[yylen]; yylen++)
-    continue;
-  return yylen;
-}
-#  endif
-# endif
-
-# ifndef yystpcpy
-#  if defined __GLIBC__ && defined _STRING_H && defined _GNU_SOURCE
-#   define yystpcpy stpcpy
-#  else
-/* Copy YYSRC to YYDEST, returning the address of the terminating '\0' in
-   YYDEST.  */
-static char *
-yystpcpy (char *yydest, const char *yysrc)
-{
-  char *yyd = yydest;
-  const char *yys = yysrc;
-
-  while ((*yyd++ = *yys++) != '\0')
-    continue;
-
-  return yyd - 1;
-}
-#  endif
-# endif
-
-# ifndef yytnamerr
-/* Copy to YYRES the contents of YYSTR after stripping away unnecessary
-   quotes and backslashes, so that it's suitable for yyerror.  The
-   heuristic is that double-quoting is unnecessary unless the string
-   contains an apostrophe, a comma, or backslash (other than
-   backslash-backslash).  YYSTR is taken from yytname.  If YYRES is
-   null, do not copy; instead, return the length of what the result
-   would have been.  */
-static YYPTRDIFF_T
-yytnamerr (char *yyres, const char *yystr)
-{
-  if (*yystr == '"')
-    {
-      YYPTRDIFF_T yyn = 0;
-      char const *yyp = yystr;
-
-      for (;;)
-        switch (*++yyp)
-          {
-          case '\'':
-          case ',':
-            goto do_not_strip_quotes;
-
-          case '\\':
-            if (*++yyp != '\\')
-              goto do_not_strip_quotes;
-            else
-              goto append;
-
-          append:
-          default:
-            if (yyres)
-              yyres[yyn] = *yyp;
-            yyn++;
-            break;
-
-          case '"':
-            if (yyres)
-              yyres[yyn] = '\0';
-            return yyn;
-          }
-    do_not_strip_quotes: ;
-    }
-
-  if (yyres)
-    return yystpcpy (yyres, yystr) - yyres;
-  else
-    return yystrlen (yystr);
-}
-# endif
-
-/* Copy into *YYMSG, which is of size *YYMSG_ALLOC, an error message
-   about the unexpected token YYTOKEN for the state stack whose top is
-   YYSSP.
-
-   Return 0 if *YYMSG was successfully written.  Return 1 if *YYMSG is
-   not large enough to hold the message.  In that case, also set
-   *YYMSG_ALLOC to the required number of bytes.  Return 2 if the
-   required number of bytes is too large to store.  */
-static int
-yysyntax_error (YYPTRDIFF_T *yymsg_alloc, char **yymsg,
-                yy_state_t *yyssp, int yytoken)
-{
-  enum { YYERROR_VERBOSE_ARGS_MAXIMUM = 5 };
-  /* Internationalized format string. */
-  const char *yyformat = YY_NULLPTR;
-  /* Arguments of yyformat: reported tokens (one for the "unexpected",
-     one per "expected"). */
-  char const *yyarg[YYERROR_VERBOSE_ARGS_MAXIMUM];
-  /* Actual size of YYARG. */
-  int yycount = 0;
-  /* Cumulated lengths of YYARG.  */
-  YYPTRDIFF_T yysize = 0;
-
-  /* There are many possibilities here to consider:
-     - If this state is a consistent state with a default action, then
-       the only way this function was invoked is if the default action
-       is an error action.  In that case, don't check for expected
-       tokens because there are none.
-     - The only way there can be no lookahead present (in yychar) is if
-       this state is a consistent state with a default action.  Thus,
-       detecting the absence of a lookahead is sufficient to determine
-       that there is no unexpected or expected token to report.  In that
-       case, just report a simple "syntax error".
-     - Don't assume there isn't a lookahead just because this state is a
-       consistent state with a default action.  There might have been a
-       previous inconsistent state, consistent state with a non-default
-       action, or user semantic action that manipulated yychar.
-     - Of course, the expected token list depends on states to have
-       correct lookahead information, and it depends on the parser not
-       to perform extra reductions after fetching a lookahead from the
-       scanner and before detecting a syntax error.  Thus, state merging
-       (from LALR or IELR) and default reductions corrupt the expected
-       token list.  However, the list is correct for canonical LR with
-       one exception: it will still contain any token that will not be
-       accepted due to an error action in a later state.
-  */
-  if (yytoken != YYEMPTY)
-    {
-      int yyn = yypact[+*yyssp];
-      YYPTRDIFF_T yysize0 = yytnamerr (YY_NULLPTR, yytname[yytoken]);
-      yysize = yysize0;
-      yyarg[yycount++] = yytname[yytoken];
-      if (!yypact_value_is_default (yyn))
-        {
-          /* Start YYX at -YYN if negative to avoid negative indexes in
-             YYCHECK.  In other words, skip the first -YYN actions for
-             this state because they are default actions.  */
-          int yyxbegin = yyn < 0 ? -yyn : 0;
-          /* Stay within bounds of both yycheck and yytname.  */
-          int yychecklim = YYLAST - yyn + 1;
-          int yyxend = yychecklim < YYNTOKENS ? yychecklim : YYNTOKENS;
-          int yyx;
-
-          for (yyx = yyxbegin; yyx < yyxend; ++yyx)
-            if (yycheck[yyx + yyn] == yyx && yyx != YYTERROR
-                && !yytable_value_is_error (yytable[yyx + yyn]))
-              {
-                if (yycount == YYERROR_VERBOSE_ARGS_MAXIMUM)
-                  {
-                    yycount = 1;
-                    yysize = yysize0;
-                    break;
-                  }
-                yyarg[yycount++] = yytname[yyx];
-                {
-                  YYPTRDIFF_T yysize1
-                    = yysize + yytnamerr (YY_NULLPTR, yytname[yyx]);
-                  if (yysize <= yysize1 && yysize1 <= YYSTACK_ALLOC_MAXIMUM)
-                    yysize = yysize1;
-                  else
-                    return 2;
-                }
-              }
-        }
-    }
-
-  switch (yycount)
-    {
-# define YYCASE_(N, S)                      \
-      case N:                               \
-        yyformat = S;                       \
-      break
-    default: /* Avoid compiler warnings. */
-      YYCASE_(0, YY_("syntax error"));
-      YYCASE_(1, YY_("syntax error, unexpected %s"));
-      YYCASE_(2, YY_("syntax error, unexpected %s, expecting %s"));
-      YYCASE_(3, YY_("syntax error, unexpected %s, expecting %s or %s"));
-      YYCASE_(4, YY_("syntax error, unexpected %s, expecting %s or %s or %s"));
-      YYCASE_(5, YY_("syntax error, unexpected %s, expecting %s or %s or %s or %s"));
-# undef YYCASE_
-    }
-
-  {
-    /* Don't count the "%s"s in the final size, but reserve room for
-       the terminator.  */
-    YYPTRDIFF_T yysize1 = yysize + (yystrlen (yyformat) - 2 * yycount) + 1;
-    if (yysize <= yysize1 && yysize1 <= YYSTACK_ALLOC_MAXIMUM)
-      yysize = yysize1;
-    else
-      return 2;
-  }
-
-  if (*yymsg_alloc < yysize)
-    {
-      *yymsg_alloc = 2 * yysize;
-      if (! (yysize <= *yymsg_alloc
-             && *yymsg_alloc <= YYSTACK_ALLOC_MAXIMUM))
-        *yymsg_alloc = YYSTACK_ALLOC_MAXIMUM;
-      return 1;
-    }
-
-  /* Avoid sprintf, as that infringes on the user's name space.
-     Don't have undefined behavior even if the translation
-     produced a string with the wrong number of "%s"s.  */
-  {
-    char *yyp = *yymsg;
-    int yyi = 0;
-    while ((*yyp = *yyformat) != '\0')
-      if (*yyp == '%' && yyformat[1] == 's' && yyi < yycount)
-        {
-          yyp += yytnamerr (yyp, yyarg[yyi++]);
-          yyformat += 2;
-        }
-      else
-        {
-          ++yyp;
-          ++yyformat;
-        }
-  }
-  return 0;
-}
-#endif /* YYERROR_VERBOSE */
 
 /*-----------------------------------------------.
 | Release the memory associated to this symbol.  |
 `-----------------------------------------------*/
 
 static void
-yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, void *yyscanner, YR_COMPILER* compiler)
+yydestruct(const char* yymsg,
+           yysymbol_kind_t yykind, YYSTYPE* yyvaluep, void* yyscanner, YR_COMPILER* compiler)
 {
-  YYUSE (yyvaluep);
-  YYUSE (yyscanner);
-  YYUSE (compiler);
-  if (!yymsg)
-    yymsg = "Deleting";
-  YY_SYMBOL_PRINT (yymsg, yytype, yyvaluep, yylocationp);
+    YY_USE(yyvaluep);
+    YY_USE(yyscanner);
+    YY_USE(compiler);
+    if (!yymsg)
+        yymsg = "Deleting";
+    YY_SYMBOL_PRINT(yymsg, yykind, yyvaluep, yylocationp);
 
-  YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
-  switch (yytype)
-    {
-    case 9: /* _IDENTIFIER_  */
-#line 210 "yara_grammar.y"
-            { yr_free(((*yyvaluep).c_string)); }
-#line 1395 "yara_grammar.c"
+    YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
+    switch (yykind) {
+        case YYSYMBOL__IDENTIFIER_: /* _IDENTIFIER_  */
+#line 224 "yara_grammar.y"
+        {
+            yr_free(((*yyvaluep).c_string));
+        }
+#line 1214 "yara_grammar.c"
         break;
 
-    case 10: /* _STRING_IDENTIFIER_  */
-#line 211 "yara_grammar.y"
-            { yr_free(((*yyvaluep).c_string)); }
-#line 1401 "yara_grammar.c"
+        case YYSYMBOL__STRING_IDENTIFIER_: /* _STRING_IDENTIFIER_  */
+#line 225 "yara_grammar.y"
+        {
+            yr_free(((*yyvaluep).c_string));
+        }
+#line 1220 "yara_grammar.c"
         break;
 
-    case 11: /* _STRING_COUNT_  */
-#line 212 "yara_grammar.y"
-            { yr_free(((*yyvaluep).c_string)); }
-#line 1407 "yara_grammar.c"
+        case YYSYMBOL__STRING_COUNT_: /* _STRING_COUNT_  */
+#line 226 "yara_grammar.y"
+        {
+            yr_free(((*yyvaluep).c_string));
+        }
+#line 1226 "yara_grammar.c"
         break;
 
-    case 12: /* _STRING_OFFSET_  */
-#line 213 "yara_grammar.y"
-            { yr_free(((*yyvaluep).c_string)); }
-#line 1413 "yara_grammar.c"
+        case YYSYMBOL__STRING_OFFSET_: /* _STRING_OFFSET_  */
+#line 227 "yara_grammar.y"
+        {
+            yr_free(((*yyvaluep).c_string));
+        }
+#line 1232 "yara_grammar.c"
         break;
 
-    case 13: /* _STRING_IDENTIFIER_WITH_WILDCARD_  */
-#line 214 "yara_grammar.y"
-            { yr_free(((*yyvaluep).c_string)); }
-#line 1419 "yara_grammar.c"
+        case YYSYMBOL__STRING_IDENTIFIER_WITH_WILDCARD_: /* _STRING_IDENTIFIER_WITH_WILDCARD_  */
+#line 228 "yara_grammar.y"
+        {
+            yr_free(((*yyvaluep).c_string));
+        }
+#line 1238 "yara_grammar.c"
         break;
 
-    case 15: /* _TEXT_STRING_  */
-#line 215 "yara_grammar.y"
-            { yr_free(((*yyvaluep).sized_string)); }
-#line 1425 "yara_grammar.c"
+        case YYSYMBOL__TEXT_STRING_: /* _TEXT_STRING_  */
+#line 229 "yara_grammar.y"
+        {
+            yr_free(((*yyvaluep).sized_string));
+        }
+#line 1244 "yara_grammar.c"
         break;
 
-    case 16: /* _HEX_STRING_  */
-#line 216 "yara_grammar.y"
-            { yr_free(((*yyvaluep).sized_string)); }
-#line 1431 "yara_grammar.c"
+        case YYSYMBOL__HEX_STRING_: /* _HEX_STRING_  */
+#line 230 "yara_grammar.y"
+        {
+            yr_free(((*yyvaluep).sized_string));
+        }
+#line 1250 "yara_grammar.c"
         break;
 
-    case 17: /* _REGEXP_  */
-#line 217 "yara_grammar.y"
-            { yr_free(((*yyvaluep).sized_string)); }
-#line 1437 "yara_grammar.c"
+        case YYSYMBOL__REGEXP_: /* _REGEXP_  */
+#line 231 "yara_grammar.y"
+        {
+            yr_free(((*yyvaluep).sized_string));
+        }
+#line 1256 "yara_grammar.c"
         break;
 
-      default:
-        break;
+        default:
+            break;
     }
-  YY_IGNORE_MAYBE_UNINITIALIZED_END
+    YY_IGNORE_MAYBE_UNINITIALIZED_END
 }
-
-
-
 
 /*----------.
 | yyparse.  |
 `----------*/
 
-int
-yyparse (void *yyscanner, YR_COMPILER* compiler)
+int yyparse(void* yyscanner, YR_COMPILER* compiler)
 {
-/* The lookahead symbol.  */
-int yychar;
+    /* Lookahead token kind.  */
+    int yychar;
 
-
-/* The semantic value of the lookahead symbol.  */
-/* Default value used for initialization, for pacifying older GCCs
-   or non-GCC compilers.  */
-YY_INITIAL_VALUE (static YYSTYPE yyval_default;)
-YYSTYPE yylval YY_INITIAL_VALUE (= yyval_default);
+    /* The semantic value of the lookahead symbol.  */
+    /* Default value used for initialization, for pacifying older GCCs
+       or non-GCC compilers.  */
+    YY_INITIAL_VALUE(static YYSTYPE yyval_default;)
+    YYSTYPE yylval YY_INITIAL_VALUE(= yyval_default);
 
     /* Number of syntax errors so far.  */
-    int yynerrs;
+    int yynerrs = 0;
 
-    yy_state_fast_t yystate;
+    yy_state_fast_t yystate = 0;
     /* Number of tokens to shift before error messages enabled.  */
-    int yyerrstatus;
+    int yyerrstatus = 0;
 
-    /* The stacks and their tools:
-       'yyss': related to states.
-       'yyvs': related to semantic values.
-
-       Refer to the stacks through separate pointers, to allow yyoverflow
+    /* Refer to the stacks through separate pointers, to allow yyoverflow
        to reallocate them elsewhere.  */
 
-    /* The state stack.  */
+    /* Their size.  */
+    YYPTRDIFF_T yystacksize = YYINITDEPTH;
+
+    /* The state stack: array, bottom, top.  */
     yy_state_t yyssa[YYINITDEPTH];
-    yy_state_t *yyss;
-    yy_state_t *yyssp;
+    yy_state_t* yyss  = yyssa;
+    yy_state_t* yyssp = yyss;
 
-    /* The semantic value stack.  */
+    /* The semantic value stack: array, bottom, top.  */
     YYSTYPE yyvsa[YYINITDEPTH];
-    YYSTYPE *yyvs;
-    YYSTYPE *yyvsp;
+    YYSTYPE* yyvs  = yyvsa;
+    YYSTYPE* yyvsp = yyvs;
 
-    YYPTRDIFF_T yystacksize;
+    int yyn;
+    /* The return value of yyparse.  */
+    int yyresult;
+    /* Lookahead symbol kind.  */
+    yysymbol_kind_t yytoken = YYSYMBOL_YYEMPTY;
+    /* The variables used to return semantic value and location from the
+       action routines.  */
+    YYSTYPE yyval;
 
-  int yyn;
-  int yyresult;
-  /* Lookahead token as an internal (translated) token number.  */
-  int yytoken = 0;
-  /* The variables used to return semantic value and location from the
-     action routines.  */
-  YYSTYPE yyval;
+#define YYPOPSTACK(N) (yyvsp -= (N), yyssp -= (N))
 
-#if YYERROR_VERBOSE
-  /* Buffer for error messages, and its allocated size.  */
-  char yymsgbuf[128];
-  char *yymsg = yymsgbuf;
-  YYPTRDIFF_T yymsg_alloc = sizeof yymsgbuf;
-#endif
+    /* The number of symbols on the RHS of the reduced rule.
+       Keep to zero when no symbol should be popped.  */
+    int yylen = 0;
 
-#define YYPOPSTACK(N)   (yyvsp -= (N), yyssp -= (N))
+    YYDPRINTF((stderr, "Starting parse\n"));
 
-  /* The number of symbols on the RHS of the reduced rule.
-     Keep to zero when no symbol should be popped.  */
-  int yylen = 0;
+    yychar = YYEMPTY; /* Cause a token to be read.  */
 
-  yyssp = yyss = yyssa;
-  yyvsp = yyvs = yyvsa;
-  yystacksize = YYINITDEPTH;
-
-  YYDPRINTF ((stderr, "Starting parse\n"));
-
-  yystate = 0;
-  yyerrstatus = 0;
-  yynerrs = 0;
-  yychar = YYEMPTY; /* Cause a token to be read.  */
-  goto yysetstate;
-
+    goto yysetstate;
 
 /*------------------------------------------------------------.
 | yynewstate -- push a new state, which is found in yystate.  |
 `------------------------------------------------------------*/
 yynewstate:
-  /* In all cases, when you get here, the value and location stacks
-     have just been pushed.  So pushing a state here evens the stacks.  */
-  yyssp++;
-
+    /* In all cases, when you get here, the value and location stacks
+       have just been pushed.  So pushing a state here evens the stacks.  */
+    yyssp++;
 
 /*--------------------------------------------------------------------.
 | yysetstate -- set current state (the top of the stack) to yystate.  |
 `--------------------------------------------------------------------*/
 yysetstate:
-  YYDPRINTF ((stderr, "Entering state %d\n", yystate));
-  YY_ASSERT (0 <= yystate && yystate < YYNSTATES);
-  YY_IGNORE_USELESS_CAST_BEGIN
-  *yyssp = YY_CAST (yy_state_t, yystate);
-  YY_IGNORE_USELESS_CAST_END
+    YYDPRINTF((stderr, "Entering state %d\n", yystate));
+    YY_ASSERT(0 <= yystate && yystate < YYNSTATES);
+    YY_IGNORE_USELESS_CAST_BEGIN
+    *yyssp = YY_CAST(yy_state_t, yystate);
+    YY_IGNORE_USELESS_CAST_END
+    YY_STACK_PRINT(yyss, yyssp);
 
-  if (yyss + yystacksize - 1 <= yyssp)
+    if (yyss + yystacksize - 1 <= yyssp)
 #if !defined yyoverflow && !defined YYSTACK_RELOCATE
-    goto yyexhaustedlab;
+        YYNOMEM;
 #else
     {
-      /* Get the current used size of the three stacks, in elements.  */
-      YYPTRDIFF_T yysize = yyssp - yyss + 1;
+        /* Get the current used size of the three stacks, in elements.  */
+        YYPTRDIFF_T yysize = yyssp - yyss + 1;
 
-# if defined yyoverflow
-      {
-        /* Give user a chance to reallocate the stack.  Use copies of
-           these so that the &'s don't force the real ones into
-           memory.  */
-        yy_state_t *yyss1 = yyss;
-        YYSTYPE *yyvs1 = yyvs;
+#if defined yyoverflow
+        {
+            /* Give user a chance to reallocate the stack.  Use copies of
+               these so that the &'s don't force the real ones into
+               memory.  */
+            yy_state_t* yyss1 = yyss;
+            YYSTYPE* yyvs1    = yyvs;
 
-        /* Each stack pointer address is followed by the size of the
-           data in use in that stack, in bytes.  This used to be a
-           conditional around just the two extra args, but that might
-           be undefined if yyoverflow is a macro.  */
-        yyoverflow (YY_("memory exhausted"),
-                    &yyss1, yysize * YYSIZEOF (*yyssp),
-                    &yyvs1, yysize * YYSIZEOF (*yyvsp),
-                    &yystacksize);
-        yyss = yyss1;
-        yyvs = yyvs1;
-      }
-# else /* defined YYSTACK_RELOCATE */
-      /* Extend the stack our own way.  */
-      if (YYMAXDEPTH <= yystacksize)
-        goto yyexhaustedlab;
-      yystacksize *= 2;
-      if (YYMAXDEPTH < yystacksize)
-        yystacksize = YYMAXDEPTH;
+            /* Each stack pointer address is followed by the size of the
+               data in use in that stack, in bytes.  This used to be a
+               conditional around just the two extra args, but that might
+               be undefined if yyoverflow is a macro.  */
+            yyoverflow(YY_("memory exhausted"),
+                       &yyss1, yysize * YYSIZEOF(*yyssp),
+                       &yyvs1, yysize * YYSIZEOF(*yyvsp),
+                       &yystacksize);
+            yyss = yyss1;
+            yyvs = yyvs1;
+        }
+#else /* defined YYSTACK_RELOCATE */
+        /* Extend the stack our own way.  */
+        if (YYMAXDEPTH <= yystacksize)
+            YYNOMEM;
+        yystacksize *= 2;
+        if (YYMAXDEPTH < yystacksize)
+            yystacksize = YYMAXDEPTH;
 
-      {
-        yy_state_t *yyss1 = yyss;
-        union yyalloc *yyptr =
-          YY_CAST (union yyalloc *,
-                   YYSTACK_ALLOC (YY_CAST (YYSIZE_T, YYSTACK_BYTES (yystacksize))));
-        if (! yyptr)
-          goto yyexhaustedlab;
-        YYSTACK_RELOCATE (yyss_alloc, yyss);
-        YYSTACK_RELOCATE (yyvs_alloc, yyvs);
-# undef YYSTACK_RELOCATE
-        if (yyss1 != yyssa)
-          YYSTACK_FREE (yyss1);
-      }
-# endif
+        {
+            yy_state_t* yyss1 = yyss;
+            union yyalloc* yyptr =
+                YY_CAST(union yyalloc*,
+                        YYSTACK_ALLOC(YY_CAST(YYSIZE_T, YYSTACK_BYTES(yystacksize))));
+            if (!yyptr)
+                YYNOMEM;
+            YYSTACK_RELOCATE(yyss_alloc, yyss);
+            YYSTACK_RELOCATE(yyvs_alloc, yyvs);
+#undef YYSTACK_RELOCATE
+            if (yyss1 != yyssa)
+                YYSTACK_FREE(yyss1);
+        }
+#endif
 
-      yyssp = yyss + yysize - 1;
-      yyvsp = yyvs + yysize - 1;
+        yyssp = yyss + yysize - 1;
+        yyvsp = yyvs + yysize - 1;
 
-      YY_IGNORE_USELESS_CAST_BEGIN
-      YYDPRINTF ((stderr, "Stack size increased to %ld\n",
-                  YY_CAST (long, yystacksize)));
-      YY_IGNORE_USELESS_CAST_END
+        YY_IGNORE_USELESS_CAST_BEGIN
+        YYDPRINTF((stderr, "Stack size increased to %ld\n",
+                   YY_CAST(long, yystacksize)));
+        YY_IGNORE_USELESS_CAST_END
 
-      if (yyss + yystacksize - 1 <= yyssp)
-        YYABORT;
+        if (yyss + yystacksize - 1 <= yyssp)
+            YYABORT;
     }
 #endif /* !defined yyoverflow && !defined YYSTACK_RELOCATE */
 
-  if (yystate == YYFINAL)
-    YYACCEPT;
+    if (yystate == YYFINAL)
+        YYACCEPT;
 
-  goto yybackup;
-
+    goto yybackup;
 
 /*-----------.
 | yybackup.  |
 `-----------*/
 yybackup:
-  /* Do appropriate processing given the current state.  Read a
-     lookahead token if we need one and don't already have one.  */
+    /* Do appropriate processing given the current state.  Read a
+       lookahead token if we need one and don't already have one.  */
 
-  /* First try to decide what to do without reference to lookahead token.  */
-  yyn = yypact[yystate];
-  if (yypact_value_is_default (yyn))
-    goto yydefault;
+    /* First try to decide what to do without reference to lookahead token.  */
+    yyn = yypact[yystate];
+    if (yypact_value_is_default(yyn))
+        goto yydefault;
 
-  /* Not known => get a lookahead token if don't already have one.  */
+    /* Not known => get a lookahead token if don't already have one.  */
 
-  /* YYCHAR is either YYEMPTY or YYEOF or a valid lookahead symbol.  */
-  if (yychar == YYEMPTY)
-    {
-      YYDPRINTF ((stderr, "Reading a token: "));
-      yychar = yylex (&yylval, yyscanner, compiler);
+    /* YYCHAR is either empty, or end-of-input, or a valid lookahead.  */
+    if (yychar == YYEMPTY) {
+        YYDPRINTF((stderr, "Reading a token\n"));
+        yychar = yylex(&yylval, yyscanner, compiler);
     }
 
-  if (yychar <= YYEOF)
-    {
-      yychar = yytoken = YYEOF;
-      YYDPRINTF ((stderr, "Now at end of input.\n"));
-    }
-  else
-    {
-      yytoken = YYTRANSLATE (yychar);
-      YY_SYMBOL_PRINT ("Next token is", yytoken, &yylval, &yylloc);
-    }
-
-  /* If the proper action on seeing token YYTOKEN is to reduce or to
-     detect an error, take that action.  */
-  yyn += yytoken;
-  if (yyn < 0 || YYLAST < yyn || yycheck[yyn] != yytoken)
-    goto yydefault;
-  yyn = yytable[yyn];
-  if (yyn <= 0)
-    {
-      if (yytable_value_is_error (yyn))
-        goto yyerrlab;
-      yyn = -yyn;
-      goto yyreduce;
+    if (yychar <= YYEOF) {
+        yychar  = YYEOF;
+        yytoken = YYSYMBOL_YYEOF;
+        YYDPRINTF((stderr, "Now at end of input.\n"));
+    } else if (yychar == YYerror) {
+        /* The scanner already issued an error message, process directly
+           to error recovery.  But do not keep the error token as
+           lookahead, it is too special and may lead us to an endless
+           loop in error recovery. */
+        yychar  = YYUNDEF;
+        yytoken = YYSYMBOL_YYerror;
+        goto yyerrlab1;
+    } else {
+        yytoken = YYTRANSLATE(yychar);
+        YY_SYMBOL_PRINT("Next token is", yytoken, &yylval, &yylloc);
     }
 
-  /* Count tokens shifted since error; after three, turn off error
-     status.  */
-  if (yyerrstatus)
-    yyerrstatus--;
+    /* If the proper action on seeing token YYTOKEN is to reduce or to
+       detect an error, take that action.  */
+    yyn += yytoken;
+    if (yyn < 0 || YYLAST < yyn || yycheck[yyn] != yytoken)
+        goto yydefault;
+    yyn = yytable[yyn];
+    if (yyn <= 0) {
+        if (yytable_value_is_error(yyn))
+            goto yyerrlab;
+        yyn = -yyn;
+        goto yyreduce;
+    }
 
-  /* Shift the lookahead token.  */
-  YY_SYMBOL_PRINT ("Shifting", yytoken, &yylval, &yylloc);
-  yystate = yyn;
-  YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
-  *++yyvsp = yylval;
-  YY_IGNORE_MAYBE_UNINITIALIZED_END
+    /* Count tokens shifted since error; after three, turn off error
+       status.  */
+    if (yyerrstatus)
+        yyerrstatus--;
 
-  /* Discard the shifted token.  */
-  yychar = YYEMPTY;
-  goto yynewstate;
+    /* Shift the lookahead token.  */
+    YY_SYMBOL_PRINT("Shifting", yytoken, &yylval, &yylloc);
+    yystate = yyn;
+    YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
+    *++yyvsp = yylval;
+    YY_IGNORE_MAYBE_UNINITIALIZED_END
 
+    /* Discard the shifted token.  */
+    yychar = YYEMPTY;
+    goto yynewstate;
 
 /*-----------------------------------------------------------.
 | yydefault -- do the default action for the current state.  |
 `-----------------------------------------------------------*/
 yydefault:
-  yyn = yydefact[yystate];
-  if (yyn == 0)
-    goto yyerrlab;
-  goto yyreduce;
-
+    yyn = yydefact[yystate];
+    if (yyn == 0)
+        goto yyerrlab;
+    goto yyreduce;
 
 /*-----------------------------.
 | yyreduce -- do a reduction.  |
 `-----------------------------*/
 yyreduce:
-  /* yyn is the number of a rule to reduce with.  */
-  yylen = yyr2[yyn];
+    /* yyn is the number of a rule to reduce with.  */
+    yylen = yyr2[yyn];
 
-  /* If YYLEN is nonzero, implement the default value of the action:
-     '$$ = $1'.
+    /* If YYLEN is nonzero, implement the default value of the action:
+       '$$ = $1'.
 
-     Otherwise, the following line sets YYVAL to garbage.
-     This behavior is undocumented and Bison
-     users should not rely upon it.  Assigning to YYVAL
-     unconditionally makes the parser a bit smaller, and it avoids a
-     GCC warning that YYVAL may be used uninitialized.  */
-  yyval = yyvsp[1-yylen];
+       Otherwise, the following line sets YYVAL to garbage.
+       This behavior is undocumented and Bison
+       users should not rely upon it.  Assigning to YYVAL
+       unconditionally makes the parser a bit smaller, and it avoids a
+       GCC warning that YYVAL may be used uninitialized.  */
+    yyval = yyvsp[1 - yylen];
 
-
-  YY_REDUCE_PRINT (yyn);
-  switch (yyn)
-    {
-  case 7:
-#line 243 "yara_grammar.y"
-      {
-        int result = yr_parser_reduce_import(yyscanner, (yyvsp[0].sized_string));
-
-        yr_free((yyvsp[0].sized_string));
-
-        ERROR_IF(result != ERROR_SUCCESS);
-      }
-#line 1717 "yara_grammar.c"
-    break;
-
-  case 8:
-#line 255 "yara_grammar.y"
-      {
-        int result = yr_parser_reduce_rule_declaration(
-            yyscanner,
-            (yyvsp[-8].integer),
-            (yyvsp[-6].c_string),
-            (yyvsp[-5].c_string),
-            (yyvsp[-2].string),
-            (yyvsp[-3].meta));
-
-        yr_free((yyvsp[-6].c_string));
-
-        ERROR_IF(result != ERROR_SUCCESS);
-      }
-#line 1735 "yara_grammar.c"
-    break;
-
-  case 9:
-#line 273 "yara_grammar.y"
-      {
-        (yyval.meta) = NULL;
-      }
-#line 1743 "yara_grammar.c"
-    break;
-
-  case 10:
-#line 277 "yara_grammar.y"
-      {
-#if REAL_YARA //Meta not supported
-        // Each rule have a list of meta-data info, consisting in a
-        // sequence of YR_META structures. The last YR_META structure does
-        // not represent a real meta-data, it's just an end-of-list marker
-        // identified by a specific type (META_TYPE_NULL). Here we
-        // write the end-of-list marker.
-
-        YR_META null_meta;
-
-        memset(&null_meta, 0xFF, sizeof(YR_META));
-        null_meta.type = META_TYPE_NULL;
-
-        compiler->last_result = yr_arena_write_data(
-            compiler->metas_arena,
-            &null_meta,
-            sizeof(YR_META),
-            NULL);
-
-#endif
-        (yyval.meta) = (yyvsp[0].meta);
-
-        ERROR_IF(compiler->last_result != ERROR_SUCCESS);
-      }
-#line 1772 "yara_grammar.c"
-    break;
-
-  case 11:
-#line 306 "yara_grammar.y"
-      {
-        (yyval.string) = NULL;
-        compiler->current_rule_strings = (yyval.string);
-      }
-#line 1781 "yara_grammar.c"
-    break;
-
-  case 12:
-#line 311 "yara_grammar.y"
-      {
-        // Each rule have a list of strings, consisting in a sequence
-        // of YR_STRING structures. The last YR_STRING structure does not
-        // represent a real string, it's just an end-of-list marker
-        // identified by a specific flag (STRING_FLAGS_NULL). Here we
-        // write the end-of-list marker.
-
-        YR_STRING null_string;
-
-        memset(&null_string, 0xFF, sizeof(YR_STRING));
-        null_string.g_flags = STRING_GFLAGS_NULL;
-
-        compiler->last_result = yr_arena_write_data(
-            compiler->strings_arena,
-            &null_string,
-            sizeof(YR_STRING),
-            NULL);
-
-        ERROR_IF(compiler->last_result != ERROR_SUCCESS);
-
-        compiler->current_rule_strings = (yyvsp[0].string);
-        (yyval.string) = (yyvsp[0].string);
-      }
-#line 1809 "yara_grammar.c"
-    break;
-
-  case 14:
-#line 343 "yara_grammar.y"
-                                       { (yyval.integer) = 0;  }
-#line 1815 "yara_grammar.c"
-    break;
-
-  case 15:
-#line 344 "yara_grammar.y"
-                                       { (yyval.integer) = (yyvsp[-1].integer) | (yyvsp[0].integer); }
-#line 1821 "yara_grammar.c"
-    break;
-
-  case 16:
-#line 349 "yara_grammar.y"
-                     { (yyval.integer) = RULE_GFLAGS_PRIVATE; }
-#line 1827 "yara_grammar.c"
-    break;
-
-  case 17:
-#line 350 "yara_grammar.y"
-                     { (yyval.integer) = RULE_GFLAGS_GLOBAL; }
-#line 1833 "yara_grammar.c"
-    break;
-
-  case 18:
-#line 356 "yara_grammar.y"
-      {
-        (yyval.c_string) = NULL;
-      }
-#line 1841 "yara_grammar.c"
-    break;
-
-  case 19:
-#line 360 "yara_grammar.y"
-      {
-#if REAL_YARA //tags not supported
-        // Tags list is represented in the arena as a sequence
-        // of null-terminated strings, the sequence ends with an
-        // additional null character. Here we write the ending null
-        //character. Example: tag1\0tag2\0tag3\0\0
-
-        compiler->last_result = yr_arena_write_string(
-            yyget_extra(yyscanner)->sz_arena, "", NULL);
-
-        ERROR_IF(compiler->last_result != ERROR_SUCCESS);
-#endif
-
-        (yyval.c_string) = (yyvsp[0].c_string);
-      }
-#line 1861 "yara_grammar.c"
-    break;
-
-  case 20:
-#line 380 "yara_grammar.y"
-      {
-#if REAL_YARA //tags not supported
-        char* identifier;
-
-        compiler->last_result = yr_arena_write_string(
-            yyget_extra(yyscanner)->sz_arena, (yyvsp[0].c_string), &identifier);
-
-#endif
-        yr_free((yyvsp[0].c_string));
-
-#if REAL_YARA //tags not supported
-        ERROR_IF(compiler->last_result != ERROR_SUCCESS);
-
-        (yyval.c_string) = identifier;
-#endif
-      }
-#line 1882 "yara_grammar.c"
-    break;
-
-  case 21:
-#line 397 "yara_grammar.y"
-      {
-#if REAL_YARA //tags not supported
-        char* tag_name = (yyvsp[-1].c_string);
-        size_t tag_length = tag_name != NULL ? strlen(tag_name) : 0;
-
-        while (tag_length > 0)
+    YY_REDUCE_PRINT(yyn);
+    switch (yyn) {
+        case 7: /* import: _IMPORT_ _TEXT_STRING_  */
+#line 257 "yara_grammar.y"
         {
-          if (strcmp(tag_name, (yyvsp[0].c_string)) == 0)
-          {
-            yr_compiler_set_error_extra_info(compiler, tag_name);
-            compiler->last_result = ERROR_DUPLICATE_TAG_IDENTIFIER;
-            break;
-          }
+            int result = yr_parser_reduce_import(yyscanner, (yyvsp[0].sized_string));
 
-          tag_name = yr_arena_next_address(
-              yyget_extra(yyscanner)->sz_arena,
-              tag_name,
-              tag_length + 1);
+            yr_free((yyvsp[0].sized_string));
 
-          tag_length = tag_name != NULL ? strlen(tag_name) : 0;
+            ERROR_IF(result != ERROR_SUCCESS);
         }
+#line 1538 "yara_grammar.c"
+        break;
 
-        if (compiler->last_result == ERROR_SUCCESS)
-          compiler->last_result = yr_arena_write_string(
-              yyget_extra(yyscanner)->sz_arena, (yyvsp[0].c_string), NULL);
-
-#endif
-        yr_free((yyvsp[0].c_string));
-
-        ERROR_IF(compiler->last_result != ERROR_SUCCESS);
-
-        (yyval.c_string) = (yyvsp[-1].c_string);
-      }
-#line 1920 "yara_grammar.c"
-    break;
-
-  case 22:
-#line 435 "yara_grammar.y"
-                                          {  (yyval.meta) = (yyvsp[0].meta); }
-#line 1926 "yara_grammar.c"
-    break;
-
-  case 23:
-#line 436 "yara_grammar.y"
-                                          {  (yyval.meta) = (yyvsp[-1].meta); }
-#line 1932 "yara_grammar.c"
-    break;
-
-  case 24:
-#line 442 "yara_grammar.y"
-      {
-        SIZED_STRING* sized_string = (yyvsp[0].sized_string);
-
-        (yyval.meta) = yr_parser_reduce_meta_declaration(
-            yyscanner,
-            META_TYPE_STRING,
-            (yyvsp[-2].c_string),
-            sized_string->c_string,
-            0);
-
-        yr_free((yyvsp[-2].c_string));
-        yr_free((yyvsp[0].sized_string));
-
-        ERROR_IF((yyval.meta) == NULL);
-      }
-#line 1952 "yara_grammar.c"
-    break;
-
-  case 25:
-#line 458 "yara_grammar.y"
-      {
-        (yyval.meta) = yr_parser_reduce_meta_declaration(
-            yyscanner,
-            META_TYPE_INTEGER,
-            (yyvsp[-2].c_string),
-            NULL,
-            (yyvsp[0].integer));
-
-        yr_free((yyvsp[-2].c_string));
-
-        ERROR_IF((yyval.meta) == NULL);
-      }
-#line 1969 "yara_grammar.c"
-    break;
-
-  case 26:
-#line 471 "yara_grammar.y"
-      {
-        (yyval.meta) = yr_parser_reduce_meta_declaration(
-            yyscanner,
-            META_TYPE_BOOLEAN,
-            (yyvsp[-2].c_string),
-            NULL,
-            TRUE);
-
-        yr_free((yyvsp[-2].c_string));
-
-        ERROR_IF((yyval.meta) == NULL);
-      }
-#line 1986 "yara_grammar.c"
-    break;
-
-  case 27:
-#line 484 "yara_grammar.y"
-      {
-        (yyval.meta) = yr_parser_reduce_meta_declaration(
-            yyscanner,
-            META_TYPE_BOOLEAN,
-            (yyvsp[-2].c_string),
-            NULL,
-            FALSE);
-
-        yr_free((yyvsp[-2].c_string));
-
-        ERROR_IF((yyval.meta) == NULL);
-      }
-#line 2003 "yara_grammar.c"
-    break;
-
-  case 28:
-#line 500 "yara_grammar.y"
-                                              { (yyval.string) = (yyvsp[0].string); }
-#line 2009 "yara_grammar.c"
-    break;
-
-  case 29:
-#line 501 "yara_grammar.y"
-                                              { (yyval.string) = (yyvsp[-1].string); }
-#line 2015 "yara_grammar.c"
-    break;
-
-  case 30:
-#line 507 "yara_grammar.y"
-      {
-        (yyval.string) = yr_parser_reduce_string_declaration(
-            yyscanner,
-            (yyvsp[0].integer),
-            (yyvsp[-3].c_string),
-            (yyvsp[-1].sized_string));
-
-        yr_free((yyvsp[-3].c_string));
-        yr_free((yyvsp[-1].sized_string));
-
-        ERROR_IF((yyval.string) == NULL);
-      }
-#line 2032 "yara_grammar.c"
-    break;
-
-  case 31:
-#line 520 "yara_grammar.y"
-      {
-        compiler->error_line = yyget_lineno(yyscanner);
-      }
-#line 2040 "yara_grammar.c"
-    break;
-
-  case 32:
-#line 524 "yara_grammar.y"
-      {
-        (yyval.string) = yr_parser_reduce_string_declaration(
-            yyscanner,
-            (yyvsp[0].integer) | STRING_GFLAGS_REGEXP,
-            (yyvsp[-4].c_string),
-            (yyvsp[-1].sized_string));
-
-        yr_free((yyvsp[-4].c_string));
-        yr_free((yyvsp[-1].sized_string));
-
-        ERROR_IF((yyval.string) == NULL);
-      }
-#line 2057 "yara_grammar.c"
-    break;
-
-  case 33:
-#line 537 "yara_grammar.y"
-      {
-        (yyval.string) = yr_parser_reduce_string_declaration(
-            yyscanner,
-            STRING_GFLAGS_HEXADECIMAL,
-            (yyvsp[-2].c_string),
-            (yyvsp[0].sized_string));
-
-        yr_free((yyvsp[-2].c_string));
-        yr_free((yyvsp[0].sized_string));
-
-        ERROR_IF((yyval.string) == NULL);
-      }
-#line 2074 "yara_grammar.c"
-    break;
-
-  case 34:
-#line 553 "yara_grammar.y"
-                                          { (yyval.integer) = 0; }
-#line 2080 "yara_grammar.c"
-    break;
-
-  case 35:
-#line 554 "yara_grammar.y"
-                                          { (yyval.integer) = (yyvsp[-1].integer) | (yyvsp[0].integer); }
-#line 2086 "yara_grammar.c"
-    break;
-
-  case 36:
-#line 559 "yara_grammar.y"
-                    { (yyval.integer) = STRING_GFLAGS_WIDE; }
-#line 2092 "yara_grammar.c"
-    break;
-
-  case 37:
-#line 560 "yara_grammar.y"
-                    { (yyval.integer) = STRING_GFLAGS_ASCII; }
-#line 2098 "yara_grammar.c"
-    break;
-
-  case 38:
-#line 561 "yara_grammar.y"
-                    { (yyval.integer) = STRING_GFLAGS_NO_CASE; }
-#line 2104 "yara_grammar.c"
-    break;
-
-  case 39:
-#line 562 "yara_grammar.y"
-                    { (yyval.integer) = STRING_GFLAGS_FULL_WORD; }
-#line 2110 "yara_grammar.c"
-    break;
-
-  case 40:
-#line 568 "yara_grammar.y"
-      {
-        YR_OBJECT* object = NULL;
-        YR_RULE* rule;
-
-        char* id;
-        char* ns = NULL;
-
-        int var_index;
-
-        var_index = yr_parser_lookup_loop_variable(yyscanner, (yyvsp[0].c_string));
-
-        if (var_index >= 0)
+        case 8: /* rule: rule_modifiers _RULE_ _IDENTIFIER_ tags '{' meta strings condition '}'  */
+#line 269 "yara_grammar.y"
         {
-         compiler->last_result = yr_parser_emit_with_arg(
-            yyscanner,
-            OP_PUSH_M,
-            LOOP_LOCAL_VARS * var_index,
-            NULL);
+            int result = yr_parser_reduce_rule_declaration(
+                yyscanner,
+                (yyvsp[-8].integer),
+                (yyvsp[-6].c_string),
+                (yyvsp[-5].c_string),
+                (yyvsp[-2].string),
+                (yyvsp[-3].meta));
 
-          (yyval.object) = (YR_OBJECT*) -1;
+            yr_free((yyvsp[-6].c_string));
+
+            ERROR_IF(result != ERROR_SUCCESS);
         }
-        else
+#line 1556 "yara_grammar.c"
+        break;
+
+        case 9: /* meta: %empty  */
+#line 287 "yara_grammar.y"
         {
-          // Search for identifier within the global namespace, where the
-          // externals variables reside.
-          object = (YR_OBJECT*) yr_hash_table_lookup(
-                compiler->objects_table,
-                (yyvsp[0].c_string),
+            (yyval.meta) = NULL;
+        }
+#line 1564 "yara_grammar.c"
+        break;
+
+        case 10: /* meta: _META_ ':' meta_declarations  */
+#line 291 "yara_grammar.y"
+        {
+#if REAL_YARA // Meta not supported
+            // Each rule have a list of meta-data info, consisting in a
+            // sequence of YR_META structures. The last YR_META structure does
+            // not represent a real meta-data, it's just an end-of-list marker
+            // identified by a specific type (META_TYPE_NULL). Here we
+            // write the end-of-list marker.
+
+            YR_META null_meta;
+
+            memset(&null_meta, 0xFF, sizeof(YR_META));
+            null_meta.type = META_TYPE_NULL;
+
+            compiler->last_result = yr_arena_write_data(
+                compiler->metas_arena,
+                &null_meta,
+                sizeof(YR_META),
                 NULL);
-          if (object == NULL)
-          {
-            // If not found, search within the current namespace.
 
-            ns = compiler->current_namespace->name;
-            object = (YR_OBJECT*) yr_hash_table_lookup(
-                compiler->objects_table,
-                (yyvsp[0].c_string),
-                ns);
-          }
-
-          if (object != NULL)
-          {
-            compiler->last_result = yr_arena_write_string(
-                compiler->sz_arena,
-                (yyvsp[0].c_string),
-                &id);
-
-            if (compiler->last_result == ERROR_SUCCESS)
-              compiler->last_result = yr_parser_emit_with_arg_reloc(
-                  yyscanner,
-                  OP_OBJ_LOAD,
-                  PTR_TO_UINT64(id),
-                  NULL);
-
-            (yyval.object) = object;
-          }
-          else
-          {
-           rule = (YR_RULE*) yr_hash_table_lookup(
-                compiler->rules_table,
-                (yyvsp[0].c_string),
-                compiler->current_namespace->name);
-            if (rule != NULL)
-            {
-              compiler->last_result = yr_parser_emit_with_arg_reloc(
-                  yyscanner,
-                  OP_PUSH_RULE,
-                  PTR_TO_UINT64(rule),
-                  NULL);
-            }
-            else
-            {
-              yr_compiler_set_error_extra_info(compiler, (yyvsp[0].c_string));
-              compiler->last_result = ERROR_UNDEFINED_IDENTIFIER;
-            }
-
-            (yyval.object) = (YR_OBJECT*) -2;
-          }
-        }
-
-        yr_free((yyvsp[0].c_string));
-
-        ERROR_IF(compiler->last_result != ERROR_SUCCESS);
-      }
-#line 2199 "yara_grammar.c"
-    break;
-
-  case 41:
-#line 653 "yara_grammar.y"
-      {
-        YR_OBJECT* object = (yyvsp[-2].object);
-        YR_OBJECT* field = NULL;
-
-        char* ident;
-
-        if (object != NULL &&
-            object != (YR_OBJECT*) -1 &&    // not a loop variable identifier
-            object != (YR_OBJECT*) -2 &&    // not a rule identifier
-            object->type == OBJECT_TYPE_STRUCTURE)
-        {
-#if REAL_YARA
-         field = yr_object_lookup_field(object, (yyvsp[0].c_string));
 #endif
-          if (field != NULL)
-          {
+            (yyval.meta) = (yyvsp[0].meta);
+
+            ERROR_IF(compiler->last_result != ERROR_SUCCESS);
+        }
+#line 1593 "yara_grammar.c"
+        break;
+
+        case 11: /* strings: %empty  */
+#line 320 "yara_grammar.y"
+        {
+            (yyval.string)                 = NULL;
+            compiler->current_rule_strings = (yyval.string);
+        }
+#line 1602 "yara_grammar.c"
+        break;
+
+        case 12: /* strings: _STRINGS_ ':' string_declarations  */
+#line 325 "yara_grammar.y"
+        {
+            // Each rule have a list of strings, consisting in a sequence
+            // of YR_STRING structures. The last YR_STRING structure does not
+            // represent a real string, it's just an end-of-list marker
+            // identified by a specific flag (STRING_FLAGS_NULL). Here we
+            // write the end-of-list marker.
+
+            YR_STRING null_string;
+
+            memset(&null_string, 0xFF, sizeof(YR_STRING));
+            null_string.g_flags = STRING_GFLAGS_NULL;
+
+            compiler->last_result = yr_arena_write_data(
+                compiler->strings_arena,
+                &null_string,
+                sizeof(YR_STRING),
+                NULL);
+
+            ERROR_IF(compiler->last_result != ERROR_SUCCESS);
+
+            compiler->current_rule_strings = (yyvsp[0].string);
+            (yyval.string)                 = (yyvsp[0].string);
+        }
+#line 1630 "yara_grammar.c"
+        break;
+
+        case 14: /* rule_modifiers: %empty  */
+#line 357 "yara_grammar.y"
+        {
+            (yyval.integer) = 0;
+        }
+#line 1636 "yara_grammar.c"
+        break;
+
+        case 15: /* rule_modifiers: rule_modifiers rule_modifier  */
+#line 358 "yara_grammar.y"
+        {
+            (yyval.integer) = (yyvsp[-1].integer) | (yyvsp[0].integer);
+        }
+#line 1642 "yara_grammar.c"
+        break;
+
+        case 16: /* rule_modifier: _PRIVATE_  */
+#line 363 "yara_grammar.y"
+        {
+            (yyval.integer) = RULE_GFLAGS_PRIVATE;
+        }
+#line 1648 "yara_grammar.c"
+        break;
+
+        case 17: /* rule_modifier: _GLOBAL_  */
+#line 364 "yara_grammar.y"
+        {
+            (yyval.integer) = RULE_GFLAGS_GLOBAL;
+        }
+#line 1654 "yara_grammar.c"
+        break;
+
+        case 18: /* tags: %empty  */
+#line 370 "yara_grammar.y"
+        {
+            (yyval.c_string) = NULL;
+        }
+#line 1662 "yara_grammar.c"
+        break;
+
+        case 19: /* tags: ':' tag_list  */
+#line 374 "yara_grammar.y"
+        {
+#if REAL_YARA // tags not supported
+            // Tags list is represented in the arena as a sequence
+            // of null-terminated strings, the sequence ends with an
+            // additional null character. Here we write the ending null
+            // character. Example: tag1\0tag2\0tag3\0\0
+
             compiler->last_result = yr_arena_write_string(
-              compiler->sz_arena,
-              (yyvsp[0].c_string),
-              &ident);
+                yyget_extra(yyscanner)->sz_arena, "", NULL);
+
+            ERROR_IF(compiler->last_result != ERROR_SUCCESS);
+#endif
+
+            (yyval.c_string) = (yyvsp[0].c_string);
+        }
+#line 1682 "yara_grammar.c"
+        break;
+
+        case 20: /* tag_list: _IDENTIFIER_  */
+#line 394 "yara_grammar.y"
+        {
+#if REAL_YARA // tags not supported
+            char* identifier;
+
+            compiler->last_result = yr_arena_write_string(
+                yyget_extra(yyscanner)->sz_arena, (yyvsp[0].c_string), &identifier);
+
+#endif
+            yr_free((yyvsp[0].c_string));
+
+#if REAL_YARA // tags not supported
+            ERROR_IF(compiler->last_result != ERROR_SUCCESS);
+
+            (yyval.c_string) = identifier;
+#endif
+        }
+#line 1703 "yara_grammar.c"
+        break;
+
+        case 21: /* tag_list: tag_list _IDENTIFIER_  */
+#line 411 "yara_grammar.y"
+        {
+#if REAL_YARA // tags not supported
+            char* tag_name    = (yyvsp[-1].c_string);
+            size_t tag_length = tag_name != NULL ? strlen(tag_name) : 0;
+
+            while (tag_length > 0) {
+                if (strcmp(tag_name, (yyvsp[0].c_string)) == 0) {
+                    yr_compiler_set_error_extra_info(compiler, tag_name);
+                    compiler->last_result = ERROR_DUPLICATE_TAG_IDENTIFIER;
+                    break;
+                }
+
+                tag_name = yr_arena_next_address(
+                    yyget_extra(yyscanner)->sz_arena,
+                    tag_name,
+                    tag_length + 1);
+
+                tag_length = tag_name != NULL ? strlen(tag_name) : 0;
+            }
 
             if (compiler->last_result == ERROR_SUCCESS)
-              compiler->last_result = yr_parser_emit_with_arg_reloc(
-                  yyscanner,
-                  OP_OBJ_FIELD,
-                  PTR_TO_UINT64(ident),
-                  NULL);
-          }
-          else
-          {
-            yr_compiler_set_error_extra_info(compiler, (yyvsp[0].c_string));
-            compiler->last_result = ERROR_INVALID_FIELD_NAME;
-          }
+                compiler->last_result = yr_arena_write_string(
+                    yyget_extra(yyscanner)->sz_arena, (yyvsp[0].c_string), NULL);
+
+#endif
+            yr_free((yyvsp[0].c_string));
+
+            ERROR_IF(compiler->last_result != ERROR_SUCCESS);
+
+            (yyval.c_string) = (yyvsp[-1].c_string);
         }
-        else
-        {
-          yr_compiler_set_error_extra_info(
-              compiler,
-              object->identifier);
+#line 1741 "yara_grammar.c"
+        break;
 
-          compiler->last_result = ERROR_NOT_A_STRUCTURE;
+        case 22: /* meta_declarations: meta_declaration  */
+#line 449 "yara_grammar.y"
+        {
+            (yyval.meta) = (yyvsp[0].meta);
         }
+#line 1747 "yara_grammar.c"
+        break;
 
-        (yyval.object) = field;
-
-        yr_free((yyvsp[0].c_string));
-
-        ERROR_IF(compiler->last_result != ERROR_SUCCESS);
-      }
-#line 2253 "yara_grammar.c"
-    break;
-
-  case 42:
-#line 703 "yara_grammar.y"
-      {
-        if ((yyvsp[-3].object) != NULL && (yyvsp[-3].object)->type == OBJECT_TYPE_ARRAY)
+        case 23: /* meta_declarations: meta_declarations meta_declaration  */
+#line 450 "yara_grammar.y"
         {
-          compiler->last_result = yr_parser_emit(
-              yyscanner,
-              OP_INDEX_ARRAY,
-              NULL);
-
-          (yyval.object) = ((YR_OBJECT_ARRAY*) (yyvsp[-3].object))->items->objects[0];
+            (yyval.meta) = (yyvsp[-1].meta);
         }
-        else
-        {
-          yr_compiler_set_error_extra_info(
-              compiler,
-              (yyvsp[-3].object)->identifier);
+#line 1753 "yara_grammar.c"
+        break;
 
-          compiler->last_result = ERROR_NOT_AN_ARRAY;
+        case 24: /* meta_declaration: _IDENTIFIER_ '=' _TEXT_STRING_  */
+#line 456 "yara_grammar.y"
+        {
+            SIZED_STRING* sized_string = (yyvsp[0].sized_string);
+
+            (yyval.meta) = yr_parser_reduce_meta_declaration(
+                yyscanner,
+                META_TYPE_STRING,
+                (yyvsp[-2].c_string),
+                sized_string->c_string,
+                0);
+
+            yr_free((yyvsp[-2].c_string));
+            yr_free((yyvsp[0].sized_string));
+
+            ERROR_IF((yyval.meta) == NULL);
         }
+#line 1773 "yara_grammar.c"
+        break;
 
-        ERROR_IF(compiler->last_result != ERROR_SUCCESS);
-      }
-#line 2279 "yara_grammar.c"
-    break;
-
-  case 43:
-#line 726 "yara_grammar.y"
-      {
-        int args_count;
-
-        if ((yyvsp[-3].object) != NULL && (yyvsp[-3].object)->type == OBJECT_TYPE_FUNCTION)
+        case 25: /* meta_declaration: _IDENTIFIER_ '=' _NUMBER_  */
+#line 472 "yara_grammar.y"
         {
-          compiler->last_result = yr_parser_check_types(
-              compiler, (YR_OBJECT_FUNCTION*) (yyvsp[-3].object), (yyvsp[-1].c_string));
+            (yyval.meta) = yr_parser_reduce_meta_declaration(
+                yyscanner,
+                META_TYPE_INTEGER,
+                (yyvsp[-2].c_string),
+                NULL,
+                (yyvsp[0].integer));
 
-          if (compiler->last_result == ERROR_SUCCESS)
-          {
-            args_count = strlen((yyvsp[-1].c_string));
+            yr_free((yyvsp[-2].c_string));
 
+            ERROR_IF((yyval.meta) == NULL);
+        }
+#line 1790 "yara_grammar.c"
+        break;
+
+        case 26: /* meta_declaration: _IDENTIFIER_ '=' _TRUE_  */
+#line 485 "yara_grammar.y"
+        {
+            (yyval.meta) = yr_parser_reduce_meta_declaration(
+                yyscanner,
+                META_TYPE_BOOLEAN,
+                (yyvsp[-2].c_string),
+                NULL,
+                TRUE);
+
+            yr_free((yyvsp[-2].c_string));
+
+            ERROR_IF((yyval.meta) == NULL);
+        }
+#line 1807 "yara_grammar.c"
+        break;
+
+        case 27: /* meta_declaration: _IDENTIFIER_ '=' _FALSE_  */
+#line 498 "yara_grammar.y"
+        {
+            (yyval.meta) = yr_parser_reduce_meta_declaration(
+                yyscanner,
+                META_TYPE_BOOLEAN,
+                (yyvsp[-2].c_string),
+                NULL,
+                FALSE);
+
+            yr_free((yyvsp[-2].c_string));
+
+            ERROR_IF((yyval.meta) == NULL);
+        }
+#line 1824 "yara_grammar.c"
+        break;
+
+        case 28: /* string_declarations: string_declaration  */
+#line 514 "yara_grammar.y"
+        {
+            (yyval.string) = (yyvsp[0].string);
+        }
+#line 1830 "yara_grammar.c"
+        break;
+
+        case 29: /* string_declarations: string_declarations string_declaration  */
+#line 515 "yara_grammar.y"
+        {
+            (yyval.string) = (yyvsp[-1].string);
+        }
+#line 1836 "yara_grammar.c"
+        break;
+
+        case 30: /* string_declaration: _STRING_IDENTIFIER_ '=' _TEXT_STRING_ string_modifiers  */
+#line 521 "yara_grammar.y"
+        {
+            (yyval.string) = yr_parser_reduce_string_declaration(
+                yyscanner,
+                (yyvsp[0].integer),
+                (yyvsp[-3].c_string),
+                (yyvsp[-1].sized_string));
+
+            yr_free((yyvsp[-3].c_string));
+            yr_free((yyvsp[-1].sized_string));
+
+            ERROR_IF((yyval.string) == NULL);
+        }
+#line 1853 "yara_grammar.c"
+        break;
+
+        case 31: /* $@1: %empty  */
+#line 534 "yara_grammar.y"
+        {
+            compiler->error_line = yyget_lineno(yyscanner);
+        }
+#line 1861 "yara_grammar.c"
+        break;
+
+        case 32: /* string_declaration: _STRING_IDENTIFIER_ '=' $@1 _REGEXP_ string_modifiers  */
+#line 538 "yara_grammar.y"
+        {
+            (yyval.string) = yr_parser_reduce_string_declaration(
+                yyscanner,
+                (yyvsp[0].integer) | STRING_GFLAGS_REGEXP,
+                (yyvsp[-4].c_string),
+                (yyvsp[-1].sized_string));
+
+            yr_free((yyvsp[-4].c_string));
+            yr_free((yyvsp[-1].sized_string));
+
+            ERROR_IF((yyval.string) == NULL);
+        }
+#line 1878 "yara_grammar.c"
+        break;
+
+        case 33: /* string_declaration: _STRING_IDENTIFIER_ '=' _HEX_STRING_ hex_modifiers  */
+#line 551 "yara_grammar.y"
+        {
+            (yyval.string) = yr_parser_reduce_string_declaration(
+                yyscanner,
+                (yyvsp[0].integer) | STRING_GFLAGS_HEXADECIMAL,
+                (yyvsp[-3].c_string),
+                (yyvsp[-1].sized_string));
+
+            yr_free((yyvsp[-3].c_string));
+            yr_free((yyvsp[-1].sized_string));
+
+            ERROR_IF((yyval.string) == NULL);
+        }
+#line 1895 "yara_grammar.c"
+        break;
+
+        case 34: /* string_modifiers: %empty  */
+#line 567 "yara_grammar.y"
+        {
+            (yyval.integer) = 0;
+        }
+#line 1901 "yara_grammar.c"
+        break;
+
+        case 35: /* string_modifiers: string_modifiers string_modifier  */
+#line 569 "yara_grammar.y"
+        {
+            if ((yyvsp[-1].integer) & (yyvsp[0].integer)) {
+                compiler->last_result = ERROR_DUPLICATED_MODIFIER;
+                ERROR_IF(compiler->last_result != ERROR_SUCCESS);
+            }
+
+            (yyval.integer) = (yyvsp[-1].integer) | (yyvsp[0].integer);
+        }
+#line 1915 "yara_grammar.c"
+        break;
+
+        case 36: /* string_modifier: _WIDE_  */
+#line 582 "yara_grammar.y"
+        {
+            (yyval.integer) = STRING_GFLAGS_WIDE;
+        }
+#line 1921 "yara_grammar.c"
+        break;
+
+        case 37: /* string_modifier: _ASCII_  */
+#line 583 "yara_grammar.y"
+        {
+            (yyval.integer) = STRING_GFLAGS_ASCII;
+        }
+#line 1927 "yara_grammar.c"
+        break;
+
+        case 38: /* string_modifier: _NOCASE_  */
+#line 584 "yara_grammar.y"
+        {
+            (yyval.integer) = STRING_GFLAGS_NO_CASE;
+        }
+#line 1933 "yara_grammar.c"
+        break;
+
+        case 39: /* string_modifier: _FULLWORD_  */
+#line 585 "yara_grammar.y"
+        {
+            (yyval.integer) = STRING_GFLAGS_FULL_WORD;
+        }
+#line 1939 "yara_grammar.c"
+        break;
+
+        case 40: /* string_modifier: _PRIVATE_  */
+#line 586 "yara_grammar.y"
+        {
+            (yyval.integer) = STRING_GFLAGS_PRIVATE;
+        }
+#line 1945 "yara_grammar.c"
+        break;
+
+        case 41: /* string_modifier: _XOR_  */
+#line 587 "yara_grammar.y"
+        {
+            (yyval.integer) = 0;
+            UNSUPPORTED_STRING_MODIFIER("xor");
+        }
+#line 1951 "yara_grammar.c"
+        break;
+
+        case 42: /* string_modifier: _XOR_ '(' _NUMBER_ ')'  */
+#line 589 "yara_grammar.y"
+        {
+            (yyval.integer) = 0;
+            UNSUPPORTED_STRING_MODIFIER("xor");
+        }
+#line 1960 "yara_grammar.c"
+        break;
+
+        case 43: /* string_modifier: _XOR_ '(' _NUMBER_ '-' _NUMBER_ ')'  */
+#line 594 "yara_grammar.y"
+        {
+            (yyval.integer) = 0;
+            UNSUPPORTED_STRING_MODIFIER("xor");
+        }
+#line 1969 "yara_grammar.c"
+        break;
+
+        case 44: /* string_modifier: _BASE64_  */
+#line 599 "yara_grammar.y"
+        {
+            (yyval.integer) = 0;
+            UNSUPPORTED_STRING_MODIFIER("base64");
+        }
+#line 1978 "yara_grammar.c"
+        break;
+
+        case 45: /* string_modifier: _BASE64_ '(' _TEXT_STRING_ ')'  */
+#line 604 "yara_grammar.y"
+        {
+            yr_free((yyvsp[-1].sized_string));
+            (yyval.integer) = 0;
+            UNSUPPORTED_STRING_MODIFIER("base64");
+        }
+#line 1988 "yara_grammar.c"
+        break;
+
+        case 46: /* string_modifier: _BASE64_WIDE_  */
+#line 610 "yara_grammar.y"
+        {
+            (yyval.integer) = 0;
+            UNSUPPORTED_STRING_MODIFIER("base64wide");
+        }
+#line 1997 "yara_grammar.c"
+        break;
+
+        case 47: /* string_modifier: _BASE64_WIDE_ '(' _TEXT_STRING_ ')'  */
+#line 615 "yara_grammar.y"
+        {
+            yr_free((yyvsp[-1].sized_string));
+            (yyval.integer) = 0;
+            UNSUPPORTED_STRING_MODIFIER("base64wide");
+        }
+#line 2007 "yara_grammar.c"
+        break;
+
+        case 48: /* hex_modifiers: %empty  */
+#line 624 "yara_grammar.y"
+        {
+            (yyval.integer) = 0;
+        }
+#line 2013 "yara_grammar.c"
+        break;
+
+        case 49: /* hex_modifiers: hex_modifiers hex_modifier  */
+#line 626 "yara_grammar.y"
+        {
+            if ((yyvsp[-1].integer) & (yyvsp[0].integer)) {
+                compiler->last_result = ERROR_DUPLICATED_MODIFIER;
+                ERROR_IF(compiler->last_result != ERROR_SUCCESS);
+            }
+
+            (yyval.integer) = (yyvsp[-1].integer) | (yyvsp[0].integer);
+        }
+#line 2027 "yara_grammar.c"
+        break;
+
+        case 50: /* hex_modifier: _PRIVATE_  */
+#line 639 "yara_grammar.y"
+        {
+            (yyval.integer) = STRING_GFLAGS_PRIVATE;
+        }
+#line 2033 "yara_grammar.c"
+        break;
+
+        case 51: /* identifier: _IDENTIFIER_  */
+#line 645 "yara_grammar.y"
+        {
+            YR_OBJECT* object = NULL;
+            YR_RULE* rule;
+
+            char* id;
+            char* ns = NULL;
+
+            int var_index;
+
+            var_index = yr_parser_lookup_loop_variable(yyscanner, (yyvsp[0].c_string));
+
+            if (var_index >= 0) {
+                compiler->last_result = yr_parser_emit_with_arg(
+                    yyscanner,
+                    OP_PUSH_M,
+                    LOOP_LOCAL_VARS * var_index,
+                    NULL);
+
+                (yyval.object) = (YR_OBJECT*)-1;
+            } else {
+                // Search for identifier within the global namespace, where the
+                // externals variables reside.
+                object = (YR_OBJECT*)yr_hash_table_lookup(
+                    compiler->objects_table,
+                    (yyvsp[0].c_string),
+                    NULL);
+                if (object == NULL) {
+                    // If not found, search within the current namespace.
+
+                    ns     = compiler->current_namespace->name;
+                    object = (YR_OBJECT*)yr_hash_table_lookup(
+                        compiler->objects_table,
+                        (yyvsp[0].c_string),
+                        ns);
+                }
+
+                if (object != NULL) {
+                    compiler->last_result = yr_arena_write_string(
+                        compiler->sz_arena,
+                        (yyvsp[0].c_string),
+                        &id);
+
+                    if (compiler->last_result == ERROR_SUCCESS)
+                        compiler->last_result = yr_parser_emit_with_arg_reloc(
+                            yyscanner,
+                            OP_OBJ_LOAD,
+                            PTR_TO_UINT64(id),
+                            NULL);
+
+                    (yyval.object) = object;
+                } else {
+                    rule = (YR_RULE*)yr_hash_table_lookup(
+                        compiler->rules_table,
+                        (yyvsp[0].c_string),
+                        compiler->current_namespace->name);
+                    if (rule != NULL) {
+                        compiler->last_result = yr_parser_emit_with_arg_reloc(
+                            yyscanner,
+                            OP_PUSH_RULE,
+                            PTR_TO_UINT64(rule),
+                            NULL);
+                    } else {
+                        yr_compiler_set_error_extra_info(compiler, (yyvsp[0].c_string));
+                        compiler->last_result = ERROR_UNDEFINED_IDENTIFIER;
+                    }
+
+                    (yyval.object) = (YR_OBJECT*)-2;
+                }
+            }
+
+            yr_free((yyvsp[0].c_string));
+
+            ERROR_IF(compiler->last_result != ERROR_SUCCESS);
+        }
+#line 2122 "yara_grammar.c"
+        break;
+
+        case 52: /* identifier: identifier '.' _IDENTIFIER_  */
+#line 730 "yara_grammar.y"
+        {
+            YR_OBJECT* object = (yyvsp[-2].object);
+            YR_OBJECT* field  = NULL;
+
+            char* ident;
+
+            if (object != NULL &&
+                object != (YR_OBJECT*)-1 && // not a loop variable identifier
+                object != (YR_OBJECT*)-2 && // not a rule identifier
+                object->type == OBJECT_TYPE_STRUCTURE) {
+#if REAL_YARA
+                field = yr_object_lookup_field(object, (yyvsp[0].c_string));
+#endif
+                if (field != NULL) {
+                    compiler->last_result = yr_arena_write_string(
+                        compiler->sz_arena,
+                        (yyvsp[0].c_string),
+                        &ident);
+
+                    if (compiler->last_result == ERROR_SUCCESS)
+                        compiler->last_result = yr_parser_emit_with_arg_reloc(
+                            yyscanner,
+                            OP_OBJ_FIELD,
+                            PTR_TO_UINT64(ident),
+                            NULL);
+                } else {
+                    yr_compiler_set_error_extra_info(compiler, (yyvsp[0].c_string));
+                    compiler->last_result = ERROR_INVALID_FIELD_NAME;
+                }
+            } else {
+                yr_compiler_set_error_extra_info(
+                    compiler,
+                    object->identifier);
+
+                compiler->last_result = ERROR_NOT_A_STRUCTURE;
+            }
+
+            (yyval.object) = field;
+
+            yr_free((yyvsp[0].c_string));
+
+            ERROR_IF(compiler->last_result != ERROR_SUCCESS);
+        }
+#line 2176 "yara_grammar.c"
+        break;
+
+        case 53: /* identifier: identifier '[' primary_expression ']'  */
+#line 780 "yara_grammar.y"
+        {
+            if ((yyvsp[-3].object) != NULL && (yyvsp[-3].object)->type == OBJECT_TYPE_ARRAY) {
+                compiler->last_result = yr_parser_emit(
+                    yyscanner,
+                    OP_INDEX_ARRAY,
+                    NULL);
+
+                (yyval.object) = ((YR_OBJECT_ARRAY*)(yyvsp[-3].object))->items->objects[0];
+            } else {
+                yr_compiler_set_error_extra_info(
+                    compiler,
+                    (yyvsp[-3].object)->identifier);
+
+                compiler->last_result = ERROR_NOT_AN_ARRAY;
+            }
+
+            ERROR_IF(compiler->last_result != ERROR_SUCCESS);
+        }
+#line 2202 "yara_grammar.c"
+        break;
+
+        case 54: /* identifier: identifier '(' arguments_list ')'  */
+#line 803 "yara_grammar.y"
+        {
+            int args_count;
+
+            if ((yyvsp[-3].object) != NULL && (yyvsp[-3].object)->type == OBJECT_TYPE_FUNCTION) {
+                compiler->last_result = yr_parser_check_types(
+                    compiler, (YR_OBJECT_FUNCTION*)(yyvsp[-3].object), (yyvsp[-1].c_string));
+
+                if (compiler->last_result == ERROR_SUCCESS) {
+                    args_count = strlen((yyvsp[-1].c_string));
+
+                    compiler->last_result = yr_parser_emit_with_arg(
+                        yyscanner,
+                        OP_CALL,
+                        args_count,
+                        NULL);
+                }
+
+                (yyval.object) = ((YR_OBJECT_FUNCTION*)(yyvsp[-3].object))->return_obj;
+            } else {
+                yr_compiler_set_error_extra_info(
+                    compiler,
+                    (yyvsp[-3].object)->identifier);
+
+                compiler->last_result = ERROR_NOT_A_FUNCTION;
+            }
+
+            yr_free((yyvsp[-1].c_string));
+
+            ERROR_IF(compiler->last_result != ERROR_SUCCESS);
+        }
+#line 2241 "yara_grammar.c"
+        break;
+
+        case 55: /* arguments_list: %empty  */
+#line 842 "yara_grammar.y"
+        {
+            (yyval.c_string) = yr_strdup("");
+        }
+#line 2249 "yara_grammar.c"
+        break;
+
+        case 56: /* arguments_list: expression  */
+#line 846 "yara_grammar.y"
+        {
+            (yyval.c_string) = yr_malloc(MAX_FUNCTION_ARGS + 1);
+
+            switch ((yyvsp[0].expression_type)) {
+                case EXPRESSION_TYPE_INTEGER:
+                    strlcpy((yyval.c_string), "i", MAX_FUNCTION_ARGS);
+                    break;
+                case EXPRESSION_TYPE_BOOLEAN:
+                    strlcpy((yyval.c_string), "b", MAX_FUNCTION_ARGS);
+                    break;
+                case EXPRESSION_TYPE_STRING:
+                    strlcpy((yyval.c_string), "s", MAX_FUNCTION_ARGS);
+                    break;
+                case EXPRESSION_TYPE_REGEXP:
+                    strlcpy((yyval.c_string), "r", MAX_FUNCTION_ARGS);
+                    break;
+            }
+
+            ERROR_IF((yyval.c_string) == NULL);
+        }
+#line 2275 "yara_grammar.c"
+        break;
+
+        case 57: /* arguments_list: arguments_list ',' expression  */
+#line 868 "yara_grammar.y"
+        {
+            if (strlen((yyvsp[-2].c_string)) == MAX_FUNCTION_ARGS) {
+                compiler->last_result = ERROR_TOO_MANY_ARGUMENTS;
+            } else {
+                switch ((yyvsp[0].expression_type)) {
+                    case EXPRESSION_TYPE_INTEGER:
+                        strlcat((yyvsp[-2].c_string), "i", MAX_FUNCTION_ARGS);
+                        break;
+                    case EXPRESSION_TYPE_BOOLEAN:
+                        strlcat((yyvsp[-2].c_string), "b", MAX_FUNCTION_ARGS);
+                        break;
+                    case EXPRESSION_TYPE_STRING:
+                        strlcat((yyvsp[-2].c_string), "s", MAX_FUNCTION_ARGS);
+                        break;
+                    case EXPRESSION_TYPE_REGEXP:
+                        strlcat((yyvsp[-2].c_string), "r", MAX_FUNCTION_ARGS);
+                        break;
+                }
+            }
+
+            ERROR_IF(compiler->last_result != ERROR_SUCCESS);
+
+            (yyval.c_string) = (yyvsp[-2].c_string);
+        }
+#line 2308 "yara_grammar.c"
+        break;
+
+        case 58: /* regexp: _REGEXP_  */
+#line 901 "yara_grammar.y"
+        {
+#ifdef REAL_YARA
+            SIZED_STRING* sized_string = (yyvsp[0].sized_string);
+            RE* re;
+            RE_ERROR error;
+
+            int re_flags = 0;
+
+            if (sized_string->flags & SIZED_STRING_FLAGS_NO_CASE)
+                re_flags |= RE_FLAGS_NO_CASE;
+
+            if (sized_string->flags & SIZED_STRING_FLAGS_DOT_ALL)
+                re_flags |= RE_FLAGS_DOT_ALL;
+
+            compiler->last_result = yr_re_compile(
+                sized_string->c_string,
+                re_flags,
+                compiler->re_code_arena,
+                &re,
+                &error);
+
+            yr_free((yyvsp[0].sized_string));
+
+            if (compiler->last_result == ERROR_INVALID_REGULAR_EXPRESSION)
+                yr_compiler_set_error_extra_info(compiler, error.message);
+
+            ERROR_IF(compiler->last_result != ERROR_SUCCESS);
+
+            if (compiler->last_result == ERROR_SUCCESS)
+                compiler->last_result = yr_parser_emit_with_arg_reloc(
+                    yyscanner,
+                    OP_PUSH,
+                    PTR_TO_UINT64(re->root_node->forward_code),
+                    NULL);
+
+            yr_re_destroy(re);
+
+            ERROR_IF(compiler->last_result != ERROR_SUCCESS);
+#endif
+
+            (yyval.expression_type) = EXPRESSION_TYPE_REGEXP;
+        }
+#line 2355 "yara_grammar.c"
+        break;
+
+        case 59: /* boolean_expression: expression  */
+#line 948 "yara_grammar.y"
+        {
+            if ((yyvsp[0].expression_type) == EXPRESSION_TYPE_STRING) {
+                compiler->last_result = yr_parser_emit(
+                    yyscanner,
+                    OP_SZ_TO_BOOL,
+                    NULL);
+
+                ERROR_IF(compiler->last_result != ERROR_SUCCESS);
+            }
+
+            (yyval.expression_type) = EXPRESSION_TYPE_BOOLEAN;
+        }
+#line 2374 "yara_grammar.c"
+        break;
+
+        case 60: /* expression: _TRUE_  */
+#line 966 "yara_grammar.y"
+        {
+            compiler->last_result = yr_parser_emit_with_arg(
+                yyscanner, OP_PUSH, 1, NULL);
+
+            ERROR_IF(compiler->last_result != ERROR_SUCCESS);
+
+            (yyval.expression_type) = EXPRESSION_TYPE_BOOLEAN;
+        }
+#line 2387 "yara_grammar.c"
+        break;
+
+        case 61: /* expression: _FALSE_  */
+#line 975 "yara_grammar.y"
+        {
+            compiler->last_result = yr_parser_emit_with_arg(
+                yyscanner, OP_PUSH, 0, NULL);
+
+            ERROR_IF(compiler->last_result != ERROR_SUCCESS);
+
+            (yyval.expression_type) = EXPRESSION_TYPE_BOOLEAN;
+        }
+#line 2400 "yara_grammar.c"
+        break;
+
+        case 62: /* expression: primary_expression _MATCHES_ regexp  */
+#line 984 "yara_grammar.y"
+        {
+            CHECK_TYPE((yyvsp[-2].expression_type), EXPRESSION_TYPE_STRING, "matches");
+            CHECK_TYPE((yyvsp[0].expression_type), EXPRESSION_TYPE_REGEXP, "matches");
+
+            if (compiler->last_result == ERROR_SUCCESS)
+                compiler->last_result = yr_parser_emit(
+                    yyscanner,
+                    OP_MATCHES,
+                    NULL);
+
+            ERROR_IF(compiler->last_result != ERROR_SUCCESS);
+
+            (yyval.expression_type) = EXPRESSION_TYPE_BOOLEAN;
+        }
+#line 2419 "yara_grammar.c"
+        break;
+
+        case 63: /* expression: primary_expression _CONTAINS_ primary_expression  */
+#line 999 "yara_grammar.y"
+        {
+            CHECK_TYPE((yyvsp[-2].expression_type), EXPRESSION_TYPE_STRING, "contains");
+            CHECK_TYPE((yyvsp[0].expression_type), EXPRESSION_TYPE_STRING, "contains");
+
+            compiler->last_result = yr_parser_emit(
+                yyscanner,
+                OP_CONTAINS,
+                NULL);
+
+            ERROR_IF(compiler->last_result != ERROR_SUCCESS);
+
+            (yyval.expression_type) = EXPRESSION_TYPE_BOOLEAN;
+        }
+#line 2437 "yara_grammar.c"
+        break;
+
+        case 64: /* expression: _STRING_IDENTIFIER_  */
+#line 1013 "yara_grammar.y"
+        {
+            int result = yr_parser_reduce_string_identifier(
+                yyscanner,
+                (yyvsp[0].c_string),
+                OP_STR_FOUND);
+
+            yr_free((yyvsp[0].c_string));
+
+            ERROR_IF(result != ERROR_SUCCESS);
+
+            (yyval.expression_type) = EXPRESSION_TYPE_BOOLEAN;
+        }
+#line 2454 "yara_grammar.c"
+        break;
+
+        case 65: /* expression: _STRING_IDENTIFIER_ _AT_ primary_expression  */
+#line 1026 "yara_grammar.y"
+        {
+            CHECK_TYPE((yyvsp[0].expression_type), EXPRESSION_TYPE_INTEGER, "at");
+
+            compiler->last_result = yr_parser_reduce_string_identifier(
+                yyscanner,
+                (yyvsp[-2].c_string),
+                OP_STR_FOUND_AT);
+
+            yr_free((yyvsp[-2].c_string));
+
+            ERROR_IF(compiler->last_result != ERROR_SUCCESS);
+
+            compiler->current_rule_clflags |= RULE_OFFSETS;
+
+            (yyval.expression_type) = EXPRESSION_TYPE_BOOLEAN;
+        }
+#line 2475 "yara_grammar.c"
+        break;
+
+        case 66: /* expression: _STRING_IDENTIFIER_ _IN_ range  */
+#line 1043 "yara_grammar.y"
+        {
+            compiler->last_result = yr_parser_reduce_string_identifier(
+                yyscanner,
+                (yyvsp[-2].c_string),
+                OP_STR_FOUND_IN);
+
+            yr_free((yyvsp[-2].c_string));
+
+            ERROR_IF(compiler->last_result != ERROR_SUCCESS);
+
+            compiler->current_rule_clflags |= RULE_OFFSETS;
+
+            (yyval.expression_type) = EXPRESSION_TYPE_BOOLEAN;
+        }
+#line 2494 "yara_grammar.c"
+        break;
+
+        case 67: /* $@2: %empty  */
+#line 1058 "yara_grammar.y"
+        {
+            int var_index;
+
+            if (compiler->loop_depth == MAX_LOOP_NESTING)
+                compiler->last_result =
+                    ERROR_LOOP_NESTING_LIMIT_EXCEEDED;
+
+            ERROR_IF(compiler->last_result != ERROR_SUCCESS);
+
+            var_index = yr_parser_lookup_loop_variable(
+                yyscanner,
+                (yyvsp[-1].c_string));
+
+            if (var_index >= 0) {
+                yr_compiler_set_error_extra_info(
+                    compiler,
+                    (yyvsp[-1].c_string));
+
+                compiler->last_result =
+                    ERROR_DUPLICATE_LOOP_IDENTIFIER;
+            }
+            ERROR_IF(compiler->last_result != ERROR_SUCCESS);
+
+            // Push end-of-list marker
             compiler->last_result = yr_parser_emit_with_arg(
                 yyscanner,
-                OP_CALL,
-                args_count,
+                OP_PUSH,
+                UNDEFINED,
                 NULL);
-          }
 
-          (yyval.object) = ((YR_OBJECT_FUNCTION*) (yyvsp[-3].object))->return_obj;
+            ERROR_IF(compiler->last_result != ERROR_SUCCESS);
         }
-        else
+#line 2532 "yara_grammar.c"
+        break;
+
+        case 68: /* $@3: %empty  */
+#line 1092 "yara_grammar.y"
         {
-          yr_compiler_set_error_extra_info(
-              compiler,
-              (yyvsp[-3].object)->identifier);
+            int mem_offset = LOOP_LOCAL_VARS * compiler->loop_depth;
 
-          compiler->last_result = ERROR_NOT_A_FUNCTION;
+            int8_t* addr;
+
+            // Clear counter for number of expressions evaluating
+            // to TRUE.
+            yr_parser_emit_with_arg(
+                yyscanner, OP_CLEAR_M, mem_offset + 1, NULL);
+
+            // Clear iterations counter
+            yr_parser_emit_with_arg(
+                yyscanner, OP_CLEAR_M, mem_offset + 2, NULL);
+
+            if ((yyvsp[-1].integer) == INTEGER_SET_ENUMERATION) {
+                // Pop the first integer
+                yr_parser_emit_with_arg(
+                    yyscanner, OP_POP_M, mem_offset, &addr);
+            } else // INTEGER_SET_RANGE
+            {
+                // Pop higher bound of set range
+                yr_parser_emit_with_arg(
+                    yyscanner, OP_POP_M, mem_offset + 3, &addr);
+
+                // Pop lower bound of set range
+                yr_parser_emit_with_arg(
+                    yyscanner, OP_POP_M, mem_offset, NULL);
+            }
+            compiler->loop_address[compiler->loop_depth]    = addr;
+            compiler->loop_identifier[compiler->loop_depth] = (yyvsp[-4].c_string);
+            compiler->loop_depth++;
         }
-
-        yr_free((yyvsp[-1].c_string));
-
-        ERROR_IF(compiler->last_result != ERROR_SUCCESS);
-      }
-#line 2318 "yara_grammar.c"
-    break;
-
-  case 44:
-#line 765 "yara_grammar.y"
-      {
-        (yyval.c_string) = yr_strdup("");
-      }
-#line 2326 "yara_grammar.c"
-    break;
-
-  case 45:
-#line 769 "yara_grammar.y"
-      {
-        (yyval.c_string) = yr_malloc(MAX_FUNCTION_ARGS + 1);
-
-        switch((yyvsp[0].expression_type))
-        {
-          case EXPRESSION_TYPE_INTEGER:
-            strlcpy((yyval.c_string), "i", MAX_FUNCTION_ARGS);
-            break;
-          case EXPRESSION_TYPE_BOOLEAN:
-            strlcpy((yyval.c_string), "b", MAX_FUNCTION_ARGS);
-            break;
-          case EXPRESSION_TYPE_STRING:
-            strlcpy((yyval.c_string), "s", MAX_FUNCTION_ARGS);
-            break;
-          case EXPRESSION_TYPE_REGEXP:
-            strlcpy((yyval.c_string), "r", MAX_FUNCTION_ARGS);
-            break;
-        }
-
-        ERROR_IF((yyval.c_string) == NULL);
-      }
-#line 2352 "yara_grammar.c"
-    break;
-
-  case 46:
-#line 791 "yara_grammar.y"
-      {
-        if (strlen((yyvsp[-2].c_string)) == MAX_FUNCTION_ARGS)
-        {
-          compiler->last_result = ERROR_TOO_MANY_ARGUMENTS;
-        }
-        else
-        {
-          switch((yyvsp[0].expression_type))
-          {
-            case EXPRESSION_TYPE_INTEGER:
-              strlcat((yyvsp[-2].c_string), "i", MAX_FUNCTION_ARGS);
-              break;
-            case EXPRESSION_TYPE_BOOLEAN:
-              strlcat((yyvsp[-2].c_string), "b", MAX_FUNCTION_ARGS);
-              break;
-            case EXPRESSION_TYPE_STRING:
-              strlcat((yyvsp[-2].c_string), "s", MAX_FUNCTION_ARGS);
-              break;
-            case EXPRESSION_TYPE_REGEXP:
-              strlcat((yyvsp[-2].c_string), "r", MAX_FUNCTION_ARGS);
-              break;
-          }
-        }
-
-        ERROR_IF(compiler->last_result != ERROR_SUCCESS);
-
-        (yyval.c_string) = (yyvsp[-2].c_string);
-      }
-#line 2385 "yara_grammar.c"
-    break;
-
-  case 47:
-#line 824 "yara_grammar.y"
-      {
-#ifdef REAL_YARA
-        SIZED_STRING* sized_string = (yyvsp[0].sized_string);
-        RE* re;
-        RE_ERROR error;
-
-        int re_flags = 0;
-
-        if (sized_string->flags & SIZED_STRING_FLAGS_NO_CASE)
-          re_flags |= RE_FLAGS_NO_CASE;
-
-        if (sized_string->flags & SIZED_STRING_FLAGS_DOT_ALL)
-          re_flags |= RE_FLAGS_DOT_ALL;
-
-        compiler->last_result = yr_re_compile(
-            sized_string->c_string,
-            re_flags,
-            compiler->re_code_arena,
-            &re,
-            &error);
-
-        yr_free((yyvsp[0].sized_string));
-
-        if (compiler->last_result == ERROR_INVALID_REGULAR_EXPRESSION)
-          yr_compiler_set_error_extra_info(compiler, error.message);
-
-        ERROR_IF(compiler->last_result != ERROR_SUCCESS);
-
-        if (compiler->last_result == ERROR_SUCCESS)
-          compiler->last_result = yr_parser_emit_with_arg_reloc(
-              yyscanner,
-              OP_PUSH,
-              PTR_TO_UINT64(re->root_node->forward_code),
-              NULL);
-
-        yr_re_destroy(re);
-
-        ERROR_IF(compiler->last_result != ERROR_SUCCESS);
-#endif
-
-        (yyval.expression_type) = EXPRESSION_TYPE_REGEXP;
-      }
-#line 2432 "yara_grammar.c"
-    break;
-
-  case 48:
-#line 871 "yara_grammar.y"
-      {
-        if ((yyvsp[0].expression_type) == EXPRESSION_TYPE_STRING)
-        {
-          compiler->last_result = yr_parser_emit(
-              yyscanner,
-              OP_SZ_TO_BOOL,
-              NULL);
-
-          ERROR_IF(compiler->last_result != ERROR_SUCCESS);
-        }
-
-
-        (yyval.expression_type) = EXPRESSION_TYPE_BOOLEAN;
-      }
-#line 2451 "yara_grammar.c"
-    break;
-
-  case 49:
-#line 889 "yara_grammar.y"
-      {
-        compiler->last_result = yr_parser_emit_with_arg(
-            yyscanner, OP_PUSH, 1, NULL);
-
-        ERROR_IF(compiler->last_result != ERROR_SUCCESS);
-
-        (yyval.expression_type) = EXPRESSION_TYPE_BOOLEAN;
-      }
-#line 2464 "yara_grammar.c"
-    break;
-
-  case 50:
-#line 898 "yara_grammar.y"
-      {
-        compiler->last_result = yr_parser_emit_with_arg(
-            yyscanner, OP_PUSH, 0, NULL);
-
-        ERROR_IF(compiler->last_result != ERROR_SUCCESS);
-
-        (yyval.expression_type) = EXPRESSION_TYPE_BOOLEAN;
-      }
-#line 2477 "yara_grammar.c"
-    break;
-
-  case 51:
-#line 907 "yara_grammar.y"
-      {
-        CHECK_TYPE((yyvsp[-2].expression_type), EXPRESSION_TYPE_STRING, "matches");
-        CHECK_TYPE((yyvsp[0].expression_type), EXPRESSION_TYPE_REGEXP, "matches");
-
-        if (compiler->last_result == ERROR_SUCCESS)
-          compiler->last_result = yr_parser_emit(
-              yyscanner,
-              OP_MATCHES,
-              NULL);
-
-        ERROR_IF(compiler->last_result != ERROR_SUCCESS);
-
-        (yyval.expression_type) = EXPRESSION_TYPE_BOOLEAN;
-      }
-#line 2496 "yara_grammar.c"
-    break;
-
-  case 52:
-#line 922 "yara_grammar.y"
-      {
-        CHECK_TYPE((yyvsp[-2].expression_type), EXPRESSION_TYPE_STRING, "contains");
-        CHECK_TYPE((yyvsp[0].expression_type), EXPRESSION_TYPE_STRING, "contains");
-
-        compiler->last_result = yr_parser_emit(
-            yyscanner,
-            OP_CONTAINS,
-            NULL);
-
-        ERROR_IF(compiler->last_result != ERROR_SUCCESS);
-
-        (yyval.expression_type) = EXPRESSION_TYPE_BOOLEAN;
-      }
-#line 2514 "yara_grammar.c"
-    break;
-
-  case 53:
-#line 936 "yara_grammar.y"
-      {
-        int result = yr_parser_reduce_string_identifier(
-            yyscanner,
-            (yyvsp[0].c_string),
-            OP_STR_FOUND);
-
-        yr_free((yyvsp[0].c_string));
-
-        ERROR_IF(result != ERROR_SUCCESS);
-
-        (yyval.expression_type) = EXPRESSION_TYPE_BOOLEAN;
-      }
-#line 2531 "yara_grammar.c"
-    break;
-
-  case 54:
-#line 949 "yara_grammar.y"
-      {
-        CHECK_TYPE((yyvsp[0].expression_type), EXPRESSION_TYPE_INTEGER, "at");
-
-        compiler->last_result = yr_parser_reduce_string_identifier(
-            yyscanner,
-            (yyvsp[-2].c_string),
-            OP_STR_FOUND_AT);
-
-        yr_free((yyvsp[-2].c_string));
-
-        ERROR_IF(compiler->last_result != ERROR_SUCCESS);
-
-        compiler->current_rule_clflags |= RULE_OFFSETS;
-
-        (yyval.expression_type) = EXPRESSION_TYPE_BOOLEAN;
-      }
-#line 2552 "yara_grammar.c"
-    break;
-
-  case 55:
-#line 966 "yara_grammar.y"
-      {
-        compiler->last_result = yr_parser_reduce_string_identifier(
-            yyscanner,
-            (yyvsp[-2].c_string),
-            OP_STR_FOUND_IN);
-
-        yr_free((yyvsp[-2].c_string));
-
-        ERROR_IF(compiler->last_result!= ERROR_SUCCESS);
-
-        compiler->current_rule_clflags |= RULE_OFFSETS;
-
-        (yyval.expression_type) = EXPRESSION_TYPE_BOOLEAN;
-      }
 #line 2571 "yara_grammar.c"
-    break;
+        break;
 
-  case 56:
-#line 981 "yara_grammar.y"
-      {
-        int var_index;
-
-        if (compiler->loop_depth == MAX_LOOP_NESTING)
-          compiler->last_result = \
-              ERROR_LOOP_NESTING_LIMIT_EXCEEDED;
-
-        ERROR_IF(compiler->last_result != ERROR_SUCCESS);
-
-        var_index = yr_parser_lookup_loop_variable(
-            yyscanner,
-            (yyvsp[-1].c_string));
-
-        if (var_index >= 0)
+        case 69: /* expression: _FOR_ for_expression _IDENTIFIER_ _IN_ $@2 integer_set ':' $@3 '(' boolean_expression ')'  */
+#line 1127 "yara_grammar.y"
         {
-          yr_compiler_set_error_extra_info(
-              compiler,
-              (yyvsp[-1].c_string));
+            int mem_offset;
 
-          compiler->last_result = \
-              ERROR_DUPLICATE_LOOP_IDENTIFIER;
+            compiler->loop_depth--;
+            mem_offset = LOOP_LOCAL_VARS * compiler->loop_depth;
+
+            // The value at the top of the stack is 1 if latest
+            // expression was true or 0 otherwise. Add this value
+            // to the counter for number of expressions evaluating
+            // to true.
+            yr_parser_emit_with_arg(
+                yyscanner, OP_ADD_M, mem_offset + 1, NULL);
+
+            // Increment iterations counter
+            yr_parser_emit_with_arg(
+                yyscanner, OP_INCR_M, mem_offset + 2, NULL);
+
+            if ((yyvsp[-5].integer) == INTEGER_SET_ENUMERATION) {
+                yr_parser_emit_with_arg_reloc(
+                    yyscanner,
+                    OP_JNUNDEF,
+                    PTR_TO_UINT64(
+                        compiler->loop_address[compiler->loop_depth]),
+                    NULL);
+            } else // INTEGER_SET_RANGE
+            {
+                // Increment lower bound of integer set
+                yr_parser_emit_with_arg(
+                    yyscanner, OP_INCR_M, mem_offset, NULL);
+
+                // Push lower bound of integer set
+                yr_parser_emit_with_arg(
+                    yyscanner, OP_PUSH_M, mem_offset, NULL);
+
+                // Push higher bound of integer set
+                yr_parser_emit_with_arg(
+                    yyscanner, OP_PUSH_M, mem_offset + 3, NULL);
+
+                // Compare higher bound with lower bound, do loop again
+                // if lower bound is still lower or equal than higher bound
+                yr_parser_emit_with_arg_reloc(
+                    yyscanner,
+                    OP_JLE,
+                    PTR_TO_UINT64(
+                        compiler->loop_address[compiler->loop_depth]),
+                    NULL);
+
+                yr_parser_emit(yyscanner, OP_POP, NULL);
+                yr_parser_emit(yyscanner, OP_POP, NULL);
+            }
+
+            // Pop end-of-list marker.
+            yr_parser_emit(yyscanner, OP_POP, NULL);
+
+            // At this point the loop quantifier (any, all, 1, 2,..)
+            // is at the top of the stack. Check if the quantifier
+            // is undefined (meaning "all") and replace it with the
+            // iterations counter in that case.
+            yr_parser_emit_with_arg(
+                yyscanner, OP_SWAPUNDEF, mem_offset + 2, NULL);
+
+            // Compare the loop quantifier with the number of
+            // expressions evaluating to TRUE.
+            yr_parser_emit_with_arg(
+                yyscanner, OP_PUSH_M, mem_offset + 1, NULL);
+
+            yr_parser_emit(yyscanner, OP_LE, NULL);
+
+            compiler->loop_identifier[compiler->loop_depth] = NULL;
+            yr_free((yyvsp[-8].c_string));
+
+            (yyval.expression_type) = EXPRESSION_TYPE_BOOLEAN;
         }
-        ERROR_IF(compiler->last_result != ERROR_SUCCESS);
+#line 2651 "yara_grammar.c"
+        break;
 
-        // Push end-of-list marker
-        compiler->last_result = yr_parser_emit_with_arg(
-            yyscanner,
-            OP_PUSH,
-            UNDEFINED,
-            NULL);
-
-        ERROR_IF(compiler->last_result != ERROR_SUCCESS);
-      }
-#line 2609 "yara_grammar.c"
-    break;
-
-  case 57:
-#line 1015 "yara_grammar.y"
-      {
-        int mem_offset = LOOP_LOCAL_VARS * compiler->loop_depth;
-
-        int8_t* addr;
-
-        // Clear counter for number of expressions evaluating
-        // to TRUE.
-        yr_parser_emit_with_arg(
-            yyscanner, OP_CLEAR_M, mem_offset + 1, NULL);
-
-        // Clear iterations counter
-        yr_parser_emit_with_arg(
-            yyscanner, OP_CLEAR_M, mem_offset + 2, NULL);
-
-        if ((yyvsp[-1].integer) == INTEGER_SET_ENUMERATION)
+        case 70: /* $@4: %empty  */
+#line 1203 "yara_grammar.y"
         {
-          // Pop the first integer
-          yr_parser_emit_with_arg(
-              yyscanner, OP_POP_M, mem_offset, &addr);
+            int mem_offset = LOOP_LOCAL_VARS * compiler->loop_depth;
+            int8_t* addr;
+
+            if (compiler->loop_depth == MAX_LOOP_NESTING)
+                compiler->last_result =
+                    ERROR_LOOP_NESTING_LIMIT_EXCEEDED;
+
+            if (compiler->loop_for_of_mem_offset != -1)
+                compiler->last_result =
+                    ERROR_NESTED_FOR_OF_LOOP;
+
+            ERROR_IF(compiler->last_result != ERROR_SUCCESS);
+
+            yr_parser_emit_with_arg(
+                yyscanner, OP_CLEAR_M, mem_offset + 1, NULL);
+
+            yr_parser_emit_with_arg(
+                yyscanner, OP_CLEAR_M, mem_offset + 2, NULL);
+
+            // Pop the first string.
+            yr_parser_emit_with_arg(
+                yyscanner, OP_POP_M, mem_offset, &addr);
+
+            compiler->loop_for_of_mem_offset                = mem_offset;
+            compiler->loop_address[compiler->loop_depth]    = addr;
+            compiler->loop_identifier[compiler->loop_depth] = NULL;
+            compiler->loop_depth++;
         }
-        else // INTEGER_SET_RANGE
+#line 2685 "yara_grammar.c"
+        break;
+
+        case 71: /* expression: _FOR_ for_expression _OF_ string_set ':' $@4 '(' boolean_expression ')'  */
+#line 1233 "yara_grammar.y"
         {
-          // Pop higher bound of set range
-          yr_parser_emit_with_arg(
-              yyscanner, OP_POP_M, mem_offset + 3, &addr);
+            int mem_offset;
 
-          // Pop lower bound of set range
-          yr_parser_emit_with_arg(
-              yyscanner, OP_POP_M, mem_offset, NULL);
+            compiler->loop_depth--;
+            compiler->loop_for_of_mem_offset = -1;
+
+            mem_offset = LOOP_LOCAL_VARS * compiler->loop_depth;
+
+            // Increment counter by the value returned by the
+            // boolean expression (0 or 1).
+            yr_parser_emit_with_arg(
+                yyscanner, OP_ADD_M, mem_offset + 1, NULL);
+
+            // Increment iterations counter.
+            yr_parser_emit_with_arg(
+                yyscanner, OP_INCR_M, mem_offset + 2, NULL);
+
+            // If next string is not undefined, go back to the
+            // beginning of the loop.
+            yr_parser_emit_with_arg_reloc(
+                yyscanner,
+                OP_JNUNDEF,
+                PTR_TO_UINT64(
+                    compiler->loop_address[compiler->loop_depth]),
+                NULL);
+
+            // Pop end-of-list marker.
+            yr_parser_emit(yyscanner, OP_POP, NULL);
+
+            // At this point the loop quantifier (any, all, 1, 2,..)
+            // is at top of the stack. Check if the quantifier is
+            // undefined (meaning "all") and replace it with the
+            // iterations counter in that case.
+            yr_parser_emit_with_arg(
+                yyscanner, OP_SWAPUNDEF, mem_offset + 2, NULL);
+
+            // Compare the loop quantifier with the number of
+            // expressions evaluating to TRUE.
+            yr_parser_emit_with_arg(
+                yyscanner, OP_PUSH_M, mem_offset + 1, NULL);
+
+            yr_parser_emit(yyscanner, OP_LE, NULL);
+            (yyval.expression_type) = EXPRESSION_TYPE_BOOLEAN;
+
         }
-        compiler->loop_address[compiler->loop_depth] = addr;
-        compiler->loop_identifier[compiler->loop_depth] = (yyvsp[-4].c_string);
-        compiler->loop_depth++;
-      }
-#line 2648 "yara_grammar.c"
-    break;
+#line 2735 "yara_grammar.c"
+        break;
 
-  case 58:
-#line 1050 "yara_grammar.y"
-      {
-        int mem_offset;
-
-        compiler->loop_depth--;
-        mem_offset = LOOP_LOCAL_VARS * compiler->loop_depth;
-
-        // The value at the top of the stack is 1 if latest
-        // expression was true or 0 otherwise. Add this value
-        // to the counter for number of expressions evaluating
-        // to true.
-        yr_parser_emit_with_arg(
-            yyscanner, OP_ADD_M, mem_offset + 1, NULL);
-
-        // Increment iterations counter
-        yr_parser_emit_with_arg(
-            yyscanner, OP_INCR_M, mem_offset + 2, NULL);
-
-        if ((yyvsp[-5].integer) == INTEGER_SET_ENUMERATION)
+        case 72: /* expression: for_expression _OF_ string_set  */
+#line 1279 "yara_grammar.y"
         {
-          yr_parser_emit_with_arg_reloc(
-              yyscanner,
-              OP_JNUNDEF,
-              PTR_TO_UINT64(
-                  compiler->loop_address[compiler->loop_depth]),
-              NULL);
+            yr_parser_emit(yyscanner, OP_OF, NULL);
+
+            (yyval.expression_type) = EXPRESSION_TYPE_BOOLEAN;
         }
-        else // INTEGER_SET_RANGE
+#line 2745 "yara_grammar.c"
+        break;
+
+        case 73: /* expression: _NOT_ boolean_expression  */
+#line 1285 "yara_grammar.y"
         {
-          // Increment lower bound of integer set
-          yr_parser_emit_with_arg(
-              yyscanner, OP_INCR_M, mem_offset, NULL);
+            yr_parser_emit(yyscanner, OP_NOT, NULL);
 
-          // Push lower bound of integer set
-          yr_parser_emit_with_arg(
-              yyscanner, OP_PUSH_M, mem_offset, NULL);
-
-          // Push higher bound of integer set
-          yr_parser_emit_with_arg(
-              yyscanner, OP_PUSH_M, mem_offset + 3, NULL);
-
-          // Compare higher bound with lower bound, do loop again
-          // if lower bound is still lower or equal than higher bound
-          yr_parser_emit_with_arg_reloc(
-              yyscanner,
-              OP_JLE,
-              PTR_TO_UINT64(
-                compiler->loop_address[compiler->loop_depth]),
-              NULL);
-
-          yr_parser_emit(yyscanner, OP_POP, NULL);
-          yr_parser_emit(yyscanner, OP_POP, NULL);
+            (yyval.expression_type) = EXPRESSION_TYPE_BOOLEAN;
         }
+#line 2755 "yara_grammar.c"
+        break;
 
-        // Pop end-of-list marker.
-        yr_parser_emit(yyscanner, OP_POP, NULL);
-
-        // At this point the loop quantifier (any, all, 1, 2,..)
-        // is at the top of the stack. Check if the quantifier
-        // is undefined (meaning "all") and replace it with the
-        // iterations counter in that case.
-        yr_parser_emit_with_arg(
-            yyscanner, OP_SWAPUNDEF, mem_offset + 2, NULL);
-
-        // Compare the loop quantifier with the number of
-        // expressions evaluating to TRUE.
-        yr_parser_emit_with_arg(
-            yyscanner, OP_PUSH_M, mem_offset + 1, NULL);
-
-        yr_parser_emit(yyscanner, OP_LE, NULL);
-
-        compiler->loop_identifier[compiler->loop_depth] = NULL;
-        yr_free((yyvsp[-8].c_string));
-
-        (yyval.expression_type) = EXPRESSION_TYPE_BOOLEAN;
-      }
-#line 2728 "yara_grammar.c"
-    break;
-
-  case 59:
-#line 1126 "yara_grammar.y"
-      {
-        int mem_offset = LOOP_LOCAL_VARS * compiler->loop_depth;
-        int8_t* addr;
-
-        if (compiler->loop_depth == MAX_LOOP_NESTING)
-          compiler->last_result = \
-            ERROR_LOOP_NESTING_LIMIT_EXCEEDED;
-
-        if (compiler->loop_for_of_mem_offset != -1)
-          compiler->last_result = \
-            ERROR_NESTED_FOR_OF_LOOP;
-
-        ERROR_IF(compiler->last_result != ERROR_SUCCESS);
-
-        yr_parser_emit_with_arg(
-            yyscanner, OP_CLEAR_M, mem_offset + 1, NULL);
-
-        yr_parser_emit_with_arg(
-            yyscanner, OP_CLEAR_M, mem_offset + 2, NULL);
-
-        // Pop the first string.
-        yr_parser_emit_with_arg(
-            yyscanner, OP_POP_M, mem_offset, &addr);
-
-        compiler->loop_for_of_mem_offset = mem_offset;
-        compiler->loop_address[compiler->loop_depth] = addr;
-        compiler->loop_identifier[compiler->loop_depth] = NULL;
-        compiler->loop_depth++;
-      }
-#line 2762 "yara_grammar.c"
-    break;
-
-  case 60:
-#line 1156 "yara_grammar.y"
-      {
-        int mem_offset;
-
-        compiler->loop_depth--;
-        compiler->loop_for_of_mem_offset = -1;
-
-        mem_offset = LOOP_LOCAL_VARS * compiler->loop_depth;
-
-        // Increment counter by the value returned by the
-        // boolean expression (0 or 1).
-        yr_parser_emit_with_arg(
-            yyscanner, OP_ADD_M, mem_offset + 1, NULL);
-
-        // Increment iterations counter.
-        yr_parser_emit_with_arg(
-            yyscanner, OP_INCR_M, mem_offset + 2, NULL);
-
-        // If next string is not undefined, go back to the
-        // beginning of the loop.
-        yr_parser_emit_with_arg_reloc(
-            yyscanner,
-            OP_JNUNDEF,
-            PTR_TO_UINT64(
-                compiler->loop_address[compiler->loop_depth]),
-            NULL);
-
-        // Pop end-of-list marker.
-        yr_parser_emit(yyscanner, OP_POP, NULL);
-
-        // At this point the loop quantifier (any, all, 1, 2,..)
-        // is at top of the stack. Check if the quantifier is
-        // undefined (meaning "all") and replace it with the
-        // iterations counter in that case.
-        yr_parser_emit_with_arg(
-            yyscanner, OP_SWAPUNDEF, mem_offset + 2, NULL);
-
-        // Compare the loop quantifier with the number of
-        // expressions evaluating to TRUE.
-        yr_parser_emit_with_arg(
-            yyscanner, OP_PUSH_M, mem_offset + 1, NULL);
-
-        yr_parser_emit(yyscanner, OP_LE, NULL);
-        (yyval.expression_type) = EXPRESSION_TYPE_BOOLEAN;
-
-      }
-#line 2812 "yara_grammar.c"
-    break;
-
-  case 61:
-#line 1202 "yara_grammar.y"
-      {
-        yr_parser_emit(yyscanner, OP_OF, NULL);
-
-        (yyval.expression_type) = EXPRESSION_TYPE_BOOLEAN;
-      }
-#line 2822 "yara_grammar.c"
-    break;
-
-  case 62:
-#line 1208 "yara_grammar.y"
-      {
-        yr_parser_emit(yyscanner, OP_NOT, NULL);
-
-        (yyval.expression_type) = EXPRESSION_TYPE_BOOLEAN;
-      }
-#line 2832 "yara_grammar.c"
-    break;
-
-  case 63:
-#line 1214 "yara_grammar.y"
-      {
-        yr_parser_emit(yyscanner, OP_AND, NULL);
-
-        (yyval.expression_type) = EXPRESSION_TYPE_BOOLEAN;
-      }
-#line 2842 "yara_grammar.c"
-    break;
-
-  case 64:
-#line 1220 "yara_grammar.y"
-      {
-        CHECK_TYPE((yyvsp[-2].expression_type), EXPRESSION_TYPE_BOOLEAN, "or");
-
-        yr_parser_emit(yyscanner, OP_OR, NULL);
-
-        (yyval.expression_type) = EXPRESSION_TYPE_BOOLEAN;
-      }
-#line 2854 "yara_grammar.c"
-    break;
-
-  case 65:
-#line 1228 "yara_grammar.y"
-      {
-        CHECK_TYPE((yyvsp[-2].expression_type), EXPRESSION_TYPE_INTEGER, "<");
-        CHECK_TYPE((yyvsp[0].expression_type), EXPRESSION_TYPE_INTEGER, "<");
-
-        yr_parser_emit(yyscanner, OP_LT, NULL);
-
-        (yyval.expression_type) = EXPRESSION_TYPE_BOOLEAN;
-      }
-#line 2867 "yara_grammar.c"
-    break;
-
-  case 66:
-#line 1237 "yara_grammar.y"
-      {
-        CHECK_TYPE((yyvsp[-2].expression_type), EXPRESSION_TYPE_INTEGER, ">");
-        CHECK_TYPE((yyvsp[0].expression_type), EXPRESSION_TYPE_INTEGER, ">");
-
-        yr_parser_emit(yyscanner, OP_GT, NULL);
-
-        (yyval.expression_type) = EXPRESSION_TYPE_BOOLEAN;
-      }
-#line 2880 "yara_grammar.c"
-    break;
-
-  case 67:
-#line 1246 "yara_grammar.y"
-      {
-        CHECK_TYPE((yyvsp[-2].expression_type), EXPRESSION_TYPE_INTEGER, "<=");
-        CHECK_TYPE((yyvsp[0].expression_type), EXPRESSION_TYPE_INTEGER, "<=");
-
-        yr_parser_emit(yyscanner, OP_LE, NULL);
-
-        (yyval.expression_type) = EXPRESSION_TYPE_BOOLEAN;
-      }
-#line 2893 "yara_grammar.c"
-    break;
-
-  case 68:
-#line 1255 "yara_grammar.y"
-      {
-        CHECK_TYPE((yyvsp[-2].expression_type), EXPRESSION_TYPE_INTEGER, ">=");
-        CHECK_TYPE((yyvsp[0].expression_type), EXPRESSION_TYPE_INTEGER, ">=");
-
-        yr_parser_emit(yyscanner, OP_GE, NULL);
-
-        (yyval.expression_type) = EXPRESSION_TYPE_BOOLEAN;
-      }
-#line 2906 "yara_grammar.c"
-    break;
-
-  case 69:
-#line 1264 "yara_grammar.y"
-      {
-        if ((yyvsp[-2].expression_type) != (yyvsp[0].expression_type))
-        {
-          yr_compiler_set_error_extra_info(
-              compiler, "mismatching types for == operator");
-          compiler->last_result = ERROR_WRONG_TYPE;
-        }
-        else if ((yyvsp[-2].expression_type) == EXPRESSION_TYPE_STRING)
-        {
-          compiler->last_result = yr_parser_emit(
-              yyscanner,
-              OP_SZ_EQ,
-              NULL);
-        }
-        else
-        {
-          compiler->last_result = yr_parser_emit(
-              yyscanner,
-              OP_EQ,
-              NULL);
-        }
-
-        ERROR_IF(compiler->last_result != ERROR_SUCCESS);
-
-        (yyval.expression_type) = EXPRESSION_TYPE_BOOLEAN;
-      }
-#line 2937 "yara_grammar.c"
-    break;
-
-  case 70:
+        case 74: /* expression: boolean_expression _AND_ boolean_expression  */
 #line 1291 "yara_grammar.y"
-      {
-        if ((yyvsp[-2].expression_type) != (yyvsp[0].expression_type))
         {
-          yr_compiler_set_error_extra_info(
-              compiler, "mismatching types for == operator");
-          compiler->last_result = ERROR_WRONG_TYPE;
+            yr_parser_emit(yyscanner, OP_AND, NULL);
+
+            (yyval.expression_type) = EXPRESSION_TYPE_BOOLEAN;
         }
-        else if ((yyvsp[-2].expression_type) == EXPRESSION_TYPE_STRING)
+#line 2765 "yara_grammar.c"
+        break;
+
+        case 75: /* expression: boolean_expression _OR_ boolean_expression  */
+#line 1297 "yara_grammar.y"
         {
-          compiler->last_result = yr_parser_emit(
-              yyscanner,
-              OP_SZ_EQ,
-              NULL);
+            CHECK_TYPE((yyvsp[-2].expression_type), EXPRESSION_TYPE_BOOLEAN, "or");
+
+            yr_parser_emit(yyscanner, OP_OR, NULL);
+
+            (yyval.expression_type) = EXPRESSION_TYPE_BOOLEAN;
         }
-        else
+#line 2777 "yara_grammar.c"
+        break;
+
+        case 76: /* expression: primary_expression _LT_ primary_expression  */
+#line 1305 "yara_grammar.y"
         {
-          compiler->last_result = yr_parser_emit(
-              yyscanner,
-              OP_EQ,
-              NULL);
+            CHECK_TYPE((yyvsp[-2].expression_type), EXPRESSION_TYPE_INTEGER, "<");
+            CHECK_TYPE((yyvsp[0].expression_type), EXPRESSION_TYPE_INTEGER, "<");
+
+            yr_parser_emit(yyscanner, OP_LT, NULL);
+
+            (yyval.expression_type) = EXPRESSION_TYPE_BOOLEAN;
         }
+#line 2790 "yara_grammar.c"
+        break;
 
-        ERROR_IF(compiler->last_result != ERROR_SUCCESS);
-
-        (yyval.expression_type) = EXPRESSION_TYPE_BOOLEAN;
-      }
-#line 2968 "yara_grammar.c"
-    break;
-
-  case 71:
-#line 1318 "yara_grammar.y"
-      {
-        if ((yyvsp[-2].expression_type) != (yyvsp[0].expression_type))
+        case 77: /* expression: primary_expression _GT_ primary_expression  */
+#line 1314 "yara_grammar.y"
         {
-          yr_compiler_set_error_extra_info(
-              compiler, "mismatching types for != operator");
-          compiler->last_result = ERROR_WRONG_TYPE;
+            CHECK_TYPE((yyvsp[-2].expression_type), EXPRESSION_TYPE_INTEGER, ">");
+            CHECK_TYPE((yyvsp[0].expression_type), EXPRESSION_TYPE_INTEGER, ">");
+
+            yr_parser_emit(yyscanner, OP_GT, NULL);
+
+            (yyval.expression_type) = EXPRESSION_TYPE_BOOLEAN;
         }
-        else if ((yyvsp[-2].expression_type) == EXPRESSION_TYPE_STRING)
+#line 2803 "yara_grammar.c"
+        break;
+
+        case 78: /* expression: primary_expression _LE_ primary_expression  */
+#line 1323 "yara_grammar.y"
         {
-          compiler->last_result = yr_parser_emit(
-              yyscanner,
-              OP_SZ_NEQ,
-              NULL);
+            CHECK_TYPE((yyvsp[-2].expression_type), EXPRESSION_TYPE_INTEGER, "<=");
+            CHECK_TYPE((yyvsp[0].expression_type), EXPRESSION_TYPE_INTEGER, "<=");
+
+            yr_parser_emit(yyscanner, OP_LE, NULL);
+
+            (yyval.expression_type) = EXPRESSION_TYPE_BOOLEAN;
         }
-        else
+#line 2816 "yara_grammar.c"
+        break;
+
+        case 79: /* expression: primary_expression _GE_ primary_expression  */
+#line 1332 "yara_grammar.y"
         {
-          compiler->last_result = yr_parser_emit(
-              yyscanner,
-              OP_NEQ,
-              NULL);
+            CHECK_TYPE((yyvsp[-2].expression_type), EXPRESSION_TYPE_INTEGER, ">=");
+            CHECK_TYPE((yyvsp[0].expression_type), EXPRESSION_TYPE_INTEGER, ">=");
+
+            yr_parser_emit(yyscanner, OP_GE, NULL);
+
+            (yyval.expression_type) = EXPRESSION_TYPE_BOOLEAN;
         }
+#line 2829 "yara_grammar.c"
+        break;
 
-        ERROR_IF(compiler->last_result != ERROR_SUCCESS);
-
-        (yyval.expression_type) = EXPRESSION_TYPE_BOOLEAN;
-      }
-#line 2999 "yara_grammar.c"
-    break;
-
-  case 72:
-#line 1345 "yara_grammar.y"
-      {
-        (yyval.expression_type) = (yyvsp[0].expression_type);
-      }
-#line 3007 "yara_grammar.c"
-    break;
-
-  case 73:
-#line 1349 "yara_grammar.y"
-      {
-        (yyval.expression_type) = (yyvsp[-1].expression_type);
-      }
-#line 3015 "yara_grammar.c"
-    break;
-
-  case 74:
-#line 1356 "yara_grammar.y"
-                                   { (yyval.integer) = INTEGER_SET_ENUMERATION; }
-#line 3021 "yara_grammar.c"
-    break;
-
-  case 75:
-#line 1357 "yara_grammar.y"
-                                   { (yyval.integer) = INTEGER_SET_RANGE; }
-#line 3027 "yara_grammar.c"
-    break;
-
-  case 76:
-#line 1363 "yara_grammar.y"
-      {
-        if ((yyvsp[-4].expression_type) != EXPRESSION_TYPE_INTEGER)
+        case 80: /* expression: primary_expression _EQ_ primary_expression  */
+#line 1341 "yara_grammar.y"
         {
-          yr_compiler_set_error_extra_info(
-              compiler, "wrong type for range's lower bound");
-          compiler->last_result = ERROR_WRONG_TYPE;
-        }
+            if ((yyvsp[-2].expression_type) != (yyvsp[0].expression_type)) {
+                yr_compiler_set_error_extra_info(
+                    compiler, "mismatching types for == operator");
+                compiler->last_result = ERROR_WRONG_TYPE;
+            } else if ((yyvsp[-2].expression_type) == EXPRESSION_TYPE_STRING) {
+                compiler->last_result = yr_parser_emit(
+                    yyscanner,
+                    OP_SZ_EQ,
+                    NULL);
+            } else {
+                compiler->last_result = yr_parser_emit(
+                    yyscanner,
+                    OP_EQ,
+                    NULL);
+            }
 
-        if ((yyvsp[-1].expression_type) != EXPRESSION_TYPE_INTEGER)
+            ERROR_IF(compiler->last_result != ERROR_SUCCESS);
+
+            (yyval.expression_type) = EXPRESSION_TYPE_BOOLEAN;
+        }
+#line 2860 "yara_grammar.c"
+        break;
+
+        case 81: /* expression: primary_expression _IS_ primary_expression  */
+#line 1368 "yara_grammar.y"
         {
-          yr_compiler_set_error_extra_info(
-              compiler, "wrong type for range's upper bound");
-          compiler->last_result = ERROR_WRONG_TYPE;
+            if ((yyvsp[-2].expression_type) != (yyvsp[0].expression_type)) {
+                yr_compiler_set_error_extra_info(
+                    compiler, "mismatching types for == operator");
+                compiler->last_result = ERROR_WRONG_TYPE;
+            } else if ((yyvsp[-2].expression_type) == EXPRESSION_TYPE_STRING) {
+                compiler->last_result = yr_parser_emit(
+                    yyscanner,
+                    OP_SZ_EQ,
+                    NULL);
+            } else {
+                compiler->last_result = yr_parser_emit(
+                    yyscanner,
+                    OP_EQ,
+                    NULL);
+            }
+
+            ERROR_IF(compiler->last_result != ERROR_SUCCESS);
+
+            (yyval.expression_type) = EXPRESSION_TYPE_BOOLEAN;
         }
+#line 2891 "yara_grammar.c"
+        break;
 
-        ERROR_IF(compiler->last_result != ERROR_SUCCESS);
-      }
-#line 3049 "yara_grammar.c"
-    break;
-
-  case 77:
-#line 1385 "yara_grammar.y"
-      {
-        if ((yyvsp[0].expression_type) != EXPRESSION_TYPE_INTEGER)
+        case 82: /* expression: primary_expression _NEQ_ primary_expression  */
+#line 1395 "yara_grammar.y"
         {
-          yr_compiler_set_error_extra_info(
-              compiler, "wrong type for enumeration item");
-          compiler->last_result = ERROR_WRONG_TYPE;
+            if ((yyvsp[-2].expression_type) != (yyvsp[0].expression_type)) {
+                yr_compiler_set_error_extra_info(
+                    compiler, "mismatching types for != operator");
+                compiler->last_result = ERROR_WRONG_TYPE;
+            } else if ((yyvsp[-2].expression_type) == EXPRESSION_TYPE_STRING) {
+                compiler->last_result = yr_parser_emit(
+                    yyscanner,
+                    OP_SZ_NEQ,
+                    NULL);
+            } else {
+                compiler->last_result = yr_parser_emit(
+                    yyscanner,
+                    OP_NEQ,
+                    NULL);
+            }
 
+            ERROR_IF(compiler->last_result != ERROR_SUCCESS);
+
+            (yyval.expression_type) = EXPRESSION_TYPE_BOOLEAN;
         }
+#line 2922 "yara_grammar.c"
+        break;
 
-        ERROR_IF(compiler->last_result != ERROR_SUCCESS);
-      }
-#line 3065 "yara_grammar.c"
-    break;
-
-  case 78:
-#line 1397 "yara_grammar.y"
-      {
-        if ((yyvsp[0].expression_type) != EXPRESSION_TYPE_INTEGER)
+        case 83: /* expression: primary_expression  */
+#line 1422 "yara_grammar.y"
         {
-          yr_compiler_set_error_extra_info(
-              compiler, "wrong type for enumeration item");
-          compiler->last_result = ERROR_WRONG_TYPE;
+            (yyval.expression_type) = (yyvsp[0].expression_type);
         }
+#line 2930 "yara_grammar.c"
+        break;
 
-        ERROR_IF(compiler->last_result != ERROR_SUCCESS);
-      }
-#line 3080 "yara_grammar.c"
-    break;
+        case 84: /* expression: '(' expression ')'  */
+#line 1426 "yara_grammar.y"
+        {
+            (yyval.expression_type) = (yyvsp[-1].expression_type);
+        }
+#line 2938 "yara_grammar.c"
+        break;
 
-  case 79:
-#line 1412 "yara_grammar.y"
-      {
-        // Push end-of-list marker
-        yr_parser_emit_with_arg(yyscanner, OP_PUSH, UNDEFINED, NULL);
-      }
-#line 3089 "yara_grammar.c"
-    break;
+        case 85: /* integer_set: '(' integer_enumeration ')'  */
+#line 1433 "yara_grammar.y"
+        {
+            (yyval.integer) = INTEGER_SET_ENUMERATION;
+        }
+#line 2944 "yara_grammar.c"
+        break;
 
-  case 81:
-#line 1418 "yara_grammar.y"
-      {
-        yr_parser_emit_with_arg(yyscanner, OP_PUSH, UNDEFINED, NULL);
-        yr_parser_emit_pushes_for_strings(yyscanner, "$*");
+        case 86: /* integer_set: range  */
+#line 1434 "yara_grammar.y"
+        {
+            (yyval.integer) = INTEGER_SET_RANGE;
+        }
+#line 2950 "yara_grammar.c"
+        break;
+
+        case 87: /* range: '(' primary_expression '.' '.' primary_expression ')'  */
+#line 1440 "yara_grammar.y"
+        {
+            if ((yyvsp[-4].expression_type) != EXPRESSION_TYPE_INTEGER) {
+                yr_compiler_set_error_extra_info(
+                    compiler, "wrong type for range's lower bound");
+                compiler->last_result = ERROR_WRONG_TYPE;
+            }
+
+            if ((yyvsp[-1].expression_type) != EXPRESSION_TYPE_INTEGER) {
+                yr_compiler_set_error_extra_info(
+                    compiler, "wrong type for range's upper bound");
+                compiler->last_result = ERROR_WRONG_TYPE;
+            }
+
+            ERROR_IF(compiler->last_result != ERROR_SUCCESS);
+        }
+#line 2972 "yara_grammar.c"
+        break;
+
+        case 88: /* integer_enumeration: primary_expression  */
+#line 1462 "yara_grammar.y"
+        {
+            if ((yyvsp[0].expression_type) != EXPRESSION_TYPE_INTEGER) {
+                yr_compiler_set_error_extra_info(
+                    compiler, "wrong type for enumeration item");
+                compiler->last_result = ERROR_WRONG_TYPE;
+            }
+
+            ERROR_IF(compiler->last_result != ERROR_SUCCESS);
+        }
+#line 2988 "yara_grammar.c"
+        break;
+
+        case 89: /* integer_enumeration: integer_enumeration ',' primary_expression  */
+#line 1474 "yara_grammar.y"
+        {
+            if ((yyvsp[0].expression_type) != EXPRESSION_TYPE_INTEGER) {
+                yr_compiler_set_error_extra_info(
+                    compiler, "wrong type for enumeration item");
+                compiler->last_result = ERROR_WRONG_TYPE;
+            }
+
+            ERROR_IF(compiler->last_result != ERROR_SUCCESS);
+        }
+#line 3003 "yara_grammar.c"
+        break;
+
+        case 90: /* $@5: %empty  */
+#line 1489 "yara_grammar.y"
+        {
+            // Push end-of-list marker
+            yr_parser_emit_with_arg(yyscanner, OP_PUSH, UNDEFINED, NULL);
+        }
+#line 3012 "yara_grammar.c"
+        break;
+
+        case 92: /* string_set: _THEM_  */
+#line 1495 "yara_grammar.y"
+        {
+            yr_parser_emit_with_arg(yyscanner, OP_PUSH, UNDEFINED, NULL);
+            yr_parser_emit_pushes_for_strings(yyscanner, "$*");
 #ifdef YARA_PROTO
-        compiler->current_rule_clflags |= RULE_THEM;
+            compiler->current_rule_clflags |= RULE_THEM;
 #endif
-      }
-#line 3101 "yara_grammar.c"
-    break;
+        }
+#line 3024 "yara_grammar.c"
+        break;
 
-  case 84:
-#line 1436 "yara_grammar.y"
-      {
-        yr_parser_emit_pushes_for_strings(yyscanner, (yyvsp[0].c_string));
-        yr_free((yyvsp[0].c_string));
-      }
-#line 3110 "yara_grammar.c"
-    break;
+        case 95: /* string_enumeration_item: _STRING_IDENTIFIER_  */
+#line 1513 "yara_grammar.y"
+        {
+            yr_parser_emit_pushes_for_strings(yyscanner, (yyvsp[0].c_string));
+            yr_free((yyvsp[0].c_string));
+        }
+#line 3033 "yara_grammar.c"
+        break;
 
-  case 85:
-#line 1441 "yara_grammar.y"
-      {
-        yr_parser_emit_pushes_for_strings(yyscanner, (yyvsp[0].c_string));
-        yr_free((yyvsp[0].c_string));
-      }
-#line 3119 "yara_grammar.c"
-    break;
+        case 96: /* string_enumeration_item: _STRING_IDENTIFIER_WITH_WILDCARD_  */
+#line 1518 "yara_grammar.y"
+        {
+            yr_parser_emit_pushes_for_strings(yyscanner, (yyvsp[0].c_string));
+            yr_free((yyvsp[0].c_string));
+        }
+#line 3042 "yara_grammar.c"
+        break;
 
-  case 87:
-#line 1451 "yara_grammar.y"
-      {
-        yr_parser_emit_with_arg(yyscanner, OP_PUSH, UNDEFINED, NULL);
+        case 98: /* for_expression: _ALL_  */
+#line 1528 "yara_grammar.y"
+        {
+            yr_parser_emit_with_arg(yyscanner, OP_PUSH, UNDEFINED, NULL);
 #ifdef YARA_PROTO
-        compiler->current_rule_clflags |= RULE_ALL;
+            compiler->current_rule_clflags |= RULE_ALL;
 #endif
-      }
-#line 3130 "yara_grammar.c"
-    break;
+        }
+#line 3053 "yara_grammar.c"
+        break;
 
-  case 88:
-#line 1458 "yara_grammar.y"
-      {
-        yr_parser_emit_with_arg(yyscanner, OP_PUSH, 1, NULL);
+        case 99: /* for_expression: _ANY_  */
+#line 1535 "yara_grammar.y"
+        {
+            yr_parser_emit_with_arg(yyscanner, OP_PUSH, 1, NULL);
 #ifdef YARA_PROTO
-        compiler->current_rule_clflags |= RULE_ANY;
+            compiler->current_rule_clflags |= RULE_ANY;
 #endif
-      }
-#line 3141 "yara_grammar.c"
-    break;
+        }
+#line 3064 "yara_grammar.c"
+        break;
 
-  case 89:
-#line 1469 "yara_grammar.y"
-      {
-        (yyval.expression_type) = (yyvsp[-1].expression_type);
-      }
-#line 3149 "yara_grammar.c"
-    break;
+        case 100: /* primary_expression: '(' primary_expression ')'  */
+#line 1546 "yara_grammar.y"
+        {
+            (yyval.expression_type) = (yyvsp[-1].expression_type);
+        }
+#line 3072 "yara_grammar.c"
+        break;
 
-  case 90:
-#line 1473 "yara_grammar.y"
-      {
-        compiler->last_result = yr_parser_emit(
-            yyscanner, OP_FILESIZE, NULL);
+        case 101: /* primary_expression: _FILESIZE_  */
+#line 1550 "yara_grammar.y"
+        {
+            compiler->last_result = yr_parser_emit(
+                yyscanner, OP_FILESIZE, NULL);
 
-        (yyval.expression_type) = EXPRESSION_TYPE_INTEGER;
+            (yyval.expression_type) = EXPRESSION_TYPE_INTEGER;
 
-        ERROR_IF(compiler->last_result != ERROR_SUCCESS);
-      }
-#line 3162 "yara_grammar.c"
-    break;
+            ERROR_IF(compiler->last_result != ERROR_SUCCESS);
+        }
+#line 3085 "yara_grammar.c"
+        break;
 
-  case 91:
-#line 1482 "yara_grammar.y"
-      {
+        case 102: /* primary_expression: _ENTRYPOINT_  */
+#line 1559 "yara_grammar.y"
+        {
 #ifndef YARA_PROTO
-        yywarning(yyscanner,
-            "Using deprecated \"entrypoint\" keyword. Use the \"entry_point\" " "function from PE module instead.");
+            yywarning(yyscanner,
+                      "Using deprecated \"entrypoint\" keyword. Use the \"entry_point\" "
+                      "function from PE module instead.");
 #else
-        compiler->current_rule_clflags |= RULE_EP;
+            compiler->current_rule_clflags |= RULE_EP;
 #endif
-        compiler->last_result = yr_parser_emit(
-            yyscanner, OP_ENTRYPOINT, NULL);
+            compiler->last_result = yr_parser_emit(
+                yyscanner, OP_ENTRYPOINT, NULL);
 
-        ERROR_IF(compiler->last_result != ERROR_SUCCESS);
+            ERROR_IF(compiler->last_result != ERROR_SUCCESS);
 
-        (yyval.expression_type) = EXPRESSION_TYPE_INTEGER;
-      }
-#line 3181 "yara_grammar.c"
-    break;
+            (yyval.expression_type) = EXPRESSION_TYPE_INTEGER;
+        }
+#line 3104 "yara_grammar.c"
+        break;
 
-  case 92:
-#line 1497 "yara_grammar.y"
-      {
-        CHECK_TYPE((yyvsp[-1].expression_type), EXPRESSION_TYPE_INTEGER, "int8");
+        case 103: /* primary_expression: _INT8_ '(' primary_expression ')'  */
+#line 1574 "yara_grammar.y"
+        {
+            CHECK_TYPE((yyvsp[-1].expression_type), EXPRESSION_TYPE_INTEGER, "int8");
 
-        compiler->last_result = yr_parser_emit(
-            yyscanner, OP_INT8, NULL);
+            compiler->last_result = yr_parser_emit(
+                yyscanner, OP_INT8, NULL);
 
-        ERROR_IF(compiler->last_result != ERROR_SUCCESS);
+            ERROR_IF(compiler->last_result != ERROR_SUCCESS);
 
-        (yyval.expression_type) = EXPRESSION_TYPE_INTEGER;
-      }
-#line 3196 "yara_grammar.c"
-    break;
+            (yyval.expression_type) = EXPRESSION_TYPE_INTEGER;
+        }
+#line 3119 "yara_grammar.c"
+        break;
 
-  case 93:
-#line 1508 "yara_grammar.y"
-      {
-        CHECK_TYPE((yyvsp[-1].expression_type), EXPRESSION_TYPE_INTEGER, "int16");
+        case 104: /* primary_expression: _INT16_ '(' primary_expression ')'  */
+#line 1585 "yara_grammar.y"
+        {
+            CHECK_TYPE((yyvsp[-1].expression_type), EXPRESSION_TYPE_INTEGER, "int16");
 
-        compiler->last_result = yr_parser_emit(
-            yyscanner, OP_INT16, NULL);
+            compiler->last_result = yr_parser_emit(
+                yyscanner, OP_INT16, NULL);
 
-        ERROR_IF(compiler->last_result != ERROR_SUCCESS);
+            ERROR_IF(compiler->last_result != ERROR_SUCCESS);
 
-        (yyval.expression_type) = EXPRESSION_TYPE_INTEGER;
-      }
-#line 3211 "yara_grammar.c"
-    break;
+            (yyval.expression_type) = EXPRESSION_TYPE_INTEGER;
+        }
+#line 3134 "yara_grammar.c"
+        break;
 
-  case 94:
-#line 1519 "yara_grammar.y"
-      {
-        CHECK_TYPE((yyvsp[-1].expression_type), EXPRESSION_TYPE_INTEGER, "int32");
+        case 105: /* primary_expression: _INT32_ '(' primary_expression ')'  */
+#line 1596 "yara_grammar.y"
+        {
+            CHECK_TYPE((yyvsp[-1].expression_type), EXPRESSION_TYPE_INTEGER, "int32");
 
-        compiler->last_result = yr_parser_emit(
-            yyscanner, OP_INT32, NULL);
+            compiler->last_result = yr_parser_emit(
+                yyscanner, OP_INT32, NULL);
 
-        ERROR_IF(compiler->last_result != ERROR_SUCCESS);
+            ERROR_IF(compiler->last_result != ERROR_SUCCESS);
 
-        (yyval.expression_type) = EXPRESSION_TYPE_INTEGER;
-      }
-#line 3226 "yara_grammar.c"
-    break;
+            (yyval.expression_type) = EXPRESSION_TYPE_INTEGER;
+        }
+#line 3149 "yara_grammar.c"
+        break;
 
-  case 95:
-#line 1530 "yara_grammar.y"
-      {
-        CHECK_TYPE((yyvsp[-1].expression_type), EXPRESSION_TYPE_INTEGER, "uint8");
+        case 106: /* primary_expression: _UINT8_ '(' primary_expression ')'  */
+#line 1607 "yara_grammar.y"
+        {
+            CHECK_TYPE((yyvsp[-1].expression_type), EXPRESSION_TYPE_INTEGER, "uint8");
 
-        compiler->last_result = yr_parser_emit(
-            yyscanner, OP_UINT8, NULL);
+            compiler->last_result = yr_parser_emit(
+                yyscanner, OP_UINT8, NULL);
 
-        ERROR_IF(compiler->last_result != ERROR_SUCCESS);
+            ERROR_IF(compiler->last_result != ERROR_SUCCESS);
 
-        (yyval.expression_type) = EXPRESSION_TYPE_INTEGER;
-      }
-#line 3241 "yara_grammar.c"
-    break;
+            (yyval.expression_type) = EXPRESSION_TYPE_INTEGER;
+        }
+#line 3164 "yara_grammar.c"
+        break;
 
-  case 96:
-#line 1541 "yara_grammar.y"
-      {
-        CHECK_TYPE((yyvsp[-1].expression_type), EXPRESSION_TYPE_INTEGER, "uint16");
+        case 107: /* primary_expression: _UINT16_ '(' primary_expression ')'  */
+#line 1618 "yara_grammar.y"
+        {
+            CHECK_TYPE((yyvsp[-1].expression_type), EXPRESSION_TYPE_INTEGER, "uint16");
 
-        compiler->last_result = yr_parser_emit(
-            yyscanner, OP_UINT16, NULL);
+            compiler->last_result = yr_parser_emit(
+                yyscanner, OP_UINT16, NULL);
 
-        ERROR_IF(compiler->last_result != ERROR_SUCCESS);
+            ERROR_IF(compiler->last_result != ERROR_SUCCESS);
 
-        (yyval.expression_type) = EXPRESSION_TYPE_INTEGER;
-      }
-#line 3256 "yara_grammar.c"
-    break;
+            (yyval.expression_type) = EXPRESSION_TYPE_INTEGER;
+        }
+#line 3179 "yara_grammar.c"
+        break;
 
-  case 97:
-#line 1552 "yara_grammar.y"
-      {
-        CHECK_TYPE((yyvsp[-1].expression_type), EXPRESSION_TYPE_INTEGER, "uint32");
+        case 108: /* primary_expression: _UINT32_ '(' primary_expression ')'  */
+#line 1629 "yara_grammar.y"
+        {
+            CHECK_TYPE((yyvsp[-1].expression_type), EXPRESSION_TYPE_INTEGER, "uint32");
 
-        compiler->last_result = yr_parser_emit(
-            yyscanner, OP_UINT32, NULL);
+            compiler->last_result = yr_parser_emit(
+                yyscanner, OP_UINT32, NULL);
 
-        ERROR_IF(compiler->last_result != ERROR_SUCCESS);
+            ERROR_IF(compiler->last_result != ERROR_SUCCESS);
 
-        (yyval.expression_type) = EXPRESSION_TYPE_INTEGER;
-      }
-#line 3271 "yara_grammar.c"
-    break;
+            (yyval.expression_type) = EXPRESSION_TYPE_INTEGER;
+        }
+#line 3194 "yara_grammar.c"
+        break;
 
-  case 98:
-#line 1563 "yara_grammar.y"
-      {
-        compiler->last_result = yr_parser_emit_with_arg(
-            yyscanner, OP_PUSH, (yyvsp[0].integer), NULL);
+        case 109: /* primary_expression: _NUMBER_  */
+#line 1640 "yara_grammar.y"
+        {
+            compiler->last_result = yr_parser_emit_with_arg(
+                yyscanner, OP_PUSH, (yyvsp[0].integer), NULL);
 
-        ERROR_IF(compiler->last_result != ERROR_SUCCESS);
+            ERROR_IF(compiler->last_result != ERROR_SUCCESS);
 
-        (yyval.expression_type) = EXPRESSION_TYPE_INTEGER;
-      }
-#line 3284 "yara_grammar.c"
-    break;
+            (yyval.expression_type) = EXPRESSION_TYPE_INTEGER;
+        }
+#line 3207 "yara_grammar.c"
+        break;
 
-  case 99:
-#line 1572 "yara_grammar.y"
-      {
-#if REAL_YARA
-        SIZED_STRING* sized_string = (yyvsp[0].sized_string);
-#endif
-        char* string = NULL;
-
-#if REAL_YARA
-        compiler->last_result = yr_arena_write_string(
-            compiler->sz_arena,
-            sized_string->c_string,
-            &string);
-#endif
-
-        yr_free((yyvsp[0].sized_string));
-
-        if (compiler->last_result == ERROR_SUCCESS)
-          compiler->last_result = yr_parser_emit_with_arg_reloc(
-              yyscanner,
-              OP_PUSH,
-              PTR_TO_UINT64(string),
-              NULL);
-
-        ERROR_IF(compiler->last_result != ERROR_SUCCESS);
-
-        (yyval.expression_type) = EXPRESSION_TYPE_STRING;
-      }
-#line 3315 "yara_grammar.c"
-    break;
-
-  case 100:
-#line 1599 "yara_grammar.y"
-      {
-        compiler->last_result = yr_parser_reduce_string_identifier(
-            yyscanner,
-            (yyvsp[0].c_string),
-            OP_STR_COUNT);
-
-        yr_free((yyvsp[0].c_string));
-
-        ERROR_IF(compiler->last_result != ERROR_SUCCESS);
-
-        (yyval.expression_type) = EXPRESSION_TYPE_INTEGER;
-      }
-#line 3332 "yara_grammar.c"
-    break;
-
-  case 101:
-#line 1612 "yara_grammar.y"
-      {
-        compiler->last_result = yr_parser_reduce_string_identifier(
-            yyscanner,
-            (yyvsp[-3].c_string),
-            OP_STR_OFFSET);
-
-        yr_free((yyvsp[-3].c_string));
-
-        ERROR_IF(compiler->last_result != ERROR_SUCCESS);
-
-        compiler->current_rule_clflags |= RULE_OFFSETS;
-
-        (yyval.expression_type) = EXPRESSION_TYPE_INTEGER;
-      }
-#line 3351 "yara_grammar.c"
-    break;
-
-  case 102:
-#line 1627 "yara_grammar.y"
-      {
-        compiler->last_result = yr_parser_emit_with_arg(
-            yyscanner,
-            OP_PUSH,
-            1,
-            NULL);
-
-        if (compiler->last_result == ERROR_SUCCESS)
-          compiler->last_result = yr_parser_reduce_string_identifier(
-              yyscanner,
-              (yyvsp[0].c_string),
-              OP_STR_OFFSET);
-
-        yr_free((yyvsp[0].c_string));
-
-        ERROR_IF(compiler->last_result != ERROR_SUCCESS);
-
-        compiler->current_rule_clflags |= RULE_OFFSETS;
-
-        (yyval.expression_type) = EXPRESSION_TYPE_INTEGER;
-      }
-#line 3377 "yara_grammar.c"
-    break;
-
-  case 103:
+        case 110: /* primary_expression: _TEXT_STRING_  */
 #line 1649 "yara_grammar.y"
-      {
-        if ((yyvsp[0].object) == (YR_OBJECT*) -1)  // loop identifier
         {
-          (yyval.expression_type) = EXPRESSION_TYPE_INTEGER;
+#if REAL_YARA
+            SIZED_STRING* sized_string = (yyvsp[0].sized_string);
+#endif
+            char* string = NULL;
+
+#if REAL_YARA
+            compiler->last_result = yr_arena_write_string(
+                compiler->sz_arena,
+                sized_string->c_string,
+                &string);
+#endif
+
+            yr_free((yyvsp[0].sized_string));
+
+            if (compiler->last_result == ERROR_SUCCESS)
+                compiler->last_result = yr_parser_emit_with_arg_reloc(
+                    yyscanner,
+                    OP_PUSH,
+                    PTR_TO_UINT64(string),
+                    NULL);
+
+            ERROR_IF(compiler->last_result != ERROR_SUCCESS);
+
+            (yyval.expression_type) = EXPRESSION_TYPE_STRING;
         }
-        else if ((yyvsp[0].object) == (YR_OBJECT*) -2)  // rule identifier
+#line 3238 "yara_grammar.c"
+        break;
+
+        case 111: /* primary_expression: _STRING_COUNT_  */
+#line 1676 "yara_grammar.y"
         {
-          (yyval.expression_type) = EXPRESSION_TYPE_BOOLEAN;
+            compiler->last_result = yr_parser_reduce_string_identifier(
+                yyscanner,
+                (yyvsp[0].c_string),
+                OP_STR_COUNT);
+
+            yr_free((yyvsp[0].c_string));
+
+            ERROR_IF(compiler->last_result != ERROR_SUCCESS);
+
+            (yyval.expression_type) = EXPRESSION_TYPE_INTEGER;
         }
-        else if ((yyvsp[0].object) != NULL)
+#line 3255 "yara_grammar.c"
+        break;
+
+        case 112: /* primary_expression: _STRING_OFFSET_ '[' primary_expression ']'  */
+#line 1689 "yara_grammar.y"
         {
-          compiler->last_result = yr_parser_emit(
-              yyscanner, OP_OBJ_VALUE, NULL);
+            compiler->last_result = yr_parser_reduce_string_identifier(
+                yyscanner,
+                (yyvsp[-3].c_string),
+                OP_STR_OFFSET);
 
-          switch((yyvsp[0].object)->type)
-          {
-            case OBJECT_TYPE_INTEGER:
-              (yyval.expression_type) = EXPRESSION_TYPE_INTEGER;
-              break;
-            case OBJECT_TYPE_STRING:
-              (yyval.expression_type) = EXPRESSION_TYPE_STRING;
-              break;
-            default:
-              assert(FALSE);
-          }
+            yr_free((yyvsp[-3].c_string));
+
+            ERROR_IF(compiler->last_result != ERROR_SUCCESS);
+
+            compiler->current_rule_clflags |= RULE_OFFSETS;
+
+            (yyval.expression_type) = EXPRESSION_TYPE_INTEGER;
         }
-        else
+#line 3274 "yara_grammar.c"
+        break;
+
+        case 113: /* primary_expression: _STRING_OFFSET_  */
+#line 1704 "yara_grammar.y"
         {
-          yr_compiler_set_error_extra_info(compiler, (yyvsp[0].object)->identifier);
-          compiler->last_result = ERROR_WRONG_TYPE;
+            compiler->last_result = yr_parser_emit_with_arg(
+                yyscanner,
+                OP_PUSH,
+                1,
+                NULL);
+
+            if (compiler->last_result == ERROR_SUCCESS)
+                compiler->last_result = yr_parser_reduce_string_identifier(
+                    yyscanner,
+                    (yyvsp[0].c_string),
+                    OP_STR_OFFSET);
+
+            yr_free((yyvsp[0].c_string));
+
+            ERROR_IF(compiler->last_result != ERROR_SUCCESS);
+
+            compiler->current_rule_clflags |= RULE_OFFSETS;
+
+            (yyval.expression_type) = EXPRESSION_TYPE_INTEGER;
         }
+#line 3300 "yara_grammar.c"
+        break;
 
-        ERROR_IF(compiler->last_result != ERROR_SUCCESS);
-      }
-#line 3416 "yara_grammar.c"
-    break;
+        case 114: /* primary_expression: identifier  */
+#line 1726 "yara_grammar.y"
+        {
+            if ((yyvsp[0].object) == (YR_OBJECT*)-1) // loop identifier
+            {
+                (yyval.expression_type) = EXPRESSION_TYPE_INTEGER;
+            } else if ((yyvsp[0].object) == (YR_OBJECT*)-2) // rule identifier
+            {
+                (yyval.expression_type) = EXPRESSION_TYPE_BOOLEAN;
+            } else if ((yyvsp[0].object) != NULL) {
+                compiler->last_result = yr_parser_emit(
+                    yyscanner, OP_OBJ_VALUE, NULL);
 
-  case 104:
-#line 1684 "yara_grammar.y"
-      {
-        CHECK_TYPE((yyvsp[-2].expression_type), EXPRESSION_TYPE_INTEGER, "+");
-        CHECK_TYPE((yyvsp[0].expression_type), EXPRESSION_TYPE_INTEGER, "+");
+                switch ((yyvsp[0].object)->type) {
+                    case OBJECT_TYPE_INTEGER:
+                        (yyval.expression_type) = EXPRESSION_TYPE_INTEGER;
+                        break;
+                    case OBJECT_TYPE_STRING:
+                        (yyval.expression_type) = EXPRESSION_TYPE_STRING;
+                        break;
+                    default:
+                        assert(FALSE);
+                }
+            } else {
+                yr_compiler_set_error_extra_info(compiler, (yyvsp[0].object)->identifier);
+                compiler->last_result = ERROR_WRONG_TYPE;
+            }
 
-        yr_parser_emit(yyscanner, OP_ADD, NULL);
+            ERROR_IF(compiler->last_result != ERROR_SUCCESS);
+        }
+#line 3339 "yara_grammar.c"
+        break;
 
-        (yyval.expression_type) = EXPRESSION_TYPE_INTEGER;
-      }
-#line 3429 "yara_grammar.c"
-    break;
+        case 115: /* primary_expression: primary_expression '+' primary_expression  */
+#line 1761 "yara_grammar.y"
+        {
+            CHECK_TYPE((yyvsp[-2].expression_type), EXPRESSION_TYPE_INTEGER, "+");
+            CHECK_TYPE((yyvsp[0].expression_type), EXPRESSION_TYPE_INTEGER, "+");
 
-  case 105:
-#line 1693 "yara_grammar.y"
-      {
-        CHECK_TYPE((yyvsp[-2].expression_type), EXPRESSION_TYPE_INTEGER, "-");
-        CHECK_TYPE((yyvsp[0].expression_type), EXPRESSION_TYPE_INTEGER, "-");
+            yr_parser_emit(yyscanner, OP_ADD, NULL);
 
-        yr_parser_emit(yyscanner, OP_SUB, NULL);
+            (yyval.expression_type) = EXPRESSION_TYPE_INTEGER;
+        }
+#line 3352 "yara_grammar.c"
+        break;
 
-        (yyval.expression_type) = EXPRESSION_TYPE_INTEGER;
-      }
-#line 3442 "yara_grammar.c"
-    break;
+        case 116: /* primary_expression: primary_expression '-' primary_expression  */
+#line 1770 "yara_grammar.y"
+        {
+            CHECK_TYPE((yyvsp[-2].expression_type), EXPRESSION_TYPE_INTEGER, "-");
+            CHECK_TYPE((yyvsp[0].expression_type), EXPRESSION_TYPE_INTEGER, "-");
 
-  case 106:
-#line 1702 "yara_grammar.y"
-      {
-        CHECK_TYPE((yyvsp[-2].expression_type), EXPRESSION_TYPE_INTEGER, "*");
-        CHECK_TYPE((yyvsp[0].expression_type), EXPRESSION_TYPE_INTEGER, "*");
+            yr_parser_emit(yyscanner, OP_SUB, NULL);
 
-        yr_parser_emit(yyscanner, OP_MUL, NULL);
+            (yyval.expression_type) = EXPRESSION_TYPE_INTEGER;
+        }
+#line 3365 "yara_grammar.c"
+        break;
 
-        (yyval.expression_type) = EXPRESSION_TYPE_INTEGER;
-      }
+        case 117: /* primary_expression: primary_expression '*' primary_expression  */
+#line 1779 "yara_grammar.y"
+        {
+            CHECK_TYPE((yyvsp[-2].expression_type), EXPRESSION_TYPE_INTEGER, "*");
+            CHECK_TYPE((yyvsp[0].expression_type), EXPRESSION_TYPE_INTEGER, "*");
+
+            yr_parser_emit(yyscanner, OP_MUL, NULL);
+
+            (yyval.expression_type) = EXPRESSION_TYPE_INTEGER;
+        }
+#line 3378 "yara_grammar.c"
+        break;
+
+        case 118: /* primary_expression: primary_expression '\\' primary_expression  */
+#line 1788 "yara_grammar.y"
+        {
+            CHECK_TYPE((yyvsp[-2].expression_type), EXPRESSION_TYPE_INTEGER, "\\");
+            CHECK_TYPE((yyvsp[0].expression_type), EXPRESSION_TYPE_INTEGER, "\\");
+
+            yr_parser_emit(yyscanner, OP_DIV, NULL);
+
+            (yyval.expression_type) = EXPRESSION_TYPE_INTEGER;
+        }
+#line 3391 "yara_grammar.c"
+        break;
+
+        case 119: /* primary_expression: primary_expression '%' primary_expression  */
+#line 1797 "yara_grammar.y"
+        {
+            CHECK_TYPE((yyvsp[-2].expression_type), EXPRESSION_TYPE_INTEGER, "%");
+            CHECK_TYPE((yyvsp[0].expression_type), EXPRESSION_TYPE_INTEGER, "%");
+
+            yr_parser_emit(yyscanner, OP_MOD, NULL);
+
+            (yyval.expression_type) = EXPRESSION_TYPE_INTEGER;
+        }
+#line 3404 "yara_grammar.c"
+        break;
+
+        case 120: /* primary_expression: primary_expression '^' primary_expression  */
+#line 1806 "yara_grammar.y"
+        {
+            CHECK_TYPE((yyvsp[-2].expression_type), EXPRESSION_TYPE_INTEGER, "^");
+            CHECK_TYPE((yyvsp[0].expression_type), EXPRESSION_TYPE_INTEGER, "^");
+
+            yr_parser_emit(yyscanner, OP_XOR, NULL);
+
+            (yyval.expression_type) = EXPRESSION_TYPE_INTEGER;
+        }
+#line 3417 "yara_grammar.c"
+        break;
+
+        case 121: /* primary_expression: primary_expression '&' primary_expression  */
+#line 1815 "yara_grammar.y"
+        {
+            CHECK_TYPE((yyvsp[-2].expression_type), EXPRESSION_TYPE_INTEGER, "^");
+            CHECK_TYPE((yyvsp[0].expression_type), EXPRESSION_TYPE_INTEGER, "^");
+
+            yr_parser_emit(yyscanner, OP_AND, NULL);
+
+            (yyval.expression_type) = EXPRESSION_TYPE_INTEGER;
+        }
+#line 3430 "yara_grammar.c"
+        break;
+
+        case 122: /* primary_expression: primary_expression '|' primary_expression  */
+#line 1824 "yara_grammar.y"
+        {
+            CHECK_TYPE((yyvsp[-2].expression_type), EXPRESSION_TYPE_INTEGER, "|");
+            CHECK_TYPE((yyvsp[0].expression_type), EXPRESSION_TYPE_INTEGER, "|");
+
+            yr_parser_emit(yyscanner, OP_OR, NULL);
+
+            (yyval.expression_type) = EXPRESSION_TYPE_INTEGER;
+        }
+#line 3443 "yara_grammar.c"
+        break;
+
+        case 123: /* primary_expression: '~' primary_expression  */
+#line 1833 "yara_grammar.y"
+        {
+            CHECK_TYPE((yyvsp[0].expression_type), EXPRESSION_TYPE_INTEGER, "~");
+
+            yr_parser_emit(yyscanner, OP_NEG, NULL);
+
+            (yyval.expression_type) = EXPRESSION_TYPE_INTEGER;
+        }
 #line 3455 "yara_grammar.c"
-    break;
+        break;
 
-  case 107:
-#line 1711 "yara_grammar.y"
-      {
-        CHECK_TYPE((yyvsp[-2].expression_type), EXPRESSION_TYPE_INTEGER, "\\");
-        CHECK_TYPE((yyvsp[0].expression_type), EXPRESSION_TYPE_INTEGER, "\\");
+        case 124: /* primary_expression: primary_expression _SHIFT_LEFT_ primary_expression  */
+#line 1841 "yara_grammar.y"
+        {
+            CHECK_TYPE((yyvsp[-2].expression_type), EXPRESSION_TYPE_INTEGER, "<<");
+            CHECK_TYPE((yyvsp[0].expression_type), EXPRESSION_TYPE_INTEGER, "<<");
 
-        yr_parser_emit(yyscanner, OP_DIV, NULL);
+            yr_parser_emit(yyscanner, OP_SHL, NULL);
 
-        (yyval.expression_type) = EXPRESSION_TYPE_INTEGER;
-      }
+            (yyval.expression_type) = EXPRESSION_TYPE_INTEGER;
+        }
 #line 3468 "yara_grammar.c"
-    break;
+        break;
 
-  case 108:
-#line 1720 "yara_grammar.y"
-      {
-        CHECK_TYPE((yyvsp[-2].expression_type), EXPRESSION_TYPE_INTEGER, "%");
-        CHECK_TYPE((yyvsp[0].expression_type), EXPRESSION_TYPE_INTEGER, "%");
+        case 125: /* primary_expression: primary_expression _SHIFT_RIGHT_ primary_expression  */
+#line 1850 "yara_grammar.y"
+        {
+            CHECK_TYPE((yyvsp[-2].expression_type), EXPRESSION_TYPE_INTEGER, ">>");
+            CHECK_TYPE((yyvsp[0].expression_type), EXPRESSION_TYPE_INTEGER, ">>");
 
-        yr_parser_emit(yyscanner, OP_MOD, NULL);
+            yr_parser_emit(yyscanner, OP_SHR, NULL);
 
-        (yyval.expression_type) = EXPRESSION_TYPE_INTEGER;
-      }
+            (yyval.expression_type) = EXPRESSION_TYPE_INTEGER;
+        }
 #line 3481 "yara_grammar.c"
-    break;
+        break;
 
-  case 109:
-#line 1729 "yara_grammar.y"
-      {
-        CHECK_TYPE((yyvsp[-2].expression_type), EXPRESSION_TYPE_INTEGER, "^");
-        CHECK_TYPE((yyvsp[0].expression_type), EXPRESSION_TYPE_INTEGER, "^");
+        case 126: /* primary_expression: regexp  */
+#line 1859 "yara_grammar.y"
+        {
+            (yyval.expression_type) = (yyvsp[0].expression_type);
+        }
+#line 3489 "yara_grammar.c"
+        break;
 
-        yr_parser_emit(yyscanner, OP_XOR, NULL);
+#line 3493 "yara_grammar.c"
 
-        (yyval.expression_type) = EXPRESSION_TYPE_INTEGER;
-      }
-#line 3494 "yara_grammar.c"
-    break;
-
-  case 110:
-#line 1738 "yara_grammar.y"
-      {
-        CHECK_TYPE((yyvsp[-2].expression_type), EXPRESSION_TYPE_INTEGER, "^");
-        CHECK_TYPE((yyvsp[0].expression_type), EXPRESSION_TYPE_INTEGER, "^");
-
-        yr_parser_emit(yyscanner, OP_AND, NULL);
-
-        (yyval.expression_type) = EXPRESSION_TYPE_INTEGER;
-      }
-#line 3507 "yara_grammar.c"
-    break;
-
-  case 111:
-#line 1747 "yara_grammar.y"
-      {
-        CHECK_TYPE((yyvsp[-2].expression_type), EXPRESSION_TYPE_INTEGER, "|");
-        CHECK_TYPE((yyvsp[0].expression_type), EXPRESSION_TYPE_INTEGER, "|");
-
-        yr_parser_emit(yyscanner, OP_OR, NULL);
-
-        (yyval.expression_type) = EXPRESSION_TYPE_INTEGER;
-      }
-#line 3520 "yara_grammar.c"
-    break;
-
-  case 112:
-#line 1756 "yara_grammar.y"
-      {
-        CHECK_TYPE((yyvsp[0].expression_type), EXPRESSION_TYPE_INTEGER, "~");
-
-        yr_parser_emit(yyscanner, OP_NEG, NULL);
-
-        (yyval.expression_type) = EXPRESSION_TYPE_INTEGER;
-      }
-#line 3532 "yara_grammar.c"
-    break;
-
-  case 113:
-#line 1764 "yara_grammar.y"
-      {
-        CHECK_TYPE((yyvsp[-2].expression_type), EXPRESSION_TYPE_INTEGER, "<<");
-        CHECK_TYPE((yyvsp[0].expression_type), EXPRESSION_TYPE_INTEGER, "<<");
-
-        yr_parser_emit(yyscanner, OP_SHL, NULL);
-
-        (yyval.expression_type) = EXPRESSION_TYPE_INTEGER;
-      }
-#line 3545 "yara_grammar.c"
-    break;
-
-  case 114:
-#line 1773 "yara_grammar.y"
-      {
-        CHECK_TYPE((yyvsp[-2].expression_type), EXPRESSION_TYPE_INTEGER, ">>");
-        CHECK_TYPE((yyvsp[0].expression_type), EXPRESSION_TYPE_INTEGER, ">>");
-
-        yr_parser_emit(yyscanner, OP_SHR, NULL);
-
-        (yyval.expression_type) = EXPRESSION_TYPE_INTEGER;
-      }
-#line 3558 "yara_grammar.c"
-    break;
-
-  case 115:
-#line 1782 "yara_grammar.y"
-      {
-        (yyval.expression_type) = (yyvsp[0].expression_type);
-      }
-#line 3566 "yara_grammar.c"
-    break;
-
-
-#line 3570 "yara_grammar.c"
-
-      default: break;
+        default:
+            break;
     }
-  /* User semantic actions sometimes alter yychar, and that requires
-     that yytoken be updated with the new translation.  We take the
-     approach of translating immediately before every use of yytoken.
-     One alternative is translating here after every semantic action,
-     but that translation would be missed if the semantic action invokes
-     YYABORT, YYACCEPT, or YYERROR immediately after altering yychar or
-     if it invokes YYBACKUP.  In the case of YYABORT or YYACCEPT, an
-     incorrect destructor might then be invoked immediately.  In the
-     case of YYERROR or YYBACKUP, subsequent parser actions might lead
-     to an incorrect destructor call or verbose syntax error message
-     before the lookahead is translated.  */
-  YY_SYMBOL_PRINT ("-> $$ =", yyr1[yyn], &yyval, &yyloc);
+    /* User semantic actions sometimes alter yychar, and that requires
+       that yytoken be updated with the new translation.  We take the
+       approach of translating immediately before every use of yytoken.
+       One alternative is translating here after every semantic action,
+       but that translation would be missed if the semantic action invokes
+       YYABORT, YYACCEPT, or YYERROR immediately after altering yychar or
+       if it invokes YYBACKUP.  In the case of YYABORT or YYACCEPT, an
+       incorrect destructor might then be invoked immediately.  In the
+       case of YYERROR or YYBACKUP, subsequent parser actions might lead
+       to an incorrect destructor call or verbose syntax error message
+       before the lookahead is translated.  */
+    YY_SYMBOL_PRINT("-> $$ =", YY_CAST(yysymbol_kind_t, yyr1[yyn]), &yyval, &yyloc);
 
-  YYPOPSTACK (yylen);
-  yylen = 0;
-  YY_STACK_PRINT (yyss, yyssp);
+    YYPOPSTACK(yylen);
+    yylen = 0;
 
-  *++yyvsp = yyval;
+    *++yyvsp = yyval;
 
-  /* Now 'shift' the result of the reduction.  Determine what state
-     that goes to, based on the state we popped back to and the rule
-     number reduced by.  */
-  {
-    const int yylhs = yyr1[yyn] - YYNTOKENS;
-    const int yyi = yypgoto[yylhs] + *yyssp;
-    yystate = (0 <= yyi && yyi <= YYLAST && yycheck[yyi] == *yyssp
-               ? yytable[yyi]
-               : yydefgoto[yylhs]);
-  }
+    /* Now 'shift' the result of the reduction.  Determine what state
+       that goes to, based on the state we popped back to and the rule
+       number reduced by.  */
+    {
+        const int yylhs = yyr1[yyn] - YYNTOKENS;
+        const int yyi   = yypgoto[yylhs] + *yyssp;
+        yystate         = (0 <= yyi && yyi <= YYLAST && yycheck[yyi] == *yyssp
+                               ? yytable[yyi]
+                               : yydefgoto[yylhs]);
+    }
 
-  goto yynewstate;
-
+    goto yynewstate;
 
 /*--------------------------------------.
 | yyerrlab -- here on detecting error.  |
 `--------------------------------------*/
 yyerrlab:
-  /* Make sure we have latest lookahead translation.  See comments at
-     user semantic actions for why this is necessary.  */
-  yytoken = yychar == YYEMPTY ? YYEMPTY : YYTRANSLATE (yychar);
-
-  /* If not already recovering from an error, report this error.  */
-  if (!yyerrstatus)
-    {
-      ++yynerrs;
-#if ! YYERROR_VERBOSE
-      yyerror (yyscanner, compiler, YY_("syntax error"));
-#else
-# define YYSYNTAX_ERROR yysyntax_error (&yymsg_alloc, &yymsg, \
-                                        yyssp, yytoken)
-      {
-        char const *yymsgp = YY_("syntax error");
-        int yysyntax_error_status;
-        yysyntax_error_status = YYSYNTAX_ERROR;
-        if (yysyntax_error_status == 0)
-          yymsgp = yymsg;
-        else if (yysyntax_error_status == 1)
-          {
-            if (yymsg != yymsgbuf)
-              YYSTACK_FREE (yymsg);
-            yymsg = YY_CAST (char *, YYSTACK_ALLOC (YY_CAST (YYSIZE_T, yymsg_alloc)));
-            if (!yymsg)
-              {
-                yymsg = yymsgbuf;
-                yymsg_alloc = sizeof yymsgbuf;
-                yysyntax_error_status = 2;
-              }
-            else
-              {
-                yysyntax_error_status = YYSYNTAX_ERROR;
-                yymsgp = yymsg;
-              }
-          }
-        yyerror (yyscanner, compiler, yymsgp);
-        if (yysyntax_error_status == 2)
-          goto yyexhaustedlab;
-      }
-# undef YYSYNTAX_ERROR
-#endif
+    /* Make sure we have latest lookahead translation.  See comments at
+       user semantic actions for why this is necessary.  */
+    yytoken = yychar == YYEMPTY ? YYSYMBOL_YYEMPTY : YYTRANSLATE(yychar);
+    /* If not already recovering from an error, report this error.  */
+    if (!yyerrstatus) {
+        ++yynerrs;
+        yyerror(yyscanner, compiler, YY_("syntax error"));
     }
 
+    if (yyerrstatus == 3) {
+        /* If just tried and failed to reuse lookahead token after an
+           error, discard it.  */
 
-
-  if (yyerrstatus == 3)
-    {
-      /* If just tried and failed to reuse lookahead token after an
-         error, discard it.  */
-
-      if (yychar <= YYEOF)
-        {
-          /* Return failure if at end of input.  */
-          if (yychar == YYEOF)
-            YYABORT;
-        }
-      else
-        {
-          yydestruct ("Error: discarding",
-                      yytoken, &yylval, yyscanner, compiler);
-          yychar = YYEMPTY;
+        if (yychar <= YYEOF) {
+            /* Return failure if at end of input.  */
+            if (yychar == YYEOF)
+                YYABORT;
+        } else {
+            yydestruct("Error: discarding",
+                       yytoken, &yylval, yyscanner, compiler);
+            yychar = YYEMPTY;
         }
     }
 
-  /* Else will try to reuse lookahead token after shifting the error
-     token.  */
-  goto yyerrlab1;
-
+    /* Else will try to reuse lookahead token after shifting the error
+       token.  */
+    goto yyerrlab1;
 
 /*---------------------------------------------------.
 | yyerrorlab -- error raised explicitly by YYERROR.  |
 `---------------------------------------------------*/
 yyerrorlab:
-  /* Pacify compilers when the user code never invokes YYERROR and the
-     label yyerrorlab therefore never appears in user code.  */
-  if (0)
-    YYERROR;
+    /* Pacify compilers when the user code never invokes YYERROR and the
+       label yyerrorlab therefore never appears in user code.  */
+    if (0)
+        YYERROR;
+    ++yynerrs;
 
-  /* Do not reclaim the symbols of the rule whose action triggered
-     this YYERROR.  */
-  YYPOPSTACK (yylen);
-  yylen = 0;
-  YY_STACK_PRINT (yyss, yyssp);
-  yystate = *yyssp;
-  goto yyerrlab1;
-
+    /* Do not reclaim the symbols of the rule whose action triggered
+       this YYERROR.  */
+    YYPOPSTACK(yylen);
+    yylen = 0;
+    YY_STACK_PRINT(yyss, yyssp);
+    yystate = *yyssp;
+    goto yyerrlab1;
 
 /*-------------------------------------------------------------.
 | yyerrlab1 -- common code for both syntax error and YYERROR.  |
 `-------------------------------------------------------------*/
 yyerrlab1:
-  yyerrstatus = 3;      /* Each real token shifted decrements this.  */
+    yyerrstatus = 3; /* Each real token shifted decrements this.  */
 
-  for (;;)
-    {
-      yyn = yypact[yystate];
-      if (!yypact_value_is_default (yyn))
-        {
-          yyn += YYTERROR;
-          if (0 <= yyn && yyn <= YYLAST && yycheck[yyn] == YYTERROR)
-            {
-              yyn = yytable[yyn];
-              if (0 < yyn)
-                break;
+    /* Pop stack until we find a state that shifts the error token.  */
+    for (;;) {
+        yyn = yypact[yystate];
+        if (!yypact_value_is_default(yyn)) {
+            yyn += YYSYMBOL_YYerror;
+            if (0 <= yyn && yyn <= YYLAST && yycheck[yyn] == YYSYMBOL_YYerror) {
+                yyn = yytable[yyn];
+                if (0 < yyn)
+                    break;
             }
         }
 
-      /* Pop the current state because it cannot handle the error token.  */
-      if (yyssp == yyss)
-        YYABORT;
+        /* Pop the current state because it cannot handle the error token.  */
+        if (yyssp == yyss)
+            YYABORT;
 
-
-      yydestruct ("Error: popping",
-                  yystos[yystate], yyvsp, yyscanner, compiler);
-      YYPOPSTACK (1);
-      yystate = *yyssp;
-      YY_STACK_PRINT (yyss, yyssp);
+        yydestruct("Error: popping",
+                   YY_ACCESSING_SYMBOL(yystate), yyvsp, yyscanner, compiler);
+        YYPOPSTACK(1);
+        yystate = *yyssp;
+        YY_STACK_PRINT(yyss, yyssp);
     }
 
-  YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
-  *++yyvsp = yylval;
-  YY_IGNORE_MAYBE_UNINITIALIZED_END
+    YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
+    *++yyvsp = yylval;
+    YY_IGNORE_MAYBE_UNINITIALIZED_END
 
+    /* Shift the error token.  */
+    YY_SYMBOL_PRINT("Shifting", YY_ACCESSING_SYMBOL(yyn), yyvsp, yylsp);
 
-  /* Shift the error token.  */
-  YY_SYMBOL_PRINT ("Shifting", yystos[yyn], yyvsp, yylsp);
-
-  yystate = yyn;
-  goto yynewstate;
-
+    yystate = yyn;
+    goto yynewstate;
 
 /*-------------------------------------.
 | yyacceptlab -- YYACCEPT comes here.  |
 `-------------------------------------*/
 yyacceptlab:
-  yyresult = 0;
-  goto yyreturn;
-
+    yyresult = 0;
+    goto yyreturnlab;
 
 /*-----------------------------------.
 | yyabortlab -- YYABORT comes here.  |
 `-----------------------------------*/
 yyabortlab:
-  yyresult = 1;
-  goto yyreturn;
+    yyresult = 1;
+    goto yyreturnlab;
 
-
-#if !defined yyoverflow || YYERROR_VERBOSE
-/*-------------------------------------------------.
-| yyexhaustedlab -- memory exhaustion comes here.  |
-`-------------------------------------------------*/
+/*-----------------------------------------------------------.
+| yyexhaustedlab -- YYNOMEM (memory exhaustion) comes here.  |
+`-----------------------------------------------------------*/
 yyexhaustedlab:
-  yyerror (yyscanner, compiler, YY_("memory exhausted"));
-  yyresult = 2;
-  /* Fall through.  */
-#endif
+    yyerror(yyscanner, compiler, YY_("memory exhausted"));
+    yyresult = 2;
+    goto yyreturnlab;
 
-
-/*-----------------------------------------------------.
-| yyreturn -- parsing is finished, return the result.  |
-`-----------------------------------------------------*/
-yyreturn:
-  if (yychar != YYEMPTY)
-    {
-      /* Make sure we have latest lookahead translation.  See comments at
-         user semantic actions for why this is necessary.  */
-      yytoken = YYTRANSLATE (yychar);
-      yydestruct ("Cleanup: discarding lookahead",
-                  yytoken, &yylval, yyscanner, compiler);
+/*----------------------------------------------------------.
+| yyreturnlab -- parsing is finished, clean up and return.  |
+`----------------------------------------------------------*/
+yyreturnlab:
+    if (yychar != YYEMPTY) {
+        /* Make sure we have latest lookahead translation.  See comments at
+           user semantic actions for why this is necessary.  */
+        yytoken = YYTRANSLATE(yychar);
+        yydestruct("Cleanup: discarding lookahead",
+                   yytoken, &yylval, yyscanner, compiler);
     }
-  /* Do not reclaim the symbols of the rule whose action triggered
-     this YYABORT or YYACCEPT.  */
-  YYPOPSTACK (yylen);
-  YY_STACK_PRINT (yyss, yyssp);
-  while (yyssp != yyss)
-    {
-      yydestruct ("Cleanup: popping",
-                  yystos[+*yyssp], yyvsp, yyscanner, compiler);
-      YYPOPSTACK (1);
+    /* Do not reclaim the symbols of the rule whose action triggered
+       this YYABORT or YYACCEPT.  */
+    YYPOPSTACK(yylen);
+    YY_STACK_PRINT(yyss, yyssp);
+    while (yyssp != yyss) {
+        yydestruct("Cleanup: popping",
+                   YY_ACCESSING_SYMBOL(+*yyssp), yyvsp, yyscanner, compiler);
+        YYPOPSTACK(1);
     }
 #ifndef yyoverflow
-  if (yyss != yyssa)
-    YYSTACK_FREE (yyss);
+    if (yyss != yyssa)
+        YYSTACK_FREE(yyss);
 #endif
-#if YYERROR_VERBOSE
-  if (yymsg != yymsgbuf)
-    YYSTACK_FREE (yymsg);
-#endif
-  return yyresult;
-}
-#line 1787 "yara_grammar.y"
 
+    return yyresult;
+}
+
+#line 1864 "yara_grammar.y"

--- a/libclamav/yara_grammar.h
+++ b/libclamav/yara_grammar.h
@@ -1,3 +1,19 @@
+/*
+Copyright (c) 2007-2016. The YARA Authors. All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
 /* A Bison parser, made by GNU Bison 3.8.2.  */
 
 /* Bison interface for Yacc-like parsers in C

--- a/libclamav/yara_grammar.h
+++ b/libclamav/yara_grammar.h
@@ -1,8 +1,8 @@
-/* A Bison parser, made by GNU Bison 3.5.1.  */
+/* A Bison parser, made by GNU Bison 3.8.2.  */
 
 /* Bison interface for Yacc-like parsers in C
 
-   Copyright (C) 1984, 1989-1990, 2000-2015, 2018-2020 Free Software Foundation,
+   Copyright (C) 1984, 1989-1990, 2000-2015, 2018-2021 Free Software Foundation,
    Inc.
 
    This program is free software: you can redistribute it and/or modify
@@ -16,7 +16,7 @@
    GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License
-   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.  */
 
 /* As a special exception, you may create a larger work that contains
    part or all of the Bison parser skeleton and distribute that work
@@ -31,8 +31,9 @@
    This special exception was added by the Free Software Foundation in
    version 2.2 of Bison.  */
 
-/* Undocumented macros, especially those whose name start with YY_,
-   are private implementation details.  Do not rely on them.  */
+/* DO NOT RELY ON FEATURES THAT ARE NOT DOCUMENTED in the manual,
+   especially those whose name start with YY_ or yy_.  They are
+   private implementation details that can be changed or removed.  */
 
 #ifndef YY_YARA_YY_YARA_GRAMMAR_H_INCLUDED
 # define YY_YARA_YY_YARA_GRAMMAR_H_INCLUDED
@@ -48,72 +49,80 @@ extern int yara_yydebug;
 
 #include "yara_compiler.h"
 
-#line 52 "yara_grammar.h"
+#line 53 "yara_grammar.h"
 
-/* Token type.  */
+/* Token kinds.  */
 #ifndef YYTOKENTYPE
 # define YYTOKENTYPE
   enum yytokentype
   {
-    _RULE_ = 258,
-    _PRIVATE_ = 259,
-    _GLOBAL_ = 260,
-    _META_ = 261,
-    _STRINGS_ = 262,
-    _CONDITION_ = 263,
-    _IDENTIFIER_ = 264,
-    _STRING_IDENTIFIER_ = 265,
-    _STRING_COUNT_ = 266,
-    _STRING_OFFSET_ = 267,
-    _STRING_IDENTIFIER_WITH_WILDCARD_ = 268,
-    _NUMBER_ = 269,
-    _TEXT_STRING_ = 270,
-    _HEX_STRING_ = 271,
-    _REGEXP_ = 272,
-    _ASCII_ = 273,
-    _WIDE_ = 274,
-    _NOCASE_ = 275,
-    _FULLWORD_ = 276,
-    _AT_ = 277,
-    _FILESIZE_ = 278,
-    _ENTRYPOINT_ = 279,
-    _ALL_ = 280,
-    _ANY_ = 281,
-    _IN_ = 282,
-    _OF_ = 283,
-    _FOR_ = 284,
-    _THEM_ = 285,
-    _INT8_ = 286,
-    _INT16_ = 287,
-    _INT32_ = 288,
-    _UINT8_ = 289,
-    _UINT16_ = 290,
-    _UINT32_ = 291,
-    _MATCHES_ = 292,
-    _CONTAINS_ = 293,
-    _IMPORT_ = 294,
-    _TRUE_ = 295,
-    _FALSE_ = 296,
-    _OR_ = 297,
-    _AND_ = 298,
-    _LT_ = 299,
-    _LE_ = 300,
-    _GT_ = 301,
-    _GE_ = 302,
-    _EQ_ = 303,
-    _NEQ_ = 304,
-    _IS_ = 305,
-    _SHIFT_LEFT_ = 306,
-    _SHIFT_RIGHT_ = 307,
-    _NOT_ = 308
+    YYEMPTY = -2,
+    YYEOF = 0,                     /* "end of file"  */
+    YYerror = 256,                 /* error  */
+    YYUNDEF = 257,                 /* "invalid token"  */
+    _RULE_ = 258,                  /* _RULE_  */
+    _PRIVATE_ = 259,               /* _PRIVATE_  */
+    _GLOBAL_ = 260,                /* _GLOBAL_  */
+    _META_ = 261,                  /* _META_  */
+    _STRINGS_ = 262,               /* _STRINGS_  */
+    _CONDITION_ = 263,             /* _CONDITION_  */
+    _IDENTIFIER_ = 264,            /* _IDENTIFIER_  */
+    _STRING_IDENTIFIER_ = 265,     /* _STRING_IDENTIFIER_  */
+    _STRING_COUNT_ = 266,          /* _STRING_COUNT_  */
+    _STRING_OFFSET_ = 267,         /* _STRING_OFFSET_  */
+    _STRING_IDENTIFIER_WITH_WILDCARD_ = 268, /* _STRING_IDENTIFIER_WITH_WILDCARD_  */
+    _NUMBER_ = 269,                /* _NUMBER_  */
+    _TEXT_STRING_ = 270,           /* _TEXT_STRING_  */
+    _HEX_STRING_ = 271,            /* _HEX_STRING_  */
+    _REGEXP_ = 272,                /* _REGEXP_  */
+    _ASCII_ = 273,                 /* _ASCII_  */
+    _WIDE_ = 274,                  /* _WIDE_  */
+    _XOR_ = 275,                   /* _XOR_  */
+    _BASE64_ = 276,                /* _BASE64_  */
+    _BASE64_WIDE_ = 277,           /* _BASE64_WIDE_  */
+    _NOCASE_ = 278,                /* _NOCASE_  */
+    _FULLWORD_ = 279,              /* _FULLWORD_  */
+    _AT_ = 280,                    /* _AT_  */
+    _FILESIZE_ = 281,              /* _FILESIZE_  */
+    _ENTRYPOINT_ = 282,            /* _ENTRYPOINT_  */
+    _ALL_ = 283,                   /* _ALL_  */
+    _ANY_ = 284,                   /* _ANY_  */
+    _IN_ = 285,                    /* _IN_  */
+    _OF_ = 286,                    /* _OF_  */
+    _FOR_ = 287,                   /* _FOR_  */
+    _THEM_ = 288,                  /* _THEM_  */
+    _INT8_ = 289,                  /* _INT8_  */
+    _INT16_ = 290,                 /* _INT16_  */
+    _INT32_ = 291,                 /* _INT32_  */
+    _UINT8_ = 292,                 /* _UINT8_  */
+    _UINT16_ = 293,                /* _UINT16_  */
+    _UINT32_ = 294,                /* _UINT32_  */
+    _MATCHES_ = 295,               /* _MATCHES_  */
+    _CONTAINS_ = 296,              /* _CONTAINS_  */
+    _IMPORT_ = 297,                /* _IMPORT_  */
+    _TRUE_ = 298,                  /* _TRUE_  */
+    _FALSE_ = 299,                 /* _FALSE_  */
+    _OR_ = 300,                    /* _OR_  */
+    _AND_ = 301,                   /* _AND_  */
+    _LT_ = 302,                    /* _LT_  */
+    _LE_ = 303,                    /* _LE_  */
+    _GT_ = 304,                    /* _GT_  */
+    _GE_ = 305,                    /* _GE_  */
+    _EQ_ = 306,                    /* _EQ_  */
+    _NEQ_ = 307,                   /* _NEQ_  */
+    _IS_ = 308,                    /* _IS_  */
+    _SHIFT_LEFT_ = 309,            /* _SHIFT_LEFT_  */
+    _SHIFT_RIGHT_ = 310,           /* _SHIFT_RIGHT_  */
+    _NOT_ = 311                    /* _NOT_  */
   };
+  typedef enum yytokentype yytoken_kind_t;
 #endif
 
 /* Value type.  */
 #if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
 union YYSTYPE
 {
-#line 219 "yara_grammar.y"
+#line 233 "yara_grammar.y"
 
   SIZED_STRING*   sized_string;
   char*           c_string;
@@ -123,7 +132,7 @@ union YYSTYPE
   YR_META*        meta;
   YR_OBJECT*      object;
 
-#line 127 "yara_grammar.h"
+#line 136 "yara_grammar.h"
 
 };
 typedef union YYSTYPE YYSTYPE;
@@ -133,6 +142,8 @@ typedef union YYSTYPE YYSTYPE;
 
 
 
+
 int yara_yyparse (void *yyscanner, YR_COMPILER* compiler);
+
 
 #endif /* !YY_YARA_YY_YARA_GRAMMAR_H_INCLUDED  */

--- a/libclamav/yara_grammar.y
+++ b/libclamav/yara_grammar.y
@@ -113,6 +113,15 @@ limitations under the License.
 
 #define MSG(op)  "wrong type \"string\" for \"" op "\" operator"
 
+#define UNSUPPORTED_STRING_MODIFIER(modifier) \
+    do { \
+      yr_compiler_set_error_extra_info( \
+          compiler, "unsupported string modifier \"" modifier "\""); \
+      compiler->last_result = ERROR_INVALID_MODIFIER; \
+      yyerror(yyscanner, compiler, NULL); \
+      YYERROR; \
+    } while (0)
+
 %}
 
 
@@ -144,6 +153,9 @@ limitations under the License.
 %token <sized_string> _REGEXP_
 %token _ASCII_
 %token _WIDE_
+%token _XOR_
+%token _BASE64_
+%token _BASE64_WIDE_
 %token _NOCASE_
 %token _FULLWORD_
 %token _AT_
@@ -191,6 +203,8 @@ limitations under the License.
 
 %type <integer> string_modifier
 %type <integer> string_modifiers
+%type <integer> hex_modifier
+%type <integer> hex_modifiers
 
 %type <integer> integer_set
 
@@ -533,11 +547,11 @@ string_declaration
 
         ERROR_IF($$ == NULL);
       }
-    | _STRING_IDENTIFIER_ '=' _HEX_STRING_
+    | _STRING_IDENTIFIER_ '=' _HEX_STRING_ hex_modifiers
       {
         $$ = yr_parser_reduce_string_declaration(
             yyscanner,
-            STRING_GFLAGS_HEXADECIMAL,
+            $4 | STRING_GFLAGS_HEXADECIMAL,
             $1,
             $3);
 
@@ -551,7 +565,16 @@ string_declaration
 
 string_modifiers
     : /* empty */                         { $$ = 0; }
-    | string_modifiers string_modifier    { $$ = $1 | $2; }
+    | string_modifiers string_modifier
+      {
+        if ($1 & $2)
+        {
+          compiler->last_result = ERROR_DUPLICATED_MODIFIER;
+          ERROR_IF(compiler->last_result != ERROR_SUCCESS);
+        }
+
+        $$ = $1 | $2;
+      }
     ;
 
 
@@ -560,6 +583,60 @@ string_modifier
     | _ASCII_       { $$ = STRING_GFLAGS_ASCII; }
     | _NOCASE_      { $$ = STRING_GFLAGS_NO_CASE; }
     | _FULLWORD_    { $$ = STRING_GFLAGS_FULL_WORD; }
+    | _PRIVATE_     { $$ = STRING_GFLAGS_PRIVATE; }
+    | _XOR_         { $$ = 0; UNSUPPORTED_STRING_MODIFIER("xor"); }
+    | _XOR_ '(' _NUMBER_ ')'
+      {
+        $$ = 0;
+        UNSUPPORTED_STRING_MODIFIER("xor");
+      }
+    | _XOR_ '(' _NUMBER_ '-' _NUMBER_ ')'
+      {
+        $$ = 0;
+        UNSUPPORTED_STRING_MODIFIER("xor");
+      }
+    | _BASE64_
+      {
+        $$ = 0;
+        UNSUPPORTED_STRING_MODIFIER("base64");
+      }
+    | _BASE64_ '(' _TEXT_STRING_ ')'
+      {
+        yr_free($3);
+        $$ = 0;
+        UNSUPPORTED_STRING_MODIFIER("base64");
+      }
+    | _BASE64_WIDE_
+      {
+        $$ = 0;
+        UNSUPPORTED_STRING_MODIFIER("base64wide");
+      }
+    | _BASE64_WIDE_ '(' _TEXT_STRING_ ')'
+      {
+        yr_free($3);
+        $$ = 0;
+        UNSUPPORTED_STRING_MODIFIER("base64wide");
+      }
+    ;
+
+
+hex_modifiers
+    : /* empty */                         { $$ = 0; }
+    | hex_modifiers hex_modifier
+      {
+        if ($1 & $2)
+        {
+          compiler->last_result = ERROR_DUPLICATED_MODIFIER;
+          ERROR_IF(compiler->last_result != ERROR_SUCCESS);
+        }
+
+        $$ = $1 | $2;
+      }
+    ;
+
+
+hex_modifier
+    : _PRIVATE_     { $$ = STRING_GFLAGS_PRIVATE; }
     ;
 
 

--- a/libclamav/yara_grammar.y
+++ b/libclamav/yara_grammar.y
@@ -21,19 +21,19 @@
 /* This file was originally derived from yara 3.1.0 libyara/parser.y and is
    revised for running YARA rules in ClamAV. Following is the YARA copyright. */
 /*
-Copyright (c) 2007-2013. The YARA Authors. All Rights Reserved.
+Copyright (c) 2007-2016. The YARA Authors. All Rights Reserved.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-   http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 %code requires {
@@ -1192,7 +1192,7 @@ expression
         yr_parser_emit_with_arg(
             yyscanner, OP_PUSH_M, mem_offset + 1, NULL);
 
-        yr_parser_emit(yyscanner, OP_LE, NULL);
+        yr_parser_emit(yyscanner, OP_OF_COUNT, NULL);
 
         compiler->loop_identifier[compiler->loop_depth] = NULL;
         yr_free($3);
@@ -1271,7 +1271,7 @@ expression
         yr_parser_emit_with_arg(
             yyscanner, OP_PUSH_M, mem_offset + 1, NULL);
 
-        yr_parser_emit(yyscanner, OP_LE, NULL);
+        yr_parser_emit(yyscanner, OP_OF_COUNT, NULL);
         $$ = EXPRESSION_TYPE_BOOLEAN;
 
       }

--- a/libclamav/yara_hash.c
+++ b/libclamav/yara_hash.c
@@ -1,17 +1,17 @@
 /*
-Copyright (c) 2013. The YARA Authors. All Rights Reserved.
+Copyright (c) 2007-2016. The YARA Authors. All Rights Reserved.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-   http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include <stdint.h>

--- a/libclamav/yara_hash.h
+++ b/libclamav/yara_hash.h
@@ -1,17 +1,17 @@
 /*
-Copyright (c) 2013. The YARA Authors. All Rights Reserved.
+Copyright (c) 2007-2016. The YARA Authors. All Rights Reserved.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-   http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #ifndef YR_HASH_H

--- a/libclamav/yara_lexer.c
+++ b/libclamav/yara_lexer.c
@@ -1,6 +1,6 @@
-#line 2 "yara_lexer.c"
+#line 1 "yara_lexer.c"
 
-#line 4 "yara_lexer.c"
+#line 3 "yara_lexer.c"
 
 #define  YY_INT_ALIGNED short int
 
@@ -59,6 +59,7 @@ typedef int16_t flex_int16_t;
 typedef uint16_t flex_uint16_t;
 typedef int32_t flex_int32_t;
 typedef uint32_t flex_uint32_t;
+typedef uint64_t flex_uint64_t;
 #else
 typedef signed char flex_int8_t;
 typedef short int flex_int16_t;
@@ -197,7 +198,7 @@ typedef size_t yy_size_t;
      */
     #define  YY_LESS_LINENO(n) \
             do { \
-                int yyl;\
+                yy_size_t yyl;\
                 for ( yyl = n; yyl < yyleng; ++yyl )\
                     if ( yytext[yyl] == '\n' )\
                         --yylineno;\
@@ -242,7 +243,7 @@ struct yy_buffer_state
 	/* Number of characters read into yy_ch_buf, not including EOB
 	 * characters.
 	 */
-	int yy_n_chars;
+	yy_size_t yy_n_chars;
 
 	/* Whether we "own" the buffer - i.e., we know we created it,
 	 * and can realloc() it to grow it, and should free() it to
@@ -319,7 +320,7 @@ static void yy_init_buffer ( YY_BUFFER_STATE b, FILE *file , yyscan_t yyscanner 
 
 YY_BUFFER_STATE yy_scan_buffer ( char *base, yy_size_t size , yyscan_t yyscanner );
 YY_BUFFER_STATE yy_scan_string ( const char *yy_str , yyscan_t yyscanner );
-YY_BUFFER_STATE yy_scan_bytes ( const char *bytes, int len , yyscan_t yyscanner );
+YY_BUFFER_STATE yy_scan_bytes ( const char *bytes, yy_size_t len , yyscan_t yyscanner );
 
 void *yyalloc ( yy_size_t , yyscan_t yyscanner );
 void *yyrealloc ( void *, yy_size_t , yyscan_t yyscanner );
@@ -366,12 +367,12 @@ static void yynoreturn yy_fatal_error ( const char* msg , yyscan_t yyscanner );
  */
 #define YY_DO_BEFORE_ACTION \
 	yyg->yytext_ptr = yy_bp; \
-	yyleng = (int) (yy_cp - yy_bp); \
+	yyleng = (yy_size_t) (yy_cp - yy_bp); \
 	yyg->yy_hold_char = *yy_cp; \
 	*yy_cp = '\0'; \
 	yyg->yy_c_buf_p = yy_cp;
-#define YY_NUM_RULES 75
-#define YY_END_OF_BUFFER 76
+#define YY_NUM_RULES 80
+#define YY_END_OF_BUFFER 81
 /* This struct is not used in this scanner,
    but its presence is necessary. */
 struct yy_trans_info
@@ -379,32 +380,35 @@ struct yy_trans_info
 	flex_int32_t yy_verify;
 	flex_int32_t yy_nxt;
 	};
-static const flex_int16_t yy_accept[219] =
+static const flex_int16_t yy_accept[242] =
     {   0,
         0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
-       76,   74,   73,   73,   74,   70,   51,   50,   71,   54,
-       54,    1,   74,    2,   52,   53,   53,   53,   53,   53,
-       53,   53,   53,   53,   53,   53,   53,   53,   53,   53,
-       53,   74,   62,   63,   56,   75,   68,   69,   65,   75,
-       47,   48,   44,   44,    6,   51,   49,   50,   42,   45,
-       54,    0,    0,    0,    7,    3,    5,    4,    8,   52,
-       53,   53,   53,   53,   24,   53,   53,   53,   53,   53,
-       53,   53,   53,   25,   53,   53,   53,   26,   23,   53,
-       53,   53,   53,   53,   53,   53,    0,   62,   64,   59,
+       81,   79,   78,   78,   79,   75,   54,   53,   76,   57,
+       57,    1,   79,    2,   55,   56,   56,   56,   56,   56,
+       56,   56,   56,   56,   56,   56,   56,   56,   56,   56,
+       56,   56,   56,   79,   67,   68,   60,   80,   73,   74,
+       70,   80,   50,   51,   47,   47,    6,   54,   52,   53,
+       45,   48,   57,    0,    0,    0,    0,    7,    3,    5,
+        4,    8,   55,   56,   56,   56,   56,   27,   56,   56,
+       56,   56,   56,   56,   56,   56,   56,   28,   56,   56,
+       56,   29,   26,   56,   56,   56,   56,   56,   56,   56,
 
-       60,   58,   57,   64,   68,   65,   65,   67,   66,   47,
-       43,   45,   54,   55,   29,   22,   30,   53,   53,   53,
-       53,   53,   28,   53,   53,   53,   53,   53,   53,   53,
-       53,   21,   53,   53,   53,   53,   53,   53,   53,   72,
-        0,   53,   53,   53,   53,   53,   53,   53,   53,   53,
-       53,   53,   53,   36,   53,   12,   53,   53,   11,   53,
-       27,   19,   53,   15,   61,   14,   53,   53,   53,   20,
-       53,   53,   53,   53,   53,   37,   38,   53,   53,   53,
-       53,   53,   53,   33,   53,   53,   53,   53,   53,   10,
-       41,   53,   53,   17,   53,   53,   34,   35,   53,   53,
+       56,    0,    0,   67,   69,   64,   65,   62,   63,   61,
+       69,   73,   70,   70,   72,   71,   50,   46,   48,   57,
+       59,   58,   32,   25,   33,   56,   56,   56,   56,   56,
+       56,   31,   56,   56,   56,   56,   56,   56,   56,   56,
+       24,   56,   56,   56,   56,   56,   56,   56,   16,   77,
+        0,    0,    0,   56,   56,   56,   56,   56,   56,   56,
+       56,   56,   56,   56,   56,   56,   39,   56,   12,   56,
+       56,   11,   56,   30,   22,   56,   15,    0,    0,    0,
+        0,   66,   14,   56,   56,   56,   56,   23,   56,   56,
+       56,   56,   56,   40,   41,   56,   56,   56,   56,   56,
 
-       53,   53,   53,   53,   39,    9,   13,   53,   40,   53,
-       32,   16,    0,   18,   53,   46,   31,    0
+       56,   36,   17,   56,   56,   56,   56,   56,   10,   44,
+       56,   56,   20,   56,   56,   37,   38,   56,   56,   56,
+       56,   56,   56,   56,   42,    9,   13,   56,   56,   43,
+       56,   35,   19,    0,   56,   21,   56,   49,   18,   34,
+        0
     } ;
 
 static const YY_CHAR yy_ec[256] =
@@ -414,15 +418,15 @@ static const YY_CHAR yy_ec[256] =
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    2,    5,    6,    7,    8,    1,    1,    1,    9,
         9,   10,    1,    1,    9,    1,   11,   12,   13,   14,
-       15,   16,   16,   17,   16,   18,   16,    1,    1,   19,
-       20,   21,    9,   22,   23,   24,   23,   23,   23,   23,
-       25,   25,   25,   25,   26,   25,   27,   25,   25,   25,
-       25,   25,   25,   25,   25,   25,   25,   25,   25,   25,
-        9,   28,    9,    1,   29,    1,   30,   31,   32,   33,
+       15,   16,   17,   18,   17,   19,   20,    1,    1,   21,
+       22,   23,    9,   24,   25,   26,   25,   25,   25,   25,
+       27,   27,   27,   27,   28,   27,   29,   27,   27,   27,
+       27,   27,   27,   27,   27,   27,   27,   27,   27,   27,
+        9,   30,    9,    1,   31,    1,   32,   33,   34,   35,
 
-       34,   35,   36,   37,   38,   25,   25,   39,   40,   41,
-       42,   43,   25,   44,   45,   46,   47,   48,   49,   50,
-       51,   52,   53,    9,   54,    1,    1,    1,    1,    1,
+       36,   37,   38,   39,   40,   27,   27,   41,   42,   43,
+       44,   45,   27,   46,   47,   48,   49,   50,   51,   52,
+       53,   54,   55,    9,   56,    9,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
@@ -439,183 +443,202 @@ static const YY_CHAR yy_ec[256] =
         1,    1,    1,    1,    1
     } ;
 
-static const YY_CHAR yy_meta[55] =
+static const YY_CHAR yy_meta[57] =
     {   0,
-        1,    2,    3,    1,    1,    4,    1,    1,    2,    5,
-        6,    7,    7,    7,    7,    7,    7,    7,    1,    1,
-        1,    1,    8,    8,    9,   10,   10,   11,    9,    8,
-        8,    8,    8,    8,    8,    9,    9,    9,    9,    9,
-        9,    9,    9,    9,    9,    9,    9,    9,    9,   10,
-        9,    9,    1,    1
+        1,    2,    3,    2,    1,    4,    1,    1,    2,    5,
+        6,    7,    7,    7,    7,    7,    7,    7,    7,    7,
+        1,    1,    1,    1,    8,    8,    9,   10,   10,   11,
+        9,    8,    8,    8,    8,    8,    8,    9,    9,    9,
+        9,    9,    9,   10,    9,    9,    9,    9,    9,    9,
+        9,   10,    9,    9,    1,    1
     } ;
 
-static const flex_int16_t yy_base[238] =
+static const flex_int16_t yy_base[263] =
     {   0,
-        0,    0,   52,   53,   54,   57,  350,  349,  344,  343,
-      352,  357,  357,  357,  331,  357,    0,  340,   51,   37,
-       40,   50,  329,   51,    0,    0,   38,  306,  306,   56,
-      307,   33,   58,  303,   56,  300,  296,  296,   52,  303,
-      302,    0,    0,  357,  357,   69,    0,  357,   57,  328,
-        0,  357,  357,  327,  357,    0,  357,  327,  357,    0,
-        0,  312,  311,    0,  357,  357,  357,  357,  357,    0,
-        0,  295,   60,  301,    0,  291,  285,  291,  290,  284,
-      288,  284,  282,   67,  278,  277,   72,    0,    0,  284,
-      282,  276,  285,  271,  276,  283,  261,    0,  357,  357,
+        0,    0,   54,   55,   56,   59,  415,  414,  409,  408,
+      417,  422,  422,  422,  394,  422,    0,  405,   53,   43,
+       46,   44,  392,   46,    0,    0,   35,  381,  368,  368,
+       48,  369,   51,   41,  365,   54,  362,  358,  358,   57,
+      365,  364,  359,  391,    0,  422,  422,   75,    0,  422,
+       59,  390,    0,  422,  422,  389,  422,    0,  422,  389,
+      422,    0,    0,  372,  371,   95,    0,  422,  422,  422,
+      422,  422,    0,    0,  355,   66,  361,    0,  347,  350,
+      344,  350,  349,  343,  347,  343,  341,   68,  337,  336,
+       80,    0,    0,  343,  341,  335,  344,  330,  335,  342,
 
-      357,  357,  357,    0,    0,  269,  357,  357,  357,    0,
-      357,    0,  357,    0,    0,    0,    0,  275,   68,  268,
-      266,  276,    0,  270,  277,  265,  267,   94,  273,  274,
-      273,    0,  254,  267,  262,  259,  264,  251,  262,  357,
-        0,  257,  256,  263,  241,  257,  245,  240,  258,  243,
-      239,  268,  270,    0,  246,    0,  237,  251,    0,  239,
-        0,    0,  107,    0,  357,    0,  233,  240,  234,    0,
-      238,  233,  235,  227,  239,    0,    0,  237,  236,  223,
-      218,  227,  218,    0,  187,  181,  160,  149,  152,    0,
-        0,  161,  149,    0,  148,  136,    0,    0,  133,   79,
+      330,   68,  115,    0,  422,  422,  422,  422,  422,  422,
+        0,    0,  328,  422,  422,  422,    0,  422,    0,  422,
+      117,    0,    0,    0,    0,  334,  337,   69,  326,  324,
+      334,    0,  328,  335,  323,  325,  123,  331,  332,  331,
+        0,  312,  325,  320,  317,  322,  309,  320,    0,  422,
+      345,  351,    0,  313,  334,  311,  318,  296,  312,  300,
+      295,  313,  298,  294,  324,  327,    0,  301,    0,  292,
+      306,    0,  294,    0,    0,  124,    0,  326,  130,  332,
+      104,  422,    0,  318,  285,  292,  286,    0,  290,  285,
+      287,  279,  291,    0,    0,  253,  243,  219,  222,  239,
 
-       85,   82,   75,  104,    0,    0,    0,   64,    0,   37,
-        0,    0,  115,    0,   30,  357,    0,  357,  125,  136,
-      147,  158,  163,  169,  173,  177,  181,  190,  198,  208,
-      219,  229,  240,  251,  256,  258,  260
+      223,    0,  185,  190,  186,  173,  162,  164,    0,    0,
+      123,  111,    0,  121,  109,    0,    0,  115,  110,  106,
+      112,  115,  115,  147,    0,    0,    0,  112,  103,    0,
+      102,    0,    0,  142,   86,    0,   72,  422,    0,    0,
+      422,  160,  171,  182,  193,  198,  204,  208,  212,  216,
+      225,  233,  243,  254,  264,  275,  286,  291,  293,  301,
+      312,  317
     } ;
 
-static const flex_int16_t yy_def[238] =
+static const flex_int16_t yy_def[263] =
     {   0,
-      218,    1,  219,  219,  220,  220,  221,  221,  222,  222,
-      218,  218,  218,  218,  218,  218,  223,  224,  218,  225,
-      225,  218,  218,  218,  226,  227,  227,  227,  227,  227,
-      227,  227,  227,  227,  227,  227,  227,  227,  227,  227,
-      227,  228,  229,  218,  218,  230,  231,  218,  218,  232,
-      233,  218,  218,  218,  218,  223,  218,  224,  218,  234,
-       21,  218,  218,  235,  218,  218,  218,  218,  218,  226,
-      227,  227,  227,  227,  227,  227,  227,  227,  227,  227,
-      227,  227,  227,  227,  227,  227,  227,  227,  227,  227,
-      227,  227,  227,  227,  227,  227,  228,  229,  218,  218,
+      241,    1,  242,  242,  243,  243,  244,  244,  245,  245,
+      241,  241,  241,  241,  241,  241,  246,  247,  241,  248,
+      248,  241,  241,  241,  249,  250,  250,  250,  250,  250,
+      250,  250,  250,  250,  250,  250,  250,  250,  250,  250,
+      250,  250,  250,  251,  252,  241,  241,  253,  254,  241,
+      241,  255,  256,  241,  241,  241,  241,  246,  241,  247,
+      241,  257,   21,  241,  241,  241,  258,  241,  241,  241,
+      241,  241,  249,  250,  250,  250,  250,  250,  250,  250,
+      250,  250,  250,  250,  250,  250,  250,  250,  250,  250,
+      250,  250,  250,  250,  250,  250,  250,  250,  250,  250,
 
-      218,  218,  218,  236,  231,  218,  218,  218,  218,  233,
-      218,  234,  218,  235,  227,  227,  227,  227,  227,  227,
-      227,  227,  227,  227,  227,  227,  227,  227,  227,  227,
-      227,  227,  227,  227,  227,  227,  227,  227,  227,  218,
-      237,  227,  227,  227,  227,  227,  227,  227,  227,  227,
-      227,  227,  227,  227,  227,  227,  227,  227,  227,  227,
-      227,  227,  227,  227,  218,  227,  227,  227,  227,  227,
-      227,  227,  227,  227,  227,  227,  227,  227,  227,  227,
-      227,  227,  227,  227,  227,  227,  227,  227,  227,  227,
-      227,  227,  227,  227,  227,  227,  227,  227,  227,  227,
+      250,  251,  241,  252,  241,  241,  241,  241,  241,  241,
+      259,  254,  241,  241,  241,  241,  256,  241,  257,  241,
+      241,  258,  250,  250,  250,  250,  250,  250,  250,  250,
+      250,  250,  250,  250,  250,  250,  250,  250,  250,  250,
+      250,  250,  250,  250,  250,  250,  250,  250,  250,  241,
+      260,  261,  262,  250,  250,  250,  250,  250,  250,  250,
+      250,  250,  250,  250,  250,  250,  250,  250,  250,  250,
+      250,  250,  250,  250,  250,  250,  250,  260,  260,  261,
+      251,  241,  250,  250,  250,  250,  250,  250,  250,  250,
+      250,  250,  250,  250,  250,  250,  250,  250,  250,  250,
 
-      227,  227,  227,  227,  227,  227,  227,  227,  227,  227,
-      227,  227,  218,  227,  227,  218,  227,    0,  218,  218,
-      218,  218,  218,  218,  218,  218,  218,  218,  218,  218,
-      218,  218,  218,  218,  218,  218,  218
+      250,  250,  250,  250,  250,  250,  250,  250,  250,  250,
+      250,  250,  250,  250,  250,  250,  250,  250,  250,  250,
+      250,  250,  250,  250,  250,  250,  250,  250,  250,  250,
+      250,  250,  250,  241,  250,  250,  250,  241,  250,  250,
+        0,  241,  241,  241,  241,  241,  241,  241,  241,  241,
+      241,  241,  241,  241,  241,  241,  241,  241,  241,  241,
+      241,  241
     } ;
 
-static const flex_int16_t yy_nxt[412] =
+static const flex_int16_t yy_nxt[479] =
     {   0,
        12,   13,   14,   13,   15,   16,   17,   18,   12,   12,
-       19,   20,   21,   21,   21,   21,   21,   21,   22,   23,
-       24,   25,   26,   26,   26,   26,   26,   12,   26,   27,
-       26,   28,   26,   29,   30,   31,   26,   32,   26,   33,
-       34,   35,   36,   37,   38,   39,   40,   26,   41,   26,
-       26,   26,   42,   12,   44,   44,   48,   45,   45,   48,
-       59,   60,   62,   63,   49,   62,   63,   49,   65,   66,
-       68,   69,   83,   84,  100,  217,   72,  215,   73,   46,
-       46,   50,   74,   75,   50,   78,   64,   85,   93,  218,
-       88,   86,  116,   79,  106,   94,  101,   80,  127,   89,
+       19,   20,   21,   21,   21,   21,   21,   21,   21,   21,
+       22,   23,   24,   25,   26,   26,   26,   26,   26,   12,
+       26,   27,   28,   29,   26,   30,   31,   32,   26,   33,
+       26,   34,   35,   36,   37,   38,   39,   40,   41,   26,
+       42,   43,   26,   26,   44,   12,   46,   46,   50,   47,
+       47,   50,   61,   62,   68,   69,   51,   71,   72,   51,
+       64,   65,   89,   64,   65,   75,   90,   76,  103,   82,
+      106,   77,   78,   48,   48,   52,   66,   83,   52,  241,
+       92,   84,   87,   88,   67,   97,   85,  241,  113,   93,
 
-      143,  107,   81,  131,  214,  213,  152,  212,  153,  102,
-      117,  154,  128,  144,  103,  211,  213,  132,  104,  182,
-      216,  183,  210,  209,  184,   43,   43,   43,   43,   43,
-       43,   43,   43,   43,   43,   43,   47,   47,   47,   47,
-       47,   47,   47,   47,   47,   47,   47,   51,   51,   51,
-       51,   51,   51,   51,   51,   51,   51,   51,   53,   53,
-       53,   53,   53,   53,   53,   53,   53,   53,   53,   56,
-       56,   56,   56,   58,  208,   58,   58,   58,   58,   61,
-      207,  206,   61,   70,   70,   70,   70,   71,   71,   71,
-       71,   97,   97,  205,  204,  203,   97,   97,   98,   98,
+      124,  136,   98,  156,  107,  114,  121,  121,  121,  121,
+      121,  121,  121,  140,  103,  137,  157,  108,  125,  240,
+      109,  239,  110,  150,  151,  152,  111,  141,  121,  121,
+      121,  121,  121,  121,  121,  165,  200,  166,  201,  179,
+      102,  167,  202,  234,  237,  236,  235,  238,  234,  233,
+      232,  231,  230,  229,  228,  227,  226,  225,  224,  150,
+       45,   45,   45,   45,   45,   45,   45,   45,   45,   45,
+       45,   49,   49,   49,   49,   49,   49,   49,   49,   49,
+       49,   49,   53,   53,   53,   53,   53,   53,   53,   53,
+       53,   53,   53,   55,   55,   55,   55,   55,   55,   55,
 
-      202,  201,   98,   98,   98,   98,   98,   98,   99,   99,
-       99,   99,   99,   99,   99,   99,   99,   99,   99,  105,
-      105,  200,  105,  105,  199,  105,  105,  105,  105,  108,
-      108,  198,  108,  108,  108,  108,  108,  108,  108,  108,
-      110,  110,  110,  197,  110,  110,  110,  110,  110,  110,
-      110,  112,  112,  196,  112,  112,  112,  112,  112,  112,
-      112,  112,  114,  114,  141,  141,  165,  165,  195,  194,
-      193,  192,  191,  190,  189,  188,  187,  186,  185,  181,
-      180,  179,  178,  177,  176,  175,  174,  173,  172,  171,
-      170,  169,  168,  167,  166,  164,  163,  162,  161,  160,
+       55,   55,   55,   55,   58,   58,   58,   58,   60,  223,
+       60,   60,   60,   60,   63,  222,  221,   63,   73,   73,
+       73,   73,   74,   74,   74,   74,  102,  102,  220,  219,
+      102,  102,  102,  104,  104,  218,  217,  104,  104,  104,
+      104,  104,  104,  105,  105,  105,  105,  105,  105,  105,
+      105,  105,  105,  105,  112,  112,  216,  112,  112,  215,
+      112,  112,  112,  112,  115,  115,  214,  115,  115,  115,
+      115,  115,  115,  115,  115,  117,  117,  117,  213,  117,
+      117,  117,  117,  117,  117,  117,  119,  119,  212,  119,
+      119,  119,  119,  119,  119,  119,  119,  122,  122,  153,
 
-      159,  158,  157,  156,  155,  151,  150,  149,  148,  147,
-      146,  145,  142,  107,  140,  139,  138,  137,  136,  135,
-      134,  133,  130,  129,  126,  125,  124,  123,  122,  121,
-      120,  119,  118,  115,  113,  113,   57,  111,  109,   96,
-       95,   92,   91,   90,   87,   82,   77,   76,   67,   57,
-       55,  218,   54,   54,   52,   52,   11,  218,  218,  218,
-      218,  218,  218,  218,  218,  218,  218,  218,  218,  218,
-      218,  218,  218,  218,  218,  218,  218,  218,  218,  218,
-      218,  218,  218,  218,  218,  218,  218,  218,  218,  218,
-      218,  218,  218,  218,  218,  218,  218,  218,  218,  218,
+      153,  178,  178,  178,  178,  178,  178,  178,  178,  178,
+      178,  178,  180,  180,  180,  180,  180,  180,  180,  180,
+      180,  180,  180,  182,  182,  211,  210,  209,  208,  207,
+      206,  205,  204,  203,  181,  179,  199,  198,  197,  196,
+      195,  194,  193,  192,  191,  190,  189,  188,  187,  186,
+      185,  184,  183,  181,  179,  177,  176,  175,  174,  173,
+      172,  171,  170,  169,  168,  164,  163,  162,  161,  160,
+      159,  158,  155,  154,  114,  149,  148,  147,  146,  145,
+      144,  143,  142,  139,  138,  135,  134,  133,  132,  131,
+      130,  129,  128,  127,  126,  123,  120,  120,   59,  118,
 
-      218,  218,  218,  218,  218,  218,  218,  218,  218,  218,
-      218
+      116,  103,  101,  100,   99,   96,   95,   94,   91,   86,
+       81,   80,   79,   70,   59,   57,  241,   56,   56,   54,
+       54,   11,  241,  241,  241,  241,  241,  241,  241,  241,
+      241,  241,  241,  241,  241,  241,  241,  241,  241,  241,
+      241,  241,  241,  241,  241,  241,  241,  241,  241,  241,
+      241,  241,  241,  241,  241,  241,  241,  241,  241,  241,
+      241,  241,  241,  241,  241,  241,  241,  241,  241,  241,
+      241,  241,  241,  241,  241,  241,  241,  241
     } ;
 
-static const flex_int16_t yy_chk[412] =
+static const flex_int16_t yy_chk[479] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
-        1,    1,    1,    1,    3,    4,    5,    3,    4,    6,
-       19,   19,   20,   20,    5,   21,   21,    6,   22,   22,
-       24,   24,   32,   32,   46,  215,   27,  210,   27,    3,
-        4,    5,   27,   27,    6,   30,   20,   33,   39,   21,
-       35,   33,   73,   30,   49,   39,   46,   30,   84,   35,
+        1,    1,    1,    1,    1,    1,    3,    4,    5,    3,
+        4,    6,   19,   19,   22,   22,    5,   24,   24,    6,
+       20,   20,   34,   21,   21,   27,   34,   27,  102,   31,
+       48,   27,   27,    3,    4,    5,   20,   31,    6,   21,
+       36,   31,   33,   33,   20,   40,   31,   21,   51,   36,
 
-      119,   49,   30,   87,  208,  204,  128,  203,  128,   46,
-       73,  128,   84,  119,   46,  202,  213,   87,   46,  163,
-      213,  163,  201,  200,  163,  219,  219,  219,  219,  219,
-      219,  219,  219,  219,  219,  219,  220,  220,  220,  220,
-      220,  220,  220,  220,  220,  220,  220,  221,  221,  221,
-      221,  221,  221,  221,  221,  221,  221,  221,  222,  222,
-      222,  222,  222,  222,  222,  222,  222,  222,  222,  223,
-      223,  223,  223,  224,  199,  224,  224,  224,  224,  225,
-      196,  195,  225,  226,  226,  226,  226,  227,  227,  227,
-      227,  228,  228,  193,  192,  189,  228,  228,  229,  229,
+       76,   88,   40,  128,   48,   51,   66,   66,   66,   66,
+       66,   66,   66,   91,  181,   88,  128,   48,   76,  237,
+       48,  235,   48,  102,  103,  103,   48,   91,  121,  121,
+      121,  121,  121,  121,  121,  137,  176,  137,  176,  179,
+      179,  137,  176,  234,  231,  229,  228,  234,  224,  223,
+      222,  221,  220,  219,  218,  215,  214,  212,  211,  181,
+      242,  242,  242,  242,  242,  242,  242,  242,  242,  242,
+      242,  243,  243,  243,  243,  243,  243,  243,  243,  243,
+      243,  243,  244,  244,  244,  244,  244,  244,  244,  244,
+      244,  244,  244,  245,  245,  245,  245,  245,  245,  245,
 
-      188,  187,  229,  229,  229,  229,  229,  229,  230,  230,
-      230,  230,  230,  230,  230,  230,  230,  230,  230,  231,
-      231,  186,  231,  231,  185,  231,  231,  231,  231,  232,
-      232,  183,  232,  232,  232,  232,  232,  232,  232,  232,
-      233,  233,  233,  182,  233,  233,  233,  233,  233,  233,
-      233,  234,  234,  181,  234,  234,  234,  234,  234,  234,
-      234,  234,  235,  235,  236,  236,  237,  237,  180,  179,
-      178,  175,  174,  173,  172,  171,  169,  168,  167,  160,
-      158,  157,  155,  153,  152,  151,  150,  149,  148,  147,
-      146,  145,  144,  143,  142,  139,  138,  137,  136,  135,
+      245,  245,  245,  245,  246,  246,  246,  246,  247,  208,
+      247,  247,  247,  247,  248,  207,  206,  248,  249,  249,
+      249,  249,  250,  250,  250,  250,  251,  251,  205,  204,
+      251,  251,  251,  252,  252,  203,  201,  252,  252,  252,
+      252,  252,  252,  253,  253,  253,  253,  253,  253,  253,
+      253,  253,  253,  253,  254,  254,  200,  254,  254,  199,
+      254,  254,  254,  254,  255,  255,  198,  255,  255,  255,
+      255,  255,  255,  255,  255,  256,  256,  256,  197,  256,
+      256,  256,  256,  256,  256,  256,  257,  257,  196,  257,
+      257,  257,  257,  257,  257,  257,  257,  258,  258,  259,
 
-      134,  133,  131,  130,  129,  127,  126,  125,  124,  122,
-      121,  120,  118,  106,   97,   96,   95,   94,   93,   92,
-       91,   90,   86,   85,   83,   82,   81,   80,   79,   78,
-       77,   76,   74,   72,   63,   62,   58,   54,   50,   41,
-       40,   38,   37,   36,   34,   31,   29,   28,   23,   18,
-       15,   11,   10,    9,    8,    7,  218,  218,  218,  218,
-      218,  218,  218,  218,  218,  218,  218,  218,  218,  218,
-      218,  218,  218,  218,  218,  218,  218,  218,  218,  218,
-      218,  218,  218,  218,  218,  218,  218,  218,  218,  218,
-      218,  218,  218,  218,  218,  218,  218,  218,  218,  218,
+      259,  260,  260,  260,  260,  260,  260,  260,  260,  260,
+      260,  260,  261,  261,  261,  261,  261,  261,  261,  261,
+      261,  261,  261,  262,  262,  193,  192,  191,  190,  189,
+      187,  186,  185,  184,  180,  178,  173,  171,  170,  168,
+      166,  165,  164,  163,  162,  161,  160,  159,  158,  157,
+      156,  155,  154,  152,  151,  148,  147,  146,  145,  144,
+      143,  142,  140,  139,  138,  136,  135,  134,  133,  131,
+      130,  129,  127,  126,  113,  101,  100,   99,   98,   97,
+       96,   95,   94,   90,   89,   87,   86,   85,   84,   83,
+       82,   81,   80,   79,   77,   75,   65,   64,   60,   56,
 
-      218,  218,  218,  218,  218,  218,  218,  218,  218,  218,
-      218
+       52,   44,   43,   42,   41,   39,   38,   37,   35,   32,
+       30,   29,   28,   23,   18,   15,   11,   10,    9,    8,
+        7,  241,  241,  241,  241,  241,  241,  241,  241,  241,
+      241,  241,  241,  241,  241,  241,  241,  241,  241,  241,
+      241,  241,  241,  241,  241,  241,  241,  241,  241,  241,
+      241,  241,  241,  241,  241,  241,  241,  241,  241,  241,
+      241,  241,  241,  241,  241,  241,  241,  241,  241,  241,
+      241,  241,  241,  241,  241,  241,  241,  241
     } ;
 
 /* Table of booleans, true if rule could match eol. */
-static const flex_int32_t yy_rule_can_match_eol[76] =
+static const flex_int32_t yy_rule_can_match_eol[81] =
     {   0,
 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 1, 1, 0, 0, 0, 0, 1, 0, 0, 1, 1, 0, 0,     };
+    0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 1, 0, 0, 1, 1, 0,
+    0,     };
 
 /* The intent behind this definition is that it'll catch
  * any uses of REJECT which flex missed.
@@ -665,8 +688,11 @@ limitations under the License.
 /* Lexical analyzer for YARA */
 #line 42 "yara_lexer.l"
 
+#include <errno.h>
+#include <limits.h>
 #include <math.h>
 #include <stdio.h>
+#include <stdlib.h>
 #ifdef REAL_YARA
 #include <stdint.h>
 #endif
@@ -711,12 +737,12 @@ limitations under the License.
 #define snprintf _snprintf
 #endif
 
-#line 715 "yara_lexer.c"
+#line 740 "yara_lexer.c"
 #define YY_NO_UNISTD_H 1
 #define YY_NO_INPUT 1
 /* %option prefix="yara_yy" */
 
-#line 720 "yara_lexer.c"
+#line 745 "yara_lexer.c"
 
 #define INITIAL 0
 #define str 1
@@ -749,8 +775,8 @@ struct yyguts_t
     size_t yy_buffer_stack_max; /**< capacity of stack. */
     YY_BUFFER_STATE * yy_buffer_stack; /**< Stack as an array. */
     char yy_hold_char;
-    int yy_n_chars;
-    int yyleng_r;
+    yy_size_t yy_n_chars;
+    yy_size_t yyleng_r;
     char *yy_c_buf_p;
     int yy_init;
     int yy_start;
@@ -803,7 +829,7 @@ FILE *yyget_out ( yyscan_t yyscanner );
 
 void yyset_out  ( FILE * _out_str , yyscan_t yyscanner );
 
-			int yyget_leng ( yyscan_t yyscanner );
+			yy_size_t yyget_leng ( yyscan_t yyscanner );
 
 char *yyget_text ( yyscan_t yyscanner );
 
@@ -878,7 +904,7 @@ static int input ( yyscan_t yyscanner );
 	if ( YY_CURRENT_BUFFER_LVALUE->yy_is_interactive ) \
 		{ \
 		int c = '*'; \
-		int n; \
+		yy_size_t n; \
 		for ( n = 0; n < max_size && \
 			     (c = getc( yyin )) != EOF && c != '\n'; ++n ) \
 			buf[n] = (char) c; \
@@ -992,10 +1018,10 @@ YY_DECL
 		}
 
 	{
-#line 112 "yara_lexer.l"
+#line 116 "yara_lexer.l"
 
 
-#line 999 "yara_lexer.c"
+#line 1024 "yara_lexer.c"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -1022,13 +1048,13 @@ yy_match:
 			while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
 				{
 				yy_current_state = (int) yy_def[yy_current_state];
-				if ( yy_current_state >= 219 )
+				if ( yy_current_state >= 242 )
 					yy_c = yy_meta[yy_c];
 				}
 			yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 			++yy_cp;
 			}
-		while ( yy_base[yy_current_state] != 357 );
+		while ( yy_base[yy_current_state] != 422 );
 
 yy_find_action:
 		yy_act = yy_accept[yy_current_state];
@@ -1043,7 +1069,7 @@ yy_find_action:
 
 		if ( yy_act != YY_END_OF_BUFFER && yy_rule_can_match_eol[yy_act] )
 			{
-			int yyl;
+			yy_size_t yyl;
 			for ( yyl = 0; yyl < yyleng; ++yyl )
 				if ( yytext[yyl] == '\n' )
 
@@ -1066,248 +1092,263 @@ do_action:	/* This label is used only to access EOF actions. */
 
 case 1:
 YY_RULE_SETUP
-#line 114 "yara_lexer.l"
+#line 118 "yara_lexer.l"
 { return _LT_;          }
 	YY_BREAK
 case 2:
 YY_RULE_SETUP
-#line 115 "yara_lexer.l"
+#line 119 "yara_lexer.l"
 { return _GT_;          }
 	YY_BREAK
 case 3:
 YY_RULE_SETUP
-#line 116 "yara_lexer.l"
+#line 120 "yara_lexer.l"
 { return _LE_;          }
 	YY_BREAK
 case 4:
 YY_RULE_SETUP
-#line 117 "yara_lexer.l"
+#line 121 "yara_lexer.l"
 { return _GE_;          }
 	YY_BREAK
 case 5:
 YY_RULE_SETUP
-#line 118 "yara_lexer.l"
+#line 122 "yara_lexer.l"
 { return _EQ_;          }
 	YY_BREAK
 case 6:
 YY_RULE_SETUP
-#line 119 "yara_lexer.l"
+#line 123 "yara_lexer.l"
 { return _NEQ_;         }
 	YY_BREAK
 case 7:
 YY_RULE_SETUP
-#line 120 "yara_lexer.l"
+#line 124 "yara_lexer.l"
 { return _SHIFT_LEFT_;  }
 	YY_BREAK
 case 8:
 YY_RULE_SETUP
-#line 121 "yara_lexer.l"
+#line 125 "yara_lexer.l"
 { return _SHIFT_RIGHT_; }
 	YY_BREAK
 case 9:
 YY_RULE_SETUP
-#line 122 "yara_lexer.l"
+#line 126 "yara_lexer.l"
 { return _PRIVATE_;     }
 	YY_BREAK
 case 10:
 YY_RULE_SETUP
-#line 123 "yara_lexer.l"
+#line 127 "yara_lexer.l"
 { return _GLOBAL_;      }
 	YY_BREAK
 case 11:
 YY_RULE_SETUP
-#line 124 "yara_lexer.l"
+#line 128 "yara_lexer.l"
 { return _RULE_;        }
 	YY_BREAK
 case 12:
 YY_RULE_SETUP
-#line 125 "yara_lexer.l"
+#line 129 "yara_lexer.l"
 { return _META_;        }
 	YY_BREAK
 case 13:
 YY_RULE_SETUP
-#line 126 "yara_lexer.l"
+#line 130 "yara_lexer.l"
 { return _STRINGS_;     }
 	YY_BREAK
 case 14:
 YY_RULE_SETUP
-#line 127 "yara_lexer.l"
+#line 131 "yara_lexer.l"
 { return _ASCII_;       }
 	YY_BREAK
 case 15:
 YY_RULE_SETUP
-#line 128 "yara_lexer.l"
+#line 132 "yara_lexer.l"
 { return _WIDE_;        }
 	YY_BREAK
 case 16:
 YY_RULE_SETUP
-#line 129 "yara_lexer.l"
-{ return _FULLWORD_;    }
+#line 133 "yara_lexer.l"
+{ return _XOR_;         }
 	YY_BREAK
 case 17:
 YY_RULE_SETUP
-#line 130 "yara_lexer.l"
-{ return _NOCASE_;      }
+#line 134 "yara_lexer.l"
+{ return _BASE64_;      }
 	YY_BREAK
 case 18:
 YY_RULE_SETUP
-#line 131 "yara_lexer.l"
-{ return _CONDITION_;   }
+#line 135 "yara_lexer.l"
+{ return _BASE64_WIDE_; }
 	YY_BREAK
 case 19:
 YY_RULE_SETUP
-#line 132 "yara_lexer.l"
-{ return _TRUE_;        }
+#line 136 "yara_lexer.l"
+{ return _FULLWORD_;    }
 	YY_BREAK
 case 20:
 YY_RULE_SETUP
-#line 133 "yara_lexer.l"
-{ return _FALSE_;       }
+#line 137 "yara_lexer.l"
+{ return _NOCASE_;      }
 	YY_BREAK
 case 21:
 YY_RULE_SETUP
-#line 134 "yara_lexer.l"
-{ return _NOT_;         }
+#line 138 "yara_lexer.l"
+{ return _CONDITION_;   }
 	YY_BREAK
 case 22:
 YY_RULE_SETUP
-#line 135 "yara_lexer.l"
-{ return _AND_;         }
+#line 139 "yara_lexer.l"
+{ return _TRUE_;        }
 	YY_BREAK
 case 23:
 YY_RULE_SETUP
-#line 136 "yara_lexer.l"
-{ return _OR_;          }
+#line 140 "yara_lexer.l"
+{ return _FALSE_;       }
 	YY_BREAK
 case 24:
 YY_RULE_SETUP
-#line 137 "yara_lexer.l"
-{ return _AT_;          }
+#line 141 "yara_lexer.l"
+{ return _NOT_;         }
 	YY_BREAK
 case 25:
 YY_RULE_SETUP
-#line 138 "yara_lexer.l"
-{ return _IN_;          }
+#line 142 "yara_lexer.l"
+{ return _AND_;         }
 	YY_BREAK
 case 26:
 YY_RULE_SETUP
-#line 139 "yara_lexer.l"
-{ return _OF_;          }
+#line 143 "yara_lexer.l"
+{ return _OR_;          }
 	YY_BREAK
 case 27:
 YY_RULE_SETUP
-#line 140 "yara_lexer.l"
-{ return _THEM_;        }
+#line 144 "yara_lexer.l"
+{ return _AT_;          }
 	YY_BREAK
 case 28:
 YY_RULE_SETUP
-#line 141 "yara_lexer.l"
-{ return _FOR_;         }
+#line 145 "yara_lexer.l"
+{ return _IN_;          }
 	YY_BREAK
 case 29:
 YY_RULE_SETUP
-#line 142 "yara_lexer.l"
-{ return _ALL_;         }
+#line 146 "yara_lexer.l"
+{ return _OF_;          }
 	YY_BREAK
 case 30:
 YY_RULE_SETUP
-#line 143 "yara_lexer.l"
-{ return _ANY_;         }
+#line 147 "yara_lexer.l"
+{ return _THEM_;        }
 	YY_BREAK
 case 31:
 YY_RULE_SETUP
-#line 144 "yara_lexer.l"
-{ return _ENTRYPOINT_;  }
+#line 148 "yara_lexer.l"
+{ return _FOR_;         }
 	YY_BREAK
 case 32:
 YY_RULE_SETUP
-#line 145 "yara_lexer.l"
-{ return _FILESIZE_;    }
+#line 149 "yara_lexer.l"
+{ return _ALL_;         }
 	YY_BREAK
 case 33:
 YY_RULE_SETUP
-#line 146 "yara_lexer.l"
-{ return _UINT8_;       }
+#line 150 "yara_lexer.l"
+{ return _ANY_;         }
 	YY_BREAK
 case 34:
 YY_RULE_SETUP
-#line 147 "yara_lexer.l"
-{ return _UINT16_;      }
+#line 151 "yara_lexer.l"
+{ return _ENTRYPOINT_;  }
 	YY_BREAK
 case 35:
 YY_RULE_SETUP
-#line 148 "yara_lexer.l"
-{ return _UINT32_;      }
+#line 152 "yara_lexer.l"
+{ return _FILESIZE_;    }
 	YY_BREAK
 case 36:
 YY_RULE_SETUP
-#line 149 "yara_lexer.l"
-{ return _INT8_;        }
+#line 153 "yara_lexer.l"
+{ return _UINT8_;       }
 	YY_BREAK
 case 37:
 YY_RULE_SETUP
-#line 150 "yara_lexer.l"
-{ return _INT16_;       }
+#line 154 "yara_lexer.l"
+{ return _UINT16_;      }
 	YY_BREAK
 case 38:
 YY_RULE_SETUP
-#line 151 "yara_lexer.l"
-{ return _INT32_;       }
+#line 155 "yara_lexer.l"
+{ return _UINT32_;      }
 	YY_BREAK
 case 39:
 YY_RULE_SETUP
-#line 152 "yara_lexer.l"
-{ return _MATCHES_;     }
+#line 156 "yara_lexer.l"
+{ return _INT8_;        }
 	YY_BREAK
 case 40:
 YY_RULE_SETUP
-#line 153 "yara_lexer.l"
-{ return _CONTAINS_;    }
+#line 157 "yara_lexer.l"
+{ return _INT16_;       }
 	YY_BREAK
 case 41:
 YY_RULE_SETUP
-#line 154 "yara_lexer.l"
-{ return _IMPORT_;      }
+#line 158 "yara_lexer.l"
+{ return _INT32_;       }
 	YY_BREAK
 case 42:
 YY_RULE_SETUP
-#line 157 "yara_lexer.l"
-{ BEGIN(comment);       }
+#line 159 "yara_lexer.l"
+{ return _MATCHES_;     }
 	YY_BREAK
 case 43:
 YY_RULE_SETUP
-#line 158 "yara_lexer.l"
-{ BEGIN(INITIAL);       }
+#line 160 "yara_lexer.l"
+{ return _CONTAINS_;    }
 	YY_BREAK
 case 44:
-/* rule 44 can match eol */
 YY_RULE_SETUP
-#line 159 "yara_lexer.l"
-{ /* skip comments */   }
+#line 161 "yara_lexer.l"
+{ return _IMPORT_;      }
 	YY_BREAK
 case 45:
 YY_RULE_SETUP
-#line 162 "yara_lexer.l"
-{ /* skip single-line comments */ }
+#line 164 "yara_lexer.l"
+{ BEGIN(comment);       }
 	YY_BREAK
 case 46:
 YY_RULE_SETUP
 #line 165 "yara_lexer.l"
+{ BEGIN(INITIAL);       }
+	YY_BREAK
+case 47:
+/* rule 47 can match eol */
+YY_RULE_SETUP
+#line 166 "yara_lexer.l"
+{ /* skip comments */   }
+	YY_BREAK
+case 48:
+YY_RULE_SETUP
+#line 169 "yara_lexer.l"
+{ /* skip single-line comments */ }
+	YY_BREAK
+case 49:
+YY_RULE_SETUP
+#line 172 "yara_lexer.l"
 {
                           yyextra->lex_buf_ptr = yyextra->lex_buf;
                           yyextra->lex_buf_len = 0;
                           BEGIN(include);
                         }
 	YY_BREAK
-case 47:
-/* rule 47 can match eol */
+case 50:
+/* rule 50 can match eol */
 YY_RULE_SETUP
-#line 172 "yara_lexer.l"
+#line 179 "yara_lexer.l"
 { YYTEXT_TO_BUFFER; }
 	YY_BREAK
-case 48:
+case 51:
 YY_RULE_SETUP
-#line 175 "yara_lexer.l"
+#line 182 "yara_lexer.l"
 {
 
   char            buffer[1024];
@@ -1414,7 +1455,7 @@ case YY_STATE_EOF(str):
 case YY_STATE_EOF(regexp):
 case YY_STATE_EOF(include):
 case YY_STATE_EOF(comment):
-#line 277 "yara_lexer.l"
+#line 284 "yara_lexer.l"
 {
 
   YR_COMPILER* compiler = yyget_extra(yyscanner);
@@ -1434,9 +1475,9 @@ case YY_STATE_EOF(comment):
   }
 }
 	YY_BREAK
-case 49:
+case 52:
 YY_RULE_SETUP
-#line 297 "yara_lexer.l"
+#line 304 "yara_lexer.l"
 {
 
   yylval->c_string = yr_strdup(yytext);
@@ -1450,9 +1491,9 @@ YY_RULE_SETUP
   return _STRING_IDENTIFIER_WITH_WILDCARD_;
 }
 	YY_BREAK
-case 50:
+case 53:
 YY_RULE_SETUP
-#line 311 "yara_lexer.l"
+#line 318 "yara_lexer.l"
 {
 
   yylval->c_string = yr_strdup(yytext);
@@ -1466,9 +1507,9 @@ YY_RULE_SETUP
   return _STRING_IDENTIFIER_;
 }
 	YY_BREAK
-case 51:
+case 54:
 YY_RULE_SETUP
-#line 325 "yara_lexer.l"
+#line 332 "yara_lexer.l"
 {
 
   yylval->c_string = yr_strdup(yytext);
@@ -1483,9 +1524,9 @@ YY_RULE_SETUP
   return _STRING_COUNT_;
 }
 	YY_BREAK
-case 52:
+case 55:
 YY_RULE_SETUP
-#line 340 "yara_lexer.l"
+#line 347 "yara_lexer.l"
 {
 
   yylval->c_string = yr_strdup(yytext);
@@ -1500,9 +1541,9 @@ YY_RULE_SETUP
   return _STRING_OFFSET_;
 }
 	YY_BREAK
-case 53:
+case 56:
 YY_RULE_SETUP
-#line 355 "yara_lexer.l"
+#line 362 "yara_lexer.l"
 {
 
   if (strlen(yytext) > 128)
@@ -1520,36 +1561,96 @@ YY_RULE_SETUP
   return _IDENTIFIER_;
 }
 	YY_BREAK
-case 54:
+case 57:
 YY_RULE_SETUP
-#line 373 "yara_lexer.l"
+#line 380 "yara_lexer.l"
 {
 
-  yylval->integer = (size_t) atol(yytext);
+  char *endptr;
+
+  errno = 0;
+  yylval->integer = strtoll(yytext, &endptr, 10);
+
+  if (yylval->integer == LLONG_MAX && errno == ERANGE)
+  {
+    yr_compiler_set_error_extra_info(compiler, yytext);
+    compiler->last_result = ERROR_INTEGER_OVERFLOW;
+    yyerror(yyscanner, compiler, NULL);
+    yyterminate();
+  }
 
   if (strstr(yytext, "KB") != NULL)
   {
-     yylval->integer *= 1024;
+    if (yylval->integer > LLONG_MAX / 1024)
+    {
+      yr_compiler_set_error_extra_info(compiler, yytext);
+      compiler->last_result = ERROR_INTEGER_OVERFLOW;
+      yyerror(yyscanner, compiler, NULL);
+      yyterminate();
+    }
+
+    yylval->integer *= 1024;
   }
   else if (strstr(yytext, "MB") != NULL)
   {
-     yylval->integer *= 1048576;
+    if (yylval->integer > LLONG_MAX / 1048576)
+    {
+      yr_compiler_set_error_extra_info(compiler, yytext);
+      compiler->last_result = ERROR_INTEGER_OVERFLOW;
+      yyerror(yyscanner, compiler, NULL);
+      yyterminate();
+    }
+
+    yylval->integer *= 1048576;
   }
   return _NUMBER_;
 }
 	YY_BREAK
-case 55:
+case 58:
 YY_RULE_SETUP
-#line 389 "yara_lexer.l"
+#line 423 "yara_lexer.l"
 {
 
-  yylval->integer = xtoi(yytext + 2);
+  char *endptr;
+
+  errno = 0;
+  yylval->integer = strtoll(yytext, &endptr, 16);
+
+  if (yylval->integer == LLONG_MAX && errno == ERANGE)
+  {
+    yr_compiler_set_error_extra_info(compiler, yytext);
+    compiler->last_result = ERROR_INTEGER_OVERFLOW;
+    yyerror(yyscanner, compiler, NULL);
+    yyterminate();
+  }
+
   return _NUMBER_;
 }
 	YY_BREAK
-case 56:
+case 59:
 YY_RULE_SETUP
-#line 396 "yara_lexer.l"
+#line 442 "yara_lexer.l"
+{
+
+  char *endptr;
+
+  errno = 0;
+  yylval->integer = strtoll(yytext + 2, &endptr, 8);
+
+  if (yylval->integer == LLONG_MAX && errno == ERANGE)
+  {
+    yr_compiler_set_error_extra_info(compiler, yytext);
+    compiler->last_result = ERROR_INTEGER_OVERFLOW;
+    yyerror(yyscanner, compiler, NULL);
+    yyterminate();
+  }
+
+  return _NUMBER_;
+}
+	YY_BREAK
+case 60:
+YY_RULE_SETUP
+#line 461 "yara_lexer.l"
 {     /* saw closing quote - all done */
 
   SIZED_STRING* s;
@@ -1573,9 +1674,9 @@ YY_RULE_SETUP
   return _TEXT_STRING_;
 }
 	YY_BREAK
-case 57:
+case 61:
 YY_RULE_SETUP
-#line 420 "yara_lexer.l"
+#line 485 "yara_lexer.l"
 {
 
   LEX_CHECK_SPACE_OK("\t", yyextra->lex_buf_len, LEX_BUF_SIZE);
@@ -1583,9 +1684,9 @@ YY_RULE_SETUP
   yyextra->lex_buf_len++;
 }
 	YY_BREAK
-case 58:
+case 62:
 YY_RULE_SETUP
-#line 428 "yara_lexer.l"
+#line 493 "yara_lexer.l"
 {
 
   LEX_CHECK_SPACE_OK("\n", yyextra->lex_buf_len, LEX_BUF_SIZE);
@@ -1593,9 +1694,19 @@ YY_RULE_SETUP
   yyextra->lex_buf_len++;
 }
 	YY_BREAK
-case 59:
+case 63:
 YY_RULE_SETUP
-#line 436 "yara_lexer.l"
+#line 501 "yara_lexer.l"
+{
+
+  LEX_CHECK_SPACE_OK("\r", yyextra->lex_buf_len, LEX_BUF_SIZE);
+  *yyextra->lex_buf_ptr++ = '\r';
+  yyextra->lex_buf_len++;
+}
+	YY_BREAK
+case 64:
+YY_RULE_SETUP
+#line 509 "yara_lexer.l"
 {
 
   LEX_CHECK_SPACE_OK("\"", yyextra->lex_buf_len, LEX_BUF_SIZE);
@@ -1603,9 +1714,9 @@ YY_RULE_SETUP
   yyextra->lex_buf_len++;
 }
 	YY_BREAK
-case 60:
+case 65:
 YY_RULE_SETUP
-#line 444 "yara_lexer.l"
+#line 517 "yara_lexer.l"
 {
 
   LEX_CHECK_SPACE_OK("\\", yyextra->lex_buf_len, LEX_BUF_SIZE);
@@ -1613,9 +1724,9 @@ YY_RULE_SETUP
   yyextra->lex_buf_len++;
 }
 	YY_BREAK
-case 61:
+case 66:
 YY_RULE_SETUP
-#line 452 "yara_lexer.l"
+#line 525 "yara_lexer.l"
 {
 
    int result;
@@ -1626,33 +1737,33 @@ YY_RULE_SETUP
    yyextra->lex_buf_len++;
 }
 	YY_BREAK
-case 62:
+case 67:
 YY_RULE_SETUP
-#line 463 "yara_lexer.l"
+#line 536 "yara_lexer.l"
 { YYTEXT_TO_BUFFER; }
 	YY_BREAK
-case 63:
-/* rule 63 can match eol */
+case 68:
+/* rule 68 can match eol */
 YY_RULE_SETUP
-#line 466 "yara_lexer.l"
+#line 539 "yara_lexer.l"
 {
 
   yyerror(yyscanner, compiler, "unterminated string");
   yyterminate();
 }
 	YY_BREAK
-case 64:
-/* rule 64 can match eol */
+case 69:
+/* rule 69 can match eol */
 YY_RULE_SETUP
-#line 472 "yara_lexer.l"
+#line 545 "yara_lexer.l"
 {
 
   yyerror(yyscanner, compiler, "illegal escape sequence");
 }
 	YY_BREAK
-case 65:
+case 70:
 YY_RULE_SETUP
-#line 478 "yara_lexer.l"
+#line 551 "yara_lexer.l"
 {
 
   SIZED_STRING* s;
@@ -1683,9 +1794,9 @@ YY_RULE_SETUP
   return _REGEXP_;
 }
 	YY_BREAK
-case 66:
+case 71:
 YY_RULE_SETUP
-#line 509 "yara_lexer.l"
+#line 582 "yara_lexer.l"
 {
 
   LEX_CHECK_SPACE_OK("/", yyextra->lex_buf_len, LEX_BUF_SIZE);
@@ -1693,35 +1804,39 @@ YY_RULE_SETUP
   yyextra->lex_buf_len++ ;
 }
 	YY_BREAK
-case 67:
+case 72:
 YY_RULE_SETUP
-#line 517 "yara_lexer.l"
+#line 590 "yara_lexer.l"
 {
 
   LEX_CHECK_SPACE_OK("\\.", yyextra->lex_buf_len, LEX_BUF_SIZE);
+
+  if (yytext[1] == 0)
+    yyerror(yyscanner, compiler, "malformed regular expression");
+
   *yyextra->lex_buf_ptr++ = yytext[0];
   *yyextra->lex_buf_ptr++ = yytext[1];
   yyextra->lex_buf_len += 2;
 }
 	YY_BREAK
-case 68:
+case 73:
 YY_RULE_SETUP
-#line 526 "yara_lexer.l"
+#line 603 "yara_lexer.l"
 { YYTEXT_TO_BUFFER; }
 	YY_BREAK
-case 69:
-/* rule 69 can match eol */
+case 74:
+/* rule 74 can match eol */
 YY_RULE_SETUP
-#line 529 "yara_lexer.l"
+#line 606 "yara_lexer.l"
 {
 
   yyerror(yyscanner, compiler, "unterminated regular expression");
   yyterminate();
 }
 	YY_BREAK
-case 70:
+case 75:
 YY_RULE_SETUP
-#line 536 "yara_lexer.l"
+#line 613 "yara_lexer.l"
 {
 
   yyextra->lex_buf_ptr = yyextra->lex_buf;
@@ -1729,9 +1844,9 @@ YY_RULE_SETUP
   BEGIN(str);
 }
 	YY_BREAK
-case 71:
+case 76:
 YY_RULE_SETUP
-#line 544 "yara_lexer.l"
+#line 621 "yara_lexer.l"
 {
 
   yyextra->lex_buf_ptr = yyextra->lex_buf;
@@ -1739,10 +1854,10 @@ YY_RULE_SETUP
   BEGIN(regexp);
 }
 	YY_BREAK
-case 72:
-/* rule 72 can match eol */
+case 77:
+/* rule 77 can match eol */
 YY_RULE_SETUP
-#line 552 "yara_lexer.l"
+#line 629 "yara_lexer.l"
 {
 
   int len = strlen(yytext);
@@ -1757,15 +1872,15 @@ YY_RULE_SETUP
   return _HEX_STRING_;
 }
 	YY_BREAK
-case 73:
-/* rule 73 can match eol */
+case 78:
+/* rule 78 can match eol */
 YY_RULE_SETUP
-#line 567 "yara_lexer.l"
+#line 644 "yara_lexer.l"
 /* skip whitespace */
 	YY_BREAK
-case 74:
+case 79:
 YY_RULE_SETUP
-#line 569 "yara_lexer.l"
+#line 646 "yara_lexer.l"
 {
 
   if (yytext[0] >= 32 && yytext[0] < 127)
@@ -1779,12 +1894,12 @@ YY_RULE_SETUP
   }
 }
 	YY_BREAK
-case 75:
+case 80:
 YY_RULE_SETUP
-#line 582 "yara_lexer.l"
+#line 659 "yara_lexer.l"
 ECHO;
 	YY_BREAK
-#line 1788 "yara_lexer.c"
+#line 1902 "yara_lexer.c"
 
 	case YY_END_OF_BUFFER:
 		{
@@ -1970,7 +2085,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 
 	else
 		{
-			int num_to_read =
+			yy_size_t num_to_read =
 			YY_CURRENT_BUFFER_LVALUE->yy_buf_size - number_to_move - 1;
 
 		while ( num_to_read <= 0 )
@@ -1984,7 +2099,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 
 			if ( b->yy_is_our_buffer )
 				{
-				int new_size = b->yy_buf_size * 2;
+				yy_size_t new_size = b->yy_buf_size * 2;
 
 				if ( new_size <= 0 )
 					b->yy_buf_size += b->yy_buf_size / 8;
@@ -2042,7 +2157,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 
 	if ((yyg->yy_n_chars + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
 		/* Extend the array by 50%, plus the number we really need. */
-		int new_size = yyg->yy_n_chars + number_to_move + (yyg->yy_n_chars >> 1);
+		yy_size_t new_size = yyg->yy_n_chars + number_to_move + (yyg->yy_n_chars >> 1);
 		YY_CURRENT_BUFFER_LVALUE->yy_ch_buf = (char *) yyrealloc(
 			(void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf, (yy_size_t) new_size , yyscanner );
 		if ( ! YY_CURRENT_BUFFER_LVALUE->yy_ch_buf )
@@ -2081,7 +2196,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 		while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
 			{
 			yy_current_state = (int) yy_def[yy_current_state];
-			if ( yy_current_state >= 219 )
+			if ( yy_current_state >= 242 )
 				yy_c = yy_meta[yy_c];
 			}
 		yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
@@ -2110,11 +2225,11 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 	while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
 		{
 		yy_current_state = (int) yy_def[yy_current_state];
-		if ( yy_current_state >= 219 )
+		if ( yy_current_state >= 242 )
 			yy_c = yy_meta[yy_c];
 		}
 	yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
-	yy_is_jam = (yy_current_state == 218);
+	yy_is_jam = (yy_current_state == 241);
 
 	(void)yyg;
 	return yy_is_jam ? 0 : yy_current_state;
@@ -2149,7 +2264,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 
 		else
 			{ /* need more input */
-			int offset = (int) (yyg->yy_c_buf_p - yyg->yytext_ptr);
+			yy_size_t offset = yyg->yy_c_buf_p - yyg->yytext_ptr;
 			++yyg->yy_c_buf_p;
 
 			switch ( yy_get_next_buffer( yyscanner ) )
@@ -2534,12 +2649,12 @@ YY_BUFFER_STATE yy_scan_string (const char * yystr , yyscan_t yyscanner)
  * @param yyscanner The scanner object.
  * @return the newly allocated buffer state object.
  */
-YY_BUFFER_STATE yy_scan_bytes  (const char * yybytes, int  _yybytes_len , yyscan_t yyscanner)
+YY_BUFFER_STATE yy_scan_bytes  (const char * yybytes, yy_size_t  _yybytes_len , yyscan_t yyscanner)
 {
 	YY_BUFFER_STATE b;
 	char *buf;
 	yy_size_t n;
-	int i;
+	yy_size_t i;
 
 	/* Get memory for full buffer, including space for trailing EOB's. */
 	n = (yy_size_t) (_yybytes_len + 2);
@@ -2583,7 +2698,7 @@ static void yynoreturn yy_fatal_error (const char* msg , yyscan_t yyscanner)
 	do \
 		{ \
 		/* Undo effects of setting up yytext. */ \
-        int yyless_macro_arg = (n); \
+        yy_size_t yyless_macro_arg = (n); \
         YY_LESS_LINENO(yyless_macro_arg);\
 		yytext[yyleng] = yyg->yy_hold_char; \
 		yyg->yy_c_buf_p = yytext + yyless_macro_arg; \
@@ -2651,7 +2766,7 @@ FILE *yyget_out  (yyscan_t yyscanner)
 /** Get the length of the current token.
  * @param yyscanner The scanner object.
  */
-int yyget_leng  (yyscan_t yyscanner)
+yy_size_t yyget_leng  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     return yyleng;
@@ -2932,7 +3047,7 @@ void yyfree (void * ptr , yyscan_t yyscanner)
 
 #define YYTABLES_NAME "yytables"
 
-#line 582 "yara_lexer.l"
+#line 659 "yara_lexer.l"
 
 
 

--- a/libclamav/yara_lexer.c
+++ b/libclamav/yara_lexer.c
@@ -671,19 +671,19 @@ static const flex_int32_t yy_rule_can_match_eol[81] =
 /* This file was originally derived from yara 3.1.0 libyara/lexer.l and is
    revised for running YARA rules in ClamAV. Following is the YARA copyright. */
 /*
-Copyright (c) 2007-2013. The YARA Authors. All Rights Reserved.
+Copyright (c) 2007-2016. The YARA Authors. All Rights Reserved.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-   http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 /* Lexical analyzer for YARA */
 #line 42 "yara_lexer.l"

--- a/libclamav/yara_lexer.h
+++ b/libclamav/yara_lexer.h
@@ -1,17 +1,17 @@
 /*
-Copyright (c) 2007. Victor M. Alvarez [plusvic@gmail.com].
+Copyright (c) 2007-2016. The YARA Authors. All Rights Reserved.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-   http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #ifdef REAL_YARA

--- a/libclamav/yara_lexer.l
+++ b/libclamav/yara_lexer.l
@@ -21,19 +21,19 @@
 /* This file was originally derived from yara 3.1.0 libyara/lexer.l and is
    revised for running YARA rules in ClamAV. Following is the YARA copyright. */
 /*
-Copyright (c) 2007-2013. The YARA Authors. All Rights Reserved.
+Copyright (c) 2007-2016. The YARA Authors. All Rights Reserved.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-   http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 /* Lexical analyzer for YARA */

--- a/libclamav/yara_lexer.l
+++ b/libclamav/yara_lexer.l
@@ -40,8 +40,11 @@ limitations under the License.
 
 %{
 
+#include <errno.h>
+#include <limits.h>
 #include <math.h>
 #include <stdio.h>
+#include <stdlib.h>
 #ifdef REAL_YARA
 #include <stdint.h>
 #endif
@@ -108,6 +111,7 @@ limitations under the License.
 digit         [0-9]
 letter        [a-zA-Z]
 hexdigit      [a-fA-F0-9]
+octdigit      [0-7]
 
 %%
 
@@ -126,6 +130,9 @@ hexdigit      [a-fA-F0-9]
 "strings"               { return _STRINGS_;     }
 "ascii"                 { return _ASCII_;       }
 "wide"                  { return _WIDE_;        }
+"xor"                   { return _XOR_;         }
+"base64"                { return _BASE64_;      }
+"base64wide"            { return _BASE64_WIDE_; }
 "fullword"              { return _FULLWORD_;    }
 "nocase"                { return _NOCASE_;      }
 "condition"             { return _CONDITION_;   }
@@ -372,15 +379,42 @@ $({letter}|{digit}|_)*  {
 
 {digit}+(MB|KB){0,1}  {
 
-  yylval->integer = (size_t) atol(yytext);
+  char *endptr;
+
+  errno = 0;
+  yylval->integer = strtoll(yytext, &endptr, 10);
+
+  if (yylval->integer == LLONG_MAX && errno == ERANGE)
+  {
+    yr_compiler_set_error_extra_info(compiler, yytext);
+    compiler->last_result = ERROR_INTEGER_OVERFLOW;
+    yyerror(yyscanner, compiler, NULL);
+    yyterminate();
+  }
 
   if (strstr(yytext, "KB") != NULL)
   {
-     yylval->integer *= 1024;
+    if (yylval->integer > LLONG_MAX / 1024)
+    {
+      yr_compiler_set_error_extra_info(compiler, yytext);
+      compiler->last_result = ERROR_INTEGER_OVERFLOW;
+      yyerror(yyscanner, compiler, NULL);
+      yyterminate();
+    }
+
+    yylval->integer *= 1024;
   }
   else if (strstr(yytext, "MB") != NULL)
   {
-     yylval->integer *= 1048576;
+    if (yylval->integer > LLONG_MAX / 1048576)
+    {
+      yr_compiler_set_error_extra_info(compiler, yytext);
+      compiler->last_result = ERROR_INTEGER_OVERFLOW;
+      yyerror(yyscanner, compiler, NULL);
+      yyterminate();
+    }
+
+    yylval->integer *= 1048576;
   }
   return _NUMBER_;
 }
@@ -388,7 +422,38 @@ $({letter}|{digit}|_)*  {
 
 0x{hexdigit}+  {
 
-  yylval->integer = xtoi(yytext + 2);
+  char *endptr;
+
+  errno = 0;
+  yylval->integer = strtoll(yytext, &endptr, 16);
+
+  if (yylval->integer == LLONG_MAX && errno == ERANGE)
+  {
+    yr_compiler_set_error_extra_info(compiler, yytext);
+    compiler->last_result = ERROR_INTEGER_OVERFLOW;
+    yyerror(yyscanner, compiler, NULL);
+    yyterminate();
+  }
+
+  return _NUMBER_;
+}
+
+
+0o{octdigit}+  {
+
+  char *endptr;
+
+  errno = 0;
+  yylval->integer = strtoll(yytext + 2, &endptr, 8);
+
+  if (yylval->integer == LLONG_MAX && errno == ERANGE)
+  {
+    yr_compiler_set_error_extra_info(compiler, yytext);
+    compiler->last_result = ERROR_INTEGER_OVERFLOW;
+    yyerror(yyscanner, compiler, NULL);
+    yyterminate();
+  }
+
   return _NUMBER_;
 }
 
@@ -429,6 +494,14 @@ $({letter}|{digit}|_)*  {
 
   LEX_CHECK_SPACE_OK("\n", yyextra->lex_buf_len, LEX_BUF_SIZE);
   *yyextra->lex_buf_ptr++ = '\n';
+  yyextra->lex_buf_len++;
+}
+
+
+<str>\\r   {
+
+  LEX_CHECK_SPACE_OK("\r", yyextra->lex_buf_len, LEX_BUF_SIZE);
+  *yyextra->lex_buf_ptr++ = '\r';
   yyextra->lex_buf_len++;
 }
 
@@ -517,6 +590,10 @@ $({letter}|{digit}|_)*  {
 <regexp>\\. {
 
   LEX_CHECK_SPACE_OK("\\.", yyextra->lex_buf_len, LEX_BUF_SIZE);
+
+  if (yytext[1] == 0)
+    yyerror(yyscanner, compiler, "malformed regular expression");
+
   *yyextra->lex_buf_ptr++ = yytext[0];
   *yyextra->lex_buf_ptr++ = yytext[1];
   yyextra->lex_buf_len += 2;
@@ -549,7 +626,7 @@ $({letter}|{digit}|_)*  {
 }
 
 
-\{({hexdigit}|[ \-|\?\[\]\(\)\n\t])+\}  {
+\{(({hexdigit}|[ \-|\~\?\[\]\(\)\n\r\t]|\/\*(\/|\**[^*/])*\*+\/)+|\/\/.*\n)+\}  {
 
   int len = strlen(yytext);
   SIZED_STRING* s = (SIZED_STRING*) yr_malloc(len + sizeof(SIZED_STRING));

--- a/libclamav/yara_parser.c
+++ b/libclamav/yara_parser.c
@@ -19,19 +19,19 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 /*
-Copyright (c) 2013. The YARA Authors. All Rights Reserved.
+Copyright (c) 2007-2016. The YARA Authors. All Rights Reserved.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-   http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include <stddef.h>

--- a/libclamav/yara_parser.h
+++ b/libclamav/yara_parser.h
@@ -1,17 +1,17 @@
 /*
-Copyright (c) 2013. The YARA Authors. All Rights Reserved.
+Copyright (c) 2007-2016. The YARA Authors. All Rights Reserved.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-   http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #ifndef YR_PARSER_H

--- a/unit_tests/check_matchers.c
+++ b/unit_tests/check_matchers.c
@@ -241,6 +241,52 @@ START_TEST(test_ac_scanbuff)
 }
 END_TEST
 
+START_TEST(test_ac_native_hex_negation_representation)
+{
+    struct cli_ac_patt *pattern;
+    struct cli_matcher *root;
+    const uint16_t *tokens;
+    int ret;
+
+    root = ctx.engine->root[0];
+    ck_assert_msg(root != NULL, "root == NULL");
+    root->ac_only = 1;
+
+#ifdef USE_MPOOL
+    root->mempool = mpool_create();
+#endif
+    ret = cli_ac_init(root, CLI_DEFAULT_AC_MINDEPTH, CLI_DEFAULT_AC_MAXDEPTH, 1);
+    ck_assert_msg(ret == CL_SUCCESS, "cli_ac_init() failed");
+
+    ret = cli_add_content_match_pattern(
+        root,
+        "Native_Hex_Negation",
+        "4141~00~?0~0?4242",
+        0,
+        0,
+        0,
+        "*",
+        NULL,
+        0);
+    ck_assert_msg(ret == CL_SUCCESS, "cli_add_content_match_pattern failed");
+    ck_assert_uint_eq(root->ac_patterns, 1);
+
+    pattern = root->ac_pattable[0];
+    tokens  = pattern->prefix ? pattern->prefix : pattern->pattern;
+
+    /*
+     * Each negation must remain one matcher unit and must not allocate the
+     * special-alternate representation used by !(...).
+     */
+    ck_assert_uint_eq(pattern->prefix_length[0] + pattern->length[0], 7);
+    ck_assert_uint_eq(pattern->special, 0);
+    ck_assert_ptr_null(pattern->special_table);
+    ck_assert_uint_eq(tokens[2] & CLI_MATCH_METADATA, CLI_MATCH_NOT_BYTE);
+    ck_assert_uint_eq(tokens[3] & CLI_MATCH_METADATA, CLI_MATCH_NOT_NIBBLE_LOW);
+    ck_assert_uint_eq(tokens[4] & CLI_MATCH_METADATA, CLI_MATCH_NOT_NIBBLE_HIGH);
+}
+END_TEST
+
 START_TEST(test_ac_scanbuff_allscan)
 {
     struct cli_ac_data mdata;
@@ -580,6 +626,7 @@ Suite *test_matchers_suite(void)
 {
     Suite *s = suite_create("matchers");
     TCase *tc_matchers;
+    TCase *tc_hex_negation;
     tc_matchers = tcase_create("matchers");
     suite_add_tcase(s, tc_matchers);
     tcase_add_checked_fixture(tc_matchers, setup, teardown);
@@ -591,5 +638,10 @@ Suite *test_matchers_suite(void)
     tcase_add_test(tc_matchers, test_ac_scanbuff_allscan_ex);
     tcase_add_test(tc_matchers, test_bm_scanbuff_allscan);
     tcase_add_test(tc_matchers, test_pcre_scanbuff_allscan);
+
+    tc_hex_negation = tcase_create("hex negation");
+    suite_add_tcase(s, tc_hex_negation);
+    tcase_add_checked_fixture(tc_hex_negation, setup, teardown);
+    tcase_add_test(tc_hex_negation, test_ac_native_hex_negation_representation);
     return s;
 }

--- a/unit_tests/clamscan/hex_negation_test.py
+++ b/unit_tests/clamscan/hex_negation_test.py
@@ -34,6 +34,11 @@ class TC(testcase.TestCase):
             'boundary-marker-match.bin': b'xx AB xx',
             'line-marker-match.bin': b'xx\nAB\nxx',
             'word-marker-match.bin': b'xx!AB!xx',
+            'alternate-negation-match.bin': b'AB\x02DEF',
+            'alternate-negation-no-match.bin': b'AB\x00DEF',
+            'wide-negation-match.bin': b'a\x00\x01\x00b\x00',
+            'prefilter-negation-match.bin': b'\x02\x00\x00',
+            'prefilter-negation-no-match.bin': b'\x01\x00\x00',
         }
         for name, data in samples.items():
             (TC.path_tmp / name).write_bytes(data)
@@ -50,9 +55,22 @@ class TC(testcase.TestCase):
             'boundary-marker.ndb': 'Native.BoundaryMarker:0:*:(B)4142(B)\n',
             'line-marker.ndb': 'Native.LineMarker:0:*:(L)4142(L)\n',
             'word-marker.ndb': 'Native.WordMarker:0:*:(W)4142(W)\n',
+            'alternate-negation.ndb': 'Native.AlternateNegation:0:*:4142(~00|~0144)4546\n',
+            'prefilter-negation.ndb': 'Native.PrefilterNegation:0:*:~010000\n',
         }
         for name, signature in native_signatures.items():
             (TC.path_tmp / name).write_text(signature)
+
+        (TC.path_tmp / 'native-invalid-no-anchor-prefix.ndb').write_text(
+            'Native.Invalid.NoAnchorPrefix:0:*:~0041\n'
+        )
+        (TC.path_tmp / 'native-invalid-no-anchor-suffix.ndb').write_text(
+            'Native.Invalid.NoAnchorSuffix:0:*:41~00\n'
+        )
+
+        (TC.path_tmp / 'wide-negation.ldb').write_text(
+            'Native.WideNegation;Engine:90-255,Target:0;0;41~0042:*:w\n'
+        )
 
         (TC.path_tmp / 'logical.ldb').write_text(
             'Native.Logical;Engine:90-255,Target:0;0&1;4141;~004243\n'
@@ -156,6 +174,26 @@ class TC(testcase.TestCase):
         self.verify_match('gap.ndb', 'gap-match.bin', 'Native.Gap')
         self.verify_match('mixed.ndb', 'mixed-match.bin', 'Native.Mixed')
 
+    def test_native_negation_alternates_backtrack(self):
+        self.step_name('Test overlapping negated alternatives backtrack before suffix verification')
+        self.verify_match('alternate-negation.ndb', 'alternate-negation-match.bin', 'Native.AlternateNegation')
+        self.verify_no_match('alternate-negation.ndb', 'alternate-negation-no-match.bin')
+
+    def test_native_negation_wide_modifier(self):
+        self.step_name('Test wide modifier preserves negated units')
+        self.verify_match('wide-negation.ldb', 'wide-negation-match.bin', 'Native.WideNegation')
+
+    def test_native_negation_prefilter_enumerates_all_values(self):
+        self.step_name('Test prefilter does not drop accepted values after a negated q-gram')
+        self.verify_match('prefilter-negation.ndb', 'prefilter-negation-match.bin', 'Native.PrefilterNegation')
+        self.verify_no_match('prefilter-negation.ndb', 'prefilter-negation-no-match.bin')
+
+    def test_native_negation_requires_ac_anchor(self):
+        self.step_name('Test negation-only anchors respect the AC minimum depth')
+        for database in ('native-invalid-no-anchor-prefix.ndb', 'native-invalid-no-anchor-suffix.ndb'):
+            output = self.scan(database, 'not-byte-match.bin')
+            assert output.ec == 2
+
     def test_native_negation_in_logical_signature(self):
         self.step_name('Test native negation in a multi-part logical signature')
         self.verify_match('logical.ldb', 'logical-match.bin', 'Native.Logical')
@@ -199,6 +237,17 @@ class TC(testcase.TestCase):
             output = self.scan(database.name, 'not-byte-match.bin')
             assert output.ec == 2
             self.verify_output(output.err, expected=['Invalid hex negation'])
+
+    def test_native_negation_nocase_is_rejected(self):
+        self.step_name('Test nocase rejects negated hex units')
+        database = TC.path_tmp / 'native-invalid-nocase.ldb'
+        database.write_text('Native.Invalid.nocase;Engine:90-255,Target:0;0;4142~0043:*:i\n')
+        output = self.scan(database.name, 'not-byte-match.bin')
+        assert output.ec == 2
+        self.verify_output(
+            output.err,
+            expected=['nocase modifier [i] is not supported for negated hex units'],
+        )
 
     def test_existing_special_syntax_is_unchanged(self):
         self.step_name('Test existing negated alternates and marker classes')

--- a/unit_tests/clamscan/hex_negation_test.py
+++ b/unit_tests/clamscan/hex_negation_test.py
@@ -1,0 +1,225 @@
+# Copyright (C) 2026 Cisco Systems, Inc. and/or its affiliates. All rights reserved.
+
+"""
+Run native and YARA hexadecimal negation tests.
+"""
+
+import sys
+
+sys.path.append('../unit_tests')
+import testcase
+
+
+class TC(testcase.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super(TC, cls).setUpClass()
+
+        samples = {
+            'not-byte-match.bin': b'A\x01BCXX',
+            'not-byte-no-match.bin': b'A\x00BCXX',
+            'not-low-match.bin': b'A\x01BCXX',
+            'not-low-no-match.bin': b'A\x10BCXX',
+            'not-high-match.bin': b'A\x10BCXX',
+            'not-high-no-match.bin': b'A\x0fBCXX',
+            'prefix-match.bin': b'\x01ABCXX',
+            'prefix-no-match.bin': b'\x00ABCXX',
+            'suffix-match.bin': b'XXABC\x01',
+            'suffix-no-match.bin': b'XXABC\x00',
+            'gap-match.bin': b'AAxyz\x01BC',
+            'mixed-match.bin': b'AXYABXX',
+            'logical-match.bin': b'AAxyz\x01BC',
+            'legacy-special-match.bin': b'AA\x01BBXX',
+            'legacy-special-no-match.bin': b'AA\x00BBXX',
+            'boundary-marker-match.bin': b'xx AB xx',
+            'line-marker-match.bin': b'xx\nAB\nxx',
+            'word-marker-match.bin': b'xx!AB!xx',
+        }
+        for name, data in samples.items():
+            (TC.path_tmp / name).write_bytes(data)
+
+        native_signatures = {
+            'not-byte.ndb': 'Native.NotByte:0:*:41~004243\n',
+            'not-low.ndb': 'Native.NotLowNibble:0:*:41~?04243\n',
+            'not-high.ndb': 'Native.NotHighNibble:0:*:41~0?4243\n',
+            'prefix.ndb': 'Native.Prefix:0:0:~00414243\n',
+            'suffix.ndb': 'Native.Suffix:0:2:414243~00\n',
+            'gap.ndb': 'Native.Gap:0:*:4141*~004243\n',
+            'mixed.ndb': 'Native.Mixed:0:*:41??~?04?42\n',
+            'legacy-special.ndb': 'Native.LegacySpecial:0:*:4141!(00)4242\n',
+            'boundary-marker.ndb': 'Native.BoundaryMarker:0:*:(B)4142(B)\n',
+            'line-marker.ndb': 'Native.LineMarker:0:*:(L)4142(L)\n',
+            'word-marker.ndb': 'Native.WordMarker:0:*:(W)4142(W)\n',
+        }
+        for name, signature in native_signatures.items():
+            (TC.path_tmp / name).write_text(signature)
+
+        (TC.path_tmp / 'logical.ldb').write_text(
+            'Native.Logical;Engine:90-255,Target:0;0&1;4141;~004243\n'
+        )
+
+        yara_patterns = {
+            'not-byte': '~00 42',
+            'not-low': '~?0 42',
+            'not-high': '~0? 42',
+        }
+        for name, pattern in yara_patterns.items():
+            (TC.path_tmp / f'yara-{name}.yara').write_text(
+                f'''rule yara_{name.replace("-", "_")}
+{{
+    strings:
+        $a = {{ 41 {pattern} }}
+    condition:
+        $a
+}}
+'''
+            )
+
+        invalid_yara_patterns = {
+            'bare': '41 42 ~',
+            'all-wildcard': '41 ~?? 42',
+            'alternate': '41 ~( 42 | 43 ) 44',
+            'double': '41 ~~00 42',
+            'jump': '41 ~[1-2] 42',
+        }
+        for name, pattern in invalid_yara_patterns.items():
+            (TC.path_tmp / f'yara-invalid-{name}.yara').write_text(
+                f'''rule yara_invalid_{name.replace("-", "_")}
+{{
+    strings:
+        $a = {{ {pattern} }}
+    condition:
+        $a
+}}
+'''
+            )
+
+    @classmethod
+    def tearDownClass(cls):
+        super(TC, cls).tearDownClass()
+
+    def setUp(self):
+        super(TC, self).setUp()
+
+    def tearDown(self):
+        super(TC, self).tearDown()
+        self.verify_valgrind_log()
+
+    def scan(self, database, sample, extra_args=''):
+        command = '{valgrind} {valgrind_args} {clamscan} {extra_args} -d {path_db} {testfile}'.format(
+            valgrind=TC.valgrind,
+            valgrind_args=TC.valgrind_args,
+            clamscan=TC.clamscan,
+            extra_args=extra_args,
+            path_db=TC.path_tmp / database,
+            testfile=TC.path_tmp / sample,
+        )
+        return self.execute_command(command)
+
+    def verify_match(self, database, sample, signature_name):
+        output = self.scan(database, sample)
+        assert output.ec == 1
+        self.verify_output(
+            output.out,
+            expected=[
+                f'{sample}: {signature_name}.UNOFFICIAL FOUND',
+                'Infected files: 1',
+            ],
+        )
+
+    def verify_no_match(self, database, sample):
+        output = self.scan(database, sample)
+        assert output.ec == 0
+        self.verify_output(output.out, expected=[f'{sample}: OK'], unexpected=['FOUND'])
+
+    def test_native_negated_byte(self):
+        self.step_name('Test native exact-byte negation')
+        self.verify_match('not-byte.ndb', 'not-byte-match.bin', 'Native.NotByte')
+        self.verify_no_match('not-byte.ndb', 'not-byte-no-match.bin')
+
+    def test_native_negated_nibbles(self):
+        self.step_name('Test native high- and low-nibble negation')
+        self.verify_match('not-low.ndb', 'not-low-match.bin', 'Native.NotLowNibble')
+        self.verify_no_match('not-low.ndb', 'not-low-no-match.bin')
+        self.verify_match('not-high.ndb', 'not-high-match.bin', 'Native.NotHighNibble')
+        self.verify_no_match('not-high.ndb', 'not-high-no-match.bin')
+
+    def test_native_negation_at_file_boundaries(self):
+        self.step_name('Test native negation at the start and end of a file')
+        self.verify_match('prefix.ndb', 'prefix-match.bin', 'Native.Prefix')
+        self.verify_no_match('prefix.ndb', 'prefix-no-match.bin')
+        self.verify_match('suffix.ndb', 'suffix-match.bin', 'Native.Suffix')
+        self.verify_no_match('suffix.ndb', 'suffix-no-match.bin')
+
+    def test_native_negation_with_gap_and_wildcards(self):
+        self.step_name('Test native negation with gaps and ordinary wildcards')
+        self.verify_match('gap.ndb', 'gap-match.bin', 'Native.Gap')
+        self.verify_match('mixed.ndb', 'mixed-match.bin', 'Native.Mixed')
+
+    def test_native_negation_in_logical_signature(self):
+        self.step_name('Test native negation in a multi-part logical signature')
+        self.verify_match('logical.ldb', 'logical-match.bin', 'Native.Logical')
+
+    def test_yara_negation_semantics(self):
+        self.step_name('Test YARA byte and nibble negation semantics')
+        cases = [
+            ('yara-not-byte.yara', 'not-byte-match.bin', 'YARA.yara_not_byte'),
+            ('yara-not-low.yara', 'not-low-match.bin', 'YARA.yara_not_low'),
+            ('yara-not-high.yara', 'not-high-match.bin', 'YARA.yara_not_high'),
+        ]
+        for database, sample, signature_name in cases:
+            self.verify_match(database, sample, signature_name)
+
+        self.verify_no_match('yara-not-byte.yara', 'not-byte-no-match.bin')
+        self.verify_no_match('yara-not-low.yara', 'not-low-no-match.bin')
+        self.verify_no_match('yara-not-high.yara', 'not-high-no-match.bin')
+
+    def test_invalid_yara_negation_is_rejected(self):
+        self.step_name('Test invalid YARA negation forms')
+        for name in ('bare', 'all-wildcard', 'alternate', 'double', 'jump'):
+            output = self.scan(f'yara-invalid-{name}.yara', 'not-byte-match.bin')
+            assert output.ec == 2
+            self.verify_output(
+                output.err,
+                expected=['Invalid YARA hex negation'],
+            )
+
+    def test_invalid_native_negation_is_rejected(self):
+        self.step_name('Test invalid native negation forms')
+        invalid_signatures = {
+            'bare': '4142~',
+            'all-wildcard': '4142~??43',
+            'alternate': '41~(42|43)44',
+            'double': '4142~~0043',
+            'jump': '4142~[1-2]4344',
+        }
+        for name, pattern in invalid_signatures.items():
+            database = TC.path_tmp / f'native-invalid-{name}.ndb'
+            database.write_text(f'Native.Invalid.{name}:0:*:{pattern}\n')
+            output = self.scan(database.name, 'not-byte-match.bin')
+            assert output.ec == 2
+            self.verify_output(output.err, expected=['Invalid hex negation'])
+
+    def test_existing_special_syntax_is_unchanged(self):
+        self.step_name('Test existing negated alternates and marker classes')
+        self.verify_match(
+            'legacy-special.ndb',
+            'legacy-special-match.bin',
+            'Native.LegacySpecial',
+        )
+        self.verify_no_match('legacy-special.ndb', 'legacy-special-no-match.bin')
+        self.verify_match(
+            'boundary-marker.ndb',
+            'boundary-marker-match.bin',
+            'Native.BoundaryMarker',
+        )
+        self.verify_match(
+            'line-marker.ndb',
+            'line-marker-match.bin',
+            'Native.LineMarker',
+        )
+        self.verify_match(
+            'word-marker.ndb',
+            'word-marker-match.bin',
+            'Native.WordMarker',
+        )

--- a/unit_tests/clamscan/yara_parser_test.py
+++ b/unit_tests/clamscan/yara_parser_test.py
@@ -1,0 +1,120 @@
+# Copyright (C) 2026 Cisco Systems, Inc. and/or its affiliates. All rights reserved.
+
+"""
+Run clamscan YARA parser tests.
+"""
+
+import sys
+
+sys.path.append('../unit_tests')
+import testcase
+
+
+class TC(testcase.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super(TC, cls).setUpClass()
+
+        TC.sample = TC.path_tmp / 'yara-parser.sample'
+        TC.sample.write_text('AABBCC')
+
+        (TC.path_tmp / 'yara-hex-comments-private-octal.yara').write_text(
+            r'''rule yara_hex_comments_private_octal
+{
+    strings:
+        $a = { 41 /* A */ 41 // end-of-line comment
+               42 42 43 43 } private
+    condition:
+        $a and filesize == 0o6
+}
+'''
+        )
+
+        (TC.path_tmp / 'yara-unsupported-xor.yara').write_text(
+            r'''rule yara_unsupported_xor
+{
+    strings:
+        $a = "ABC" xor
+    condition:
+        $a
+}
+'''
+        )
+
+        (TC.path_tmp / 'yara-divide-by-zero.yara').write_text(
+            r'''rule yara_divide_by_zero
+{
+    strings:
+        $a = "AA"
+    condition:
+        $a and 1 \ 0 == 0
+}
+'''
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        super(TC, cls).tearDownClass()
+
+    def setUp(self):
+        super(TC, self).setUp()
+
+    def tearDown(self):
+        super(TC, self).tearDown()
+        self.verify_valgrind_log()
+
+    def test_yara_hex_comments_private_octal(self):
+        self.step_name('Test YARA hex comments, private modifier, and octal literal')
+
+        command = '{valgrind} {valgrind_args} {clamscan} -d {path_db} {testfile}'.format(
+            valgrind=TC.valgrind, valgrind_args=TC.valgrind_args,
+            clamscan=TC.clamscan,
+            path_db=TC.path_tmp / 'yara-hex-comments-private-octal.yara',
+            testfile=TC.sample,
+        )
+        output = self.execute_command(command)
+
+        assert output.ec == 1  # virus found
+
+        expected_results = [
+            'yara-parser.sample: YARA.yara_hex_comments_private_octal.UNOFFICIAL FOUND',
+            'Infected files: 1',
+        ]
+        self.verify_output(output.out, expected=expected_results)
+
+    def test_yara_unsupported_xor_modifier(self):
+        self.step_name('Test YARA unsupported xor modifier reports a parser error')
+
+        command = '{valgrind} {valgrind_args} {clamscan} -d {path_db} {testfile}'.format(
+            valgrind=TC.valgrind, valgrind_args=TC.valgrind_args,
+            clamscan=TC.clamscan,
+            path_db=TC.path_tmp / 'yara-unsupported-xor.yara',
+            testfile=TC.sample,
+        )
+        output = self.execute_command(command)
+
+        assert output.ec == 0
+
+        self.verify_output(
+            output.err,
+            expected=[
+                'unsupported string modifier "xor"',
+                'failed to parse or load 1 yara rules',
+            ],
+        )
+        self.verify_output(output.out, expected=['yara-parser.sample: OK'])
+
+    def test_yara_divide_by_zero_is_undefined(self):
+        self.step_name('Test YARA divide by zero evaluates as undefined')
+
+        command = '{valgrind} {valgrind_args} {clamscan} -d {path_db} {testfile}'.format(
+            valgrind=TC.valgrind, valgrind_args=TC.valgrind_args,
+            clamscan=TC.clamscan,
+            path_db=TC.path_tmp / 'yara-divide-by-zero.yara',
+            testfile=TC.sample,
+        )
+        output = self.execute_command(command)
+
+        assert output.ec == 0
+
+        self.verify_output(output.out, expected=['yara-parser.sample: OK'], unexpected=['FOUND'])

--- a/unit_tests/clamscan/yara_parser_test.py
+++ b/unit_tests/clamscan/yara_parser_test.py
@@ -52,6 +52,39 @@ class TC(testcase.TestCase):
 '''
         )
 
+        (TC.path_tmp / 'yara-hex-not-byte-match.yara').write_text(
+            r'''rule yara_hex_not_byte_match
+{
+    strings:
+        $a = { 41 41 ~43 42 }
+    condition:
+        $a
+}
+'''
+        )
+
+        (TC.path_tmp / 'yara-for-zero-of-no-match.yara').write_text(
+            r'''rule yara_for_zero_of_no_match
+{
+    strings:
+        $a = "AA"
+    condition:
+        for 0 of ($*) : (true)
+}
+'''
+        )
+
+        (TC.path_tmp / 'yara-for-zero-of-match.yara').write_text(
+            r'''rule yara_for_zero_of_match
+{
+    strings:
+        $a = "AA"
+    condition:
+        for 0 of ($*) : (false)
+}
+'''
+        )
+
     @classmethod
     def tearDownClass(cls):
         super(TC, cls).tearDownClass()
@@ -118,3 +151,53 @@ class TC(testcase.TestCase):
         assert output.ec == 0
 
         self.verify_output(output.out, expected=['yara-parser.sample: OK'], unexpected=['FOUND'])
+
+    def test_yara_hex_not_byte(self):
+        self.step_name('Test YARA hex not-byte syntax')
+
+        command = '{valgrind} {valgrind_args} {clamscan} -d {path_db} {testfile}'.format(
+            valgrind=TC.valgrind, valgrind_args=TC.valgrind_args,
+            clamscan=TC.clamscan,
+            path_db=TC.path_tmp / 'yara-hex-not-byte-match.yara',
+            testfile=TC.sample,
+        )
+        output = self.execute_command(command)
+
+        assert output.ec == 1  # virus found
+
+        expected_results = [
+            'yara-parser.sample: YARA.yara_hex_not_byte_match.UNOFFICIAL FOUND',
+            'Infected files: 1',
+        ]
+        self.verify_output(output.out, expected=expected_results)
+
+    def test_yara_for_zero_of(self):
+        self.step_name('Test YARA for 0 of quantifier semantics')
+
+        command = '{valgrind} {valgrind_args} {clamscan} -d {path_db} {testfile}'.format(
+            valgrind=TC.valgrind, valgrind_args=TC.valgrind_args,
+            clamscan=TC.clamscan,
+            path_db=TC.path_tmp / 'yara-for-zero-of-no-match.yara',
+            testfile=TC.sample,
+        )
+        output = self.execute_command(command)
+
+        assert output.ec == 0
+
+        self.verify_output(output.out, expected=['yara-parser.sample: OK'], unexpected=['FOUND'])
+
+        command = '{valgrind} {valgrind_args} {clamscan} -d {path_db} {testfile}'.format(
+            valgrind=TC.valgrind, valgrind_args=TC.valgrind_args,
+            clamscan=TC.clamscan,
+            path_db=TC.path_tmp / 'yara-for-zero-of-match.yara',
+            testfile=TC.sample,
+        )
+        output = self.execute_command(command)
+
+        assert output.ec == 1  # virus found
+
+        expected_results = [
+            'yara-parser.sample: YARA.yara_for_zero_of_match.UNOFFICIAL FOUND',
+            'Infected files: 1',
+        ]
+        self.verify_output(output.out, expected=expected_results)

--- a/unit_tests/clamscan/yara_parser_test.py
+++ b/unit_tests/clamscan/yara_parser_test.py
@@ -63,6 +63,29 @@ class TC(testcase.TestCase):
 '''
         )
 
+        (TC.path_tmp / 'yara-hex-not-nibble-match.yara').write_text(
+            r'''rule yara_hex_not_nibble_match
+{
+    strings:
+        $a = { 41 41 ~?3 42 ~5? 43 }
+    condition:
+        $a
+}
+'''
+        )
+
+        (TC.path_tmp / 'yara-hex-not-nibble-no-match.yara').write_text(
+            r'''rule yara_hex_not_nibble_no_match
+{
+    strings:
+        $low = { 41 41 ~?2 42 }
+        $high = { 41 41 ~4? 42 }
+    condition:
+        any of them
+}
+'''
+        )
+
         (TC.path_tmp / 'yara-for-zero-of-no-match.yara').write_text(
             r'''rule yara_for_zero_of_no_match
 {
@@ -170,6 +193,37 @@ class TC(testcase.TestCase):
             'Infected files: 1',
         ]
         self.verify_output(output.out, expected=expected_results)
+
+    def test_yara_hex_not_nibble(self):
+        self.step_name('Test YARA hex not-byte syntax with nibble wildcards')
+
+        command = '{valgrind} {valgrind_args} {clamscan} -d {path_db} {testfile}'.format(
+            valgrind=TC.valgrind, valgrind_args=TC.valgrind_args,
+            clamscan=TC.clamscan,
+            path_db=TC.path_tmp / 'yara-hex-not-nibble-match.yara',
+            testfile=TC.sample,
+        )
+        output = self.execute_command(command)
+
+        assert output.ec == 1  # virus found
+
+        expected_results = [
+            'yara-parser.sample: YARA.yara_hex_not_nibble_match.UNOFFICIAL FOUND',
+            'Infected files: 1',
+        ]
+        self.verify_output(output.out, expected=expected_results)
+
+        command = '{valgrind} {valgrind_args} {clamscan} -d {path_db} {testfile}'.format(
+            valgrind=TC.valgrind, valgrind_args=TC.valgrind_args,
+            clamscan=TC.clamscan,
+            path_db=TC.path_tmp / 'yara-hex-not-nibble-no-match.yara',
+            testfile=TC.sample,
+        )
+        output = self.execute_command(command)
+
+        assert output.ec == 0
+
+        self.verify_output(output.out, expected=['yara-parser.sample: OK'], unexpected=['FOUND'])
 
     def test_yara_for_zero_of(self):
         self.step_name('Test YARA for 0 of quantifier semantics')


### PR DESCRIPTION
Refresh ClamAV's YARA parser/lexer support toward current YARA syntax, including hex-string comments, private strings, octal literals, and clearer errors for unsupported modifiers.

Also harden YARA VM edge cases around fmap reads, divide/modulo/shift operations, undefined string operands, and add clamscan sanity tests for the new parser/runtime behavior.