### PR TITLE
method `openssl::asn1::Asn1StringRef::as_utf8` is deprecated

### DIFF
--- a/libclamav_rust/Cargo.toml
+++ b/libclamav_rust/Cargo.toml
@@ -29,7 +29,7 @@ delharc = "0.6"
 clam-sigutil = { git = "https://github.com/Cisco-Talos/clamav-signature-util", tag = "1.2.4" }
 tar = "0.4.43"
 md5 = "0.7.0"
-openssl = "0.10.70"
+openssl = "0.10.81"
 glob = "0.3.1"
 indexmap = "2.10.0"
 ruzstd = "0.8.3"

--- a/libclamav_rust/src/codesign.rs
+++ b/libclamav_rust/src/codesign.rs
@@ -591,8 +591,14 @@ impl Verifier {
                             .find(|name_entry| {
                                 name_entry.object().nid() == openssl::nid::Nid::COMMONNAME
                             })
-                            .map(|name_entry| name_entry.data().to_string())
-                            .unwrap();
+                            .ok_or_else(|| {
+                                Error::CertificateStore(
+                                    "Certificate is missing a common name".to_string(),
+                                )
+                            })?
+                            .data()
+                            .as_utf8()?
+                            .to_string();
 
                         if root_common_names.contains(&common_name) {
                             return Err(Error::CertificateStore(format!(
@@ -627,16 +633,21 @@ impl Verifier {
             let signer = pkcs7.signers(&certs, flags)?;
             let signers: Vec<String> = signer
                 .iter()
-                .map(|cert| {
-                    cert.subject_name()
+                .map(|cert| -> Result<String, Error> {
+                    let name_entry = cert
+                        .subject_name()
                         .entries()
                         .find(|name_entry| {
                             name_entry.object().nid() == openssl::nid::Nid::COMMONNAME
                         })
-                        .map(|name_entry| name_entry.data().to_string())
-                        .unwrap()
+                        .ok_or_else(|| {
+                            Error::CertificateStore(
+                                "Signer certificate is missing a common name".to_string(),
+                            )
+                        })?;
+                    Ok(name_entry.data().as_utf8()?.to_string())
                 })
-                .collect();
+                .collect::<Result<Vec<String>, Error>>()?;
 
             match result {
                 Ok(()) => {

--- a/libclamav_rust/src/codesign.rs
+++ b/libclamav_rust/src/codesign.rs
@@ -597,8 +597,7 @@ impl Verifier {
                                 )
                             })?
                             .data()
-                            .as_utf8()?
-                            .to_string();
+                            .to_string()?;
 
                         if root_common_names.contains(&common_name) {
                             return Err(Error::CertificateStore(format!(
@@ -645,7 +644,7 @@ impl Verifier {
                                 "Signer certificate is missing a common name".to_string(),
                             )
                         })?;
-                    Ok(name_entry.data().as_utf8()?.to_string())
+                    Ok(name_entry.data().to_string()?)
                 })
                 .collect::<Result<Vec<String>, Error>>()?;
 

--- a/libclamav_rust/src/codesign.rs
+++ b/libclamav_rust/src/codesign.rs
@@ -591,7 +591,7 @@ impl Verifier {
                             .find(|name_entry| {
                                 name_entry.object().nid() == openssl::nid::Nid::COMMONNAME
                             })
-                            .map(|name_entry| name_entry.data().as_utf8().unwrap().to_string())
+                            .map(|name_entry| name_entry.data().to_string())
                             .unwrap();
 
                         if root_common_names.contains(&common_name) {
@@ -633,7 +633,7 @@ impl Verifier {
                         .find(|name_entry| {
                             name_entry.object().nid() == openssl::nid::Nid::COMMONNAME
                         })
-                        .map(|name_entry| name_entry.data().as_utf8().unwrap().to_string())
+                        .map(|name_entry| name_entry.data().to_string())
                         .unwrap()
                 })
                 .collect();


### PR DESCRIPTION
Silences the warning
```
use of deprecated method `openssl::asn1::Asn1StringRef::as_utf8`: truncates at the first interior NUL byte; use `to_string` instead
```