### PR TITLE
CLAM-3049 perf(matcher): avoid slow AC heads with repeated bytes

### DIFF
--- a/libclamav/matcher-ac.c
+++ b/libclamav/matcher-ac.c
@@ -248,6 +248,126 @@ static int sort_heads_by_partno_fn(const void *a, const void *b)
     return 0;
 }
 
+static bool ac_static_window_byte(uint16_t value, uint8_t *byte)
+{
+    switch (value & CLI_MATCH_METADATA) {
+        case CLI_MATCH_CHAR:
+        case CLI_MATCH_NOCASE:
+            if (byte) {
+                *byte = (uint8_t)(value & 0xff);
+            }
+            return true;
+        default:
+            return false;
+    }
+}
+
+static bool ac_select_repeated_prefix_exact_window(const uint16_t *pattern, uint16_t length, uint8_t ac_maxdepth, uint16_t *ppos)
+{
+    const size_t depth = ac_maxdepth;
+    uint8_t repeated;
+    size_t repeated_run_len = 1;
+    size_t best_start       = 0;
+    unsigned int best_repeated_count;
+    unsigned int best_distinct_count = 0;
+    bool found                        = false;
+    size_t start;
+
+    if (!pattern || !ppos || 0 == depth || length <= depth) {
+        return false;
+    }
+
+    if (!ac_static_window_byte(pattern[0], &repeated)) {
+        return false;
+    }
+
+    while (repeated_run_len < length) {
+        uint8_t byte;
+
+        if (!ac_static_window_byte(pattern[repeated_run_len], &byte) || byte != repeated) {
+            break;
+        }
+        repeated_run_len++;
+    }
+    if (repeated_run_len < depth) {
+        return false;
+    }
+
+    best_repeated_count = (unsigned int)depth + 1;
+
+    for (start = 1; start <= (size_t)length - depth; start++) {
+        bool distinct[256]             = {false};
+        unsigned int repeated_count    = 0;
+        unsigned int distinct_count    = 0;
+        bool valid                     = true;
+        size_t i;
+
+        for (i = start; i < start + depth; i++) {
+            uint8_t byte;
+
+            if (!ac_static_window_byte(pattern[i], &byte)) {
+                valid = false;
+                break;
+            }
+            if (byte == repeated) {
+                repeated_count++;
+            }
+            if (!distinct[byte]) {
+                distinct[byte] = true;
+                distinct_count++;
+            }
+        }
+
+        if (!valid || repeated_count >= depth) {
+            continue;
+        }
+
+        if (!found ||
+            repeated_count < best_repeated_count ||
+            (repeated_count == best_repeated_count && distinct_count > best_distinct_count) ||
+            (repeated_count == best_repeated_count && distinct_count == best_distinct_count && start > best_start)) {
+            found                = true;
+            best_start           = start;
+            best_repeated_count  = repeated_count;
+            best_distinct_count  = distinct_count;
+        }
+    }
+
+    if (!found) {
+        return false;
+    }
+
+    *ppos = (uint16_t)best_start;
+    return true;
+}
+
+static void ac_shift_pattern_prefix(struct cli_ac_patt *pattern, uint16_t ppos)
+{
+    uint16_t i;
+    uint16_t j;
+
+    pattern->prefix           = pattern->pattern;
+    pattern->prefix_length[0] = ppos;
+    for (i = 0, j = 0; i < pattern->prefix_length[0]; i++) {
+        if ((pattern->prefix[i] & CLI_MATCH_WILDCARD) == CLI_MATCH_SPECIAL)
+            pattern->special_pattern++;
+
+        if ((pattern->prefix[i] & CLI_MATCH_METADATA) == CLI_MATCH_SPECIAL) {
+            pattern->prefix_length[1] += pattern->special_table[j]->len[0];
+            pattern->prefix_length[2] += pattern->special_table[j]->len[1];
+            j++;
+        } else {
+            pattern->prefix_length[1]++;
+            pattern->prefix_length[2]++;
+        }
+    }
+
+    pattern->pattern = &pattern->prefix[ppos];
+    pattern->length[0] -= pattern->prefix_length[0];
+    pattern->length[1] -= pattern->prefix_length[1];
+    pattern->length[2] -= pattern->prefix_length[2];
+}
+
 static inline void link_node_lists(struct cli_ac_list **listtable, unsigned int nentries)
 {
     struct cli_ac_list *prev = listtable[0];
@@ -3071,13 +3191,16 @@ cl_error_t cli_ac_addsig(struct cli_matcher *root, const char *virname, const ch
     }
 
     /*
-     * Check beginning bytes of the pattern up to the max-depth of the AC trie to see if:
-     *  a. it contains a wildcard, or
-     *  b. the bytes are all zeroes.
+     * Check beginning bytes of the pattern up to the max-depth of the AC trie
+     * to see if they make a poor trie head:
+     *  a. the window contains a wildcard,
+     *  b. the window is all zeroes, or
+     *  c. the pattern starts with a repeated exact byte.
      *
-     * If it does, we can try to shift the start of the pattern the right, have those beginning
-     * bytes be a "prefix" which gets backwards-matched after the AC match.
-     * This happens in the call to ac_backward_match_branch() in ac_forward_match_branch()
+     * If so, try to shift the start of the pattern to the right and store the
+     * original bytes as a prefix that gets backwards-matched after the AC match.
+     * This happens in the call to ac_backward_match_branch() in
+     * ac_forward_match_branch().
      */
     for (i = 0; i < root->ac_maxdepth && i < new->length[0]; i++) {
         if (new->pattern[i] & CLI_MATCH_WILDCARD) {
@@ -3159,30 +3282,9 @@ cl_error_t cli_ac_addsig(struct cli_matcher *root, const char *virname, const ch
             return CL_EMALFDB;
         }
 
-        // Store those initial bytes as the pattern "prefix" (the stuff before what goes in the AC Trie)
-        new->prefix = new->pattern;
-        // The "prefix" length is the number of bytes before the starting position of the pattern that goes in the AC Trie.
-        new->prefix_length[0] = ppos;
-        for (i = 0, j = 0; i < new->prefix_length[0]; i++) {
-            if ((new->prefix[i] & CLI_MATCH_WILDCARD) == CLI_MATCH_SPECIAL)
-                new->special_pattern++;
-
-            if ((new->prefix[i] & CLI_MATCH_METADATA) == CLI_MATCH_SPECIAL) {
-                new->prefix_length[1] += new->special_table[j]->len[0];
-                new->prefix_length[2] += new->special_table[j]->len[1];
-                j++;
-            } else {
-                new->prefix_length[1]++;
-                new->prefix_length[2]++;
-            }
-        }
-
-        // Update the pattern to start at the shifted position with the static bytes.
-        new->pattern = &new->prefix[ppos];
-        // And update the pattern length to remove the prefix bytes.
-        new->length[0] -= new->prefix_length[0];
-        new->length[1] -= new->prefix_length[1];
-        new->length[2] -= new->prefix_length[2];
+        ac_shift_pattern_prefix(new, ppos);
+    } else if (ac_select_repeated_prefix_exact_window(new->pattern, new->length[0], root->ac_maxdepth, &ppos)) {
+        ac_shift_pattern_prefix(new, ppos);
     }
 
     if (new->length[2] + new->prefix_length[2] > root->maxpatlen) {

--- a/libclamav/matcher-ac.c
+++ b/libclamav/matcher-ac.c
@@ -318,7 +318,10 @@ static bool ac_select_repeated_prefix_exact_window(const uint16_t *pattern, uint
             }
         }
 
-        if (!valid || repeated_count >= depth) {
+        /* Replacing one repeated trie head with another only changes which
+         * common byte can produce excessive candidates. Require the shifted
+         * window to contain a transition, regardless of the repeated value. */
+        if (!valid || repeated_count >= depth || distinct_count < 2) {
             continue;
         }
 

--- a/unit_tests/check_matchers.c
+++ b/unit_tests/check_matchers.c
@@ -241,6 +241,49 @@ START_TEST(test_ac_scanbuff)
 }
 END_TEST
 
+START_TEST(test_ac_repeated_prefix_does_not_shift_to_repeated_window)
+{
+    static const unsigned char data[] = {0xff, 0xff, 0xff, 0x00, 0x00, 0x00};
+    struct cli_ac_data mdata;
+    struct cli_ac_patt *pattern;
+    struct cli_matcher *root;
+    cl_error_t status;
+
+    root = ctx.engine->root[0];
+    ck_assert_msg(root != NULL, "root == NULL");
+    root->ac_only = 1;
+
+#ifdef USE_MPOOL
+    root->mempool = mpool_create();
+#endif
+    status = cli_ac_init(root, CLI_DEFAULT_AC_MINDEPTH, CLI_DEFAULT_AC_MAXDEPTH, 1);
+    ck_assert_msg(status == CL_SUCCESS, "cli_ac_init() failed");
+
+    status = cli_add_content_match_pattern(root, "RepeatedPrefixTransition", "ffffff000000", 0, 0, 0, "*", NULL, 0);
+    ck_assert_msg(status == CL_SUCCESS, "cli_add_content_match_pattern failed");
+    ck_assert_uint_eq(root->ac_patterns, 1);
+
+    pattern = root->ac_pattable[0];
+    ck_assert_ptr_nonnull(pattern);
+    ck_assert_uint_eq(pattern->prefix_length[0], 2);
+    ck_assert_uint_eq(pattern->depth, CLI_DEFAULT_AC_MAXDEPTH);
+    ck_assert_uint_eq(pattern->pattern[0] & 0xff, 0xff);
+    ck_assert_uint_eq(pattern->pattern[1] & 0xff, 0x00);
+    ck_assert_uint_eq(pattern->pattern[2] & 0xff, 0x00);
+
+    status = cli_ac_buildtrie(root);
+    ck_assert_msg(status == CL_SUCCESS, "cli_ac_buildtrie() failed");
+    status = cli_ac_initdata(&mdata, root->ac_partsigs, 0, 0, CLI_DEFAULT_AC_TRACKLEN);
+    ck_assert_msg(status == CL_SUCCESS, "cli_ac_initdata() failed");
+
+    status = cli_ac_scanbuff(data, sizeof(data), &virname, NULL, NULL, root, &mdata, 0, 0, NULL, AC_SCAN_VIR, NULL);
+    ck_assert_msg(status == CL_VIRUS, "cli_ac_scanbuff() failed");
+    ck_assert_msg(!strncmp(virname, "RepeatedPrefixTransition", strlen("RepeatedPrefixTransition")), "Incorrect signature matched in cli_ac_scanbuff()\n");
+
+    cli_ac_freedata(&mdata);
+}
+END_TEST
+
 START_TEST(test_ac_scanbuff_allscan)
 {
     struct cli_ac_data mdata;
@@ -584,6 +627,7 @@ Suite *test_matchers_suite(void)
     suite_add_tcase(s, tc_matchers);
     tcase_add_checked_fixture(tc_matchers, setup, teardown);
     tcase_add_test(tc_matchers, test_ac_scanbuff);
+    tcase_add_test(tc_matchers, test_ac_repeated_prefix_does_not_shift_to_repeated_window);
     tcase_add_test(tc_matchers, test_ac_scanbuff_ex);
     tcase_add_test(tc_matchers, test_bm_scanbuff);
     tcase_add_test(tc_matchers, test_pcre_scanbuff);


### PR DESCRIPTION
## Summary

This PR extends ClamAV's existing AC matcher prefix-shift optimization so patterns that begin with a repeated exact byte do not use that low-selectivity repeated-byte window as the trie head.

The existing matcher already shifts poor heads when the first AC window contains wildcards or is all zero bytes. This adds the same treatment for repeated exact-byte prefixes, such as long runs of `0x20` spaces, while preserving the skipped bytes as a backwards-checked prefix.

## Problem

Some production hex signatures start a sub-pattern with many copies of the same byte. When that byte is common in scanned content, the AC trie produces a large number of candidate branches before the rest of the pattern can reject the match.

The motivating case is a real sample scanned with `main.ldb`, where several Valyria signatures start with repeated spaces. The scan spent minutes in this matcher path even though the file ultimately scanned clean.

Representative slow signatures from `main.ldb` included:

- `Xls.Dropper.Valyria-6680530-0`
- `Xls.Dropper.Valyria-6680531-0`
- `Doc.Dropper.Valyria-6680532-0`
- `Doc.Dropper.Valyria-6680533-0`
- `Doc.Malware.Valyria-6691358-0`

## Solution

The new helper detects when a pattern starts with a run of the same static byte at least as long as the AC trie depth. It then scans for a later exact static window of the same depth and chooses the best window using these tie-breaks:

1. fewer occurrences of the repeated prefix byte,
2. more distinct bytes,
3. later position when the first two are tied.

The skipped leading bytes are stored as the pattern prefix and verified by the existing backwards-match path, so match semantics remain unchanged. The previous wildcard/all-zero prefix-shift path now uses the same shared prefix helper.

## Benchmark Results

Release builds from the same base commit were compared on macOS with local `main.ldb` and a known slow sample. Both scans returned `OK`.

Focused five-signature Valyria repro:

- main: `5.846 sec` ClamAV summary, `5.85 real`
- branch: `2.134 sec` ClamAV summary, `2.14 real`
- result: about `2.7x` faster

Full `main.ldb` repro:

- main: `262.176 sec` ClamAV summary, `262.18 real`, `254.78 user`
- branch: `3.302 sec` ClamAV summary, `3.31 real`, `2.20 user`
- result: about `79x` faster

Benchmark command shape:

```sh
clamscan -d ~/main-unpacked/main.ldb ~/Downloads/c72ca7651909b7bd89bc05dbd18be88fe8a22c4cbff0b837d016ea1be9caf277
```

Note: I can't provide the test sample here for privacy reasons. 