### PR TITLE
CLAM-3002: Libclamav: fix assorted parser edge cases

### DIFF
--- a/libclamav/entconv.c
+++ b/libclamav/entconv.c
@@ -123,18 +123,23 @@ const char* entity_norm(struct entity_conv* conv, const unsigned char* entity)
     return NULL;
 }
 
-#ifndef HAVE_ICONV
 static size_t encoding_bytes(const char* fromcode, enum encodings* encoding)
 {
+    enum encodings detected_encoding;
+
     /* special case for these unusual byteorders */
     struct cli_element* e = cli_hashtab_find(&aliases_htable, fromcode, strlen(fromcode));
     if (e && e->key) {
-        *encoding = (enum encodings)e->data;
+        detected_encoding = (enum encodings)e->data;
     } else {
-        *encoding = E_OTHER;
+        detected_encoding = E_OTHER;
     }
 
-    switch (*encoding) {
+    if (encoding) {
+        *encoding = detected_encoding;
+    }
+
+    switch (detected_encoding) {
         case E_UCS4:
         case E_UCS4_1234:
         case E_UCS4_4321:
@@ -153,6 +158,7 @@ static size_t encoding_bytes(const char* fromcode, enum encodings* encoding)
     }
 }
 
+#ifndef HAVE_ICONV
 static iconv_t iconv_open(const char* tocode, const char* fromcode)
 {
     UNUSEDPARAM(tocode);
@@ -271,31 +277,50 @@ static int iconv(iconv_t iconv_struct, char** inbuf, size_t* inbytesleft,
             const size_t maxread  = *inbytesleft;
             const size_t maxwrite = *outbytesleft;
             size_t j;
-            for (i = 0, j = 0; i < maxread && j < maxwrite;) {
+            for (i = 0, j = 0; i < maxread && j + 1 < maxwrite;) {
                 if (input[i] < 0x7F) {
                     output[j++] = 0;
                     output[j++] = input[i++];
                 } else if ((input[i] & 0xE0) == 0xC0) {
+                    if (i + 1 >= maxread) {
+                        output[j++] = 0;
+                        output[j++] = input[i++];
+                        continue;
+                    }
                     if ((input[i + 1] & 0xC0) == 0x80) {
                         /* 2 bytes long 110yyyyy zzzzzzzz -> 00000yyy yyzzzzzz*/
                         output[j++] = ((input[i] & 0x1F) >> 2) & 0x07;
                         output[j++] = ((input[i] & 0x1F) << 6) | (input[i + 1] & 0x3F);
                     } else {
                         cli_dbgmsg(MODULE_NAME "invalid UTF8 character encountered\n");
-                        break;
+                        output[j++] = 0;
+                        output[j++] = input[i++];
+                        continue;
                     }
                     i += 2;
                 } else if ((input[i] & 0xE0) == 0xE0) {
+                    if (i + 2 >= maxread) {
+                        output[j++] = 0;
+                        output[j++] = input[i++];
+                        continue;
+                    }
                     if ((input[i + 1] & 0xC0) == 0x80 && (input[i + 2] & 0xC0) == 0x80) {
                         /* 3 bytes long 1110xxxx 10yyyyyy 10zzzzzzzz -> xxxxyyyy yyzzzzzz*/
                         output[j++] = (input[i] << 4) | ((input[i + 1] >> 2) & 0x0F);
                         output[j++] = (input[i + 1] << 6) | (input[i + 2] & 0x3F);
                     } else {
                         cli_dbgmsg(MODULE_NAME "invalid UTF8 character encountered\n");
-                        break;
+                        output[j++] = 0;
+                        output[j++] = input[i++];
+                        continue;
                     }
                     i += 3;
                 } else if ((input[i] & 0xF8) == 0xF0) {
+                    if (i + 3 >= maxread) {
+                        output[j++] = 0;
+                        output[j++] = input[i++];
+                        continue;
+                    }
                     if ((input[i + 1] & 0xC0) == 0x80 && (input[i + 2] & 0xC0) == 0x80 && (input[i + 3] & 0xC0) == 0x80) {
                         /* 4 bytes long 11110www 10xxxxxx 10yyyyyy 10zzzzzz -> 000wwwxx xxxxyyyy yyzzzzzz*/
                         cli_dbgmsg(MODULE_NAME "UTF8 character out of UTF16 range encountered\n");
@@ -307,22 +332,21 @@ static int iconv(iconv_t iconv_struct, char** inbuf, size_t* inbytesleft,
                                                         out[j++] = (input[i+2] << 6) | (input[i+2] & 0x3F);*/
                     } else {
                         cli_dbgmsg(MODULE_NAME "invalid UTF8 character encountered\n");
-                        break;
+                        output[j++] = 0;
+                        output[j++] = input[i++];
+                        continue;
                     }
                     i += 4;
                 } else {
                     cli_dbgmsg(MODULE_NAME "invalid UTF8 character encountered\n");
-                    break;
+                    output[j++] = 0;
+                    output[j++] = input[i++];
                 }
             }
             *inbytesleft -= i;
             *outbytesleft -= j;
             *inbuf += i;
             *outbuf += j;
-            if (*inbytesleft && *outbytesleft) {
-                errno = EILSEQ; /* we had an early exit */
-                return -1;
-            }
             if (*inbytesleft) {
                 errno = E2BIG;
                 return -1;
@@ -676,7 +700,7 @@ static iconv_t iconv_open_cached(const char* fromcode)
     return (iconv_t)-1;
 }
 
-static int in_iconv_u16(const m_area_t* in_m_area, iconv_t* iconv_struct, m_area_t* out_m_area)
+static int in_iconv_u16(const m_area_t* in_m_area, iconv_t* iconv_struct, m_area_t* out_m_area, size_t encoding_width)
 {
     char tmp4[4];
     size_t inleft = in_m_area->length - in_m_area->offset;
@@ -689,29 +713,31 @@ static int in_iconv_u16(const m_area_t* in_m_area, iconv_t* iconv_struct, m_area
     if (!inleft) {
         return 0;
     }
+    if (encoding_width == 0 || encoding_width > sizeof(tmp4)) {
+        encoding_width = sizeof(tmp4);
+    }
     /* convert encoding conv->tmp_area. conv->out_area */
 
     /*
-     * iconv gives an error if we give it less than 4 bytes to convert,
-     * and we are using ucs4, ditto for utf16, and 1 byte.
+     * iconv gives an error if we give it an incomplete fixed-width code unit.
      *
      * If an alignfix is needed, we just trim the extra un-aligned
      * bytes from the buffer.
-     * We hold on to the extra bytes, putting them into an aligned 4-byte
+     * We hold on to the extra bytes, putting them into a zero-padded
      * buffer (tmp4), and then convert them with a final call to iconv.
      */
-    alignfix = inleft % 4;
+    alignfix = inleft % encoding_width;
     inleft -= alignfix;
 
     if (alignfix) {
-        /* Number of bytes is not mod(4).
+        /* Number of bytes is not a multiple of the encoding width.
          * Copy the unaligned bytes from the end of the input.*/
         memset(tmp4, 0, 4);
         memcpy(tmp4, input + inleft, alignfix);
 
         if (inleft == 0) {
-            /* Total number of bytes was < 4, so we only have the "unaligned" bytes to convert. */
-            inleft   = 4;
+            /* Only the unaligned bytes remain to convert. */
+            inleft   = encoding_width;
             input    = tmp4;
             alignfix = 0;
         }
@@ -731,7 +757,7 @@ static int in_iconv_u16(const m_area_t* in_m_area, iconv_t* iconv_struct, m_area
             cli_dbgmsg(MODULE_NAME "iconv consumed all input\n");
             if (alignfix) {
                 /* Convert the "unaligned" bytes. */
-                inleft   = 4;
+                inleft   = encoding_width;
                 input    = tmp4;
                 alignfix = 0;
                 continue;
@@ -757,7 +783,7 @@ static int in_iconv_u16(const m_area_t* in_m_area, iconv_t* iconv_struct, m_area
 
         if (0 == inleft && alignfix) {
             /* Convert the "unaligned" bytes. */
-            inleft   = 4;
+            inleft   = encoding_width;
             input    = tmp4;
             alignfix = 0;
             continue;
@@ -784,6 +810,7 @@ int encoding_normalize_toascii(const m_area_t* in_m_area, const char* initial_en
     iconv_t iconv_struct;
     off_t i, j;
     char* encoding;
+    size_t encoding_width;
 
     if (!initial_encoding || !in_m_area || !out_m_area) {
         return CL_ENULLARG;
@@ -796,6 +823,7 @@ int encoding_normalize_toascii(const m_area_t* in_m_area, const char* initial_en
     }
 
     cli_dbgmsg(MODULE_NAME "Encoding %s\n", encoding);
+    encoding_width = encoding_bytes(encoding, NULL);
     iconv_struct = iconv_open_cached(encoding);
     if (iconv_struct == (iconv_t)-1) {
         cli_dbgmsg(MODULE_NAME "Encoding not accepted by iconv_open(): %s\n", encoding);
@@ -803,7 +831,7 @@ int encoding_normalize_toascii(const m_area_t* in_m_area, const char* initial_en
         return -1;
     }
     free(encoding);
-    in_iconv_u16(in_m_area, &iconv_struct, out_m_area);
+    in_iconv_u16(in_m_area, &iconv_struct, out_m_area, encoding_width);
     for (i = 0, j = 0; i < out_m_area->length; i += 2) {
         const unsigned char c = (out_m_area->buffer[i] << 4) + out_m_area->buffer[i + 1];
         if (c) {

--- a/libclamav/pdf.c
+++ b/libclamav/pdf.c
@@ -2389,12 +2389,16 @@ void pdf_parseobj(struct pdf_struct *pdf, struct pdf_obj *obj)
 
         dict_length -= q2 - q;
         q = q2;
+        if (dict_length <= 1)
+            break;
         /* normalize PDF names */
-        for (i = 0; dict_length > 0 && (i < sizeof(pdfname) - 1); i++) {
+        for (i = 0; dict_length > 1 && (i < sizeof(pdfname) - 1); i++) {
             q++;
             dict_length--;
 
             if (*q == '#') {
+                if (dict_length < 3)
+                    break;
                 if (cli_hex2str_to(q + 1, pdfname + i, 2) == -1)
                     break;
 

--- a/libclamav/pdf.c
+++ b/libclamav/pdf.c
@@ -2840,8 +2840,10 @@ static int pdf_readint(const char *q0, int len, const char *key)
         value = -1;
     } else if (CL_SUCCESS != cli_strntol_wrap(q, (size_t)len, 0, 10, &value)) {
         value = -1;
+    } else if (value < INT_MIN || value > INT_MAX) {
+        value = -1;
     }
-    return value;
+    return (int)value;
 }
 
 static int pdf_readbool(const char *q0, int len, const char *key, int Default)

--- a/libclamav/pe.c
+++ b/libclamav/pe.c
@@ -2204,7 +2204,9 @@ static int validate_impname(const char *name, uint32_t length, int dll)
             (*c >= 'a' && *c <= 'z') ||
             (*c >= 'A' && *c <= 'Z') ||
             (*c == '_') ||
-            (dll && *c == '.')) {
+            (*c == '.') ||
+            (dll && *c == '+') ||
+            (dll && *c == '-')) {
 
             c++;
             i++;
@@ -2213,6 +2215,56 @@ static int validate_impname(const char *name, uint32_t length, int dll)
     }
 
     return 1;
+}
+
+/**
+ * Read a PE import name, preserving the legacy local cap.
+ *
+ * PE import strings are NUL-terminated, but not limited by PE_MAXNAMESIZE. If a
+ * name exceeds the local cap, keep the old capped-prefix behavior instead of
+ * scanning farther for a terminator. Only reject as unterminated when all
+ * available bytes fit within the cap and no NUL was found.
+ */
+static cl_error_t read_pe_impname(fmap_t *map, size_t offset, size_t fsize, const char *name_kind, const char **buffer, size_t *name_len)
+{
+    size_t available;
+    size_t name_size;
+    const char *name;
+    size_t len;
+
+    if (offset > fsize) {
+        cli_dbgmsg("scan_pe: invalid offset for imported %s name\n", name_kind);
+        return CL_EFORMAT;
+    }
+
+    available = fsize - offset;
+    name_size = MIN(PE_MAXNAMESIZE, available);
+    if (name_size == 0) {
+        cli_dbgmsg("scan_pe: empty name for imported %s\n", name_kind);
+        return CL_EFORMAT;
+    }
+
+    name = fmap_need_off_once(map, offset, name_size);
+    if (name == NULL) {
+        cli_dbgmsg("scan_pe: failed to read name for imported %s\n", name_kind);
+        return CL_EREAD;
+    }
+
+    len = CLI_STRNLEN(name, name_size);
+    if (len == 0) {
+        cli_dbgmsg("scan_pe: empty name for imported %s\n", name_kind);
+        return CL_EFORMAT;
+    }
+
+    if (len == name_size && available <= PE_MAXNAMESIZE) {
+        cli_dbgmsg("scan_pe: unterminated name for imported %s\n", name_kind);
+        return CL_EFORMAT;
+    }
+
+    *buffer   = name;
+    *name_len = len;
+
+    return CL_SUCCESS;
 }
 
 static inline int hash_impfns(cli_ctx *ctx, void **hashctx, uint32_t *impsz, struct pe_image_import_descriptor *image, const char *dllname, struct cli_exe_info *peinfo, int *first)
@@ -2262,7 +2314,13 @@ static inline int hash_impfns(cli_ctx *ctx, void **hashctx, uint32_t *impsz, str
             }                                                                       \
                                                                                     \
             funclen = strlen(funcname);                                             \
-            if (validate_impname(funcname, funclen, 1) == 0) {                      \
+            if (funclen == 0) {                                                     \
+                cli_dbgmsg("scan_pe: empty name for imported function\n");          \
+                ret = CL_EFORMAT;                                                   \
+                break;                                                              \
+            }                                                                       \
+                                                                                    \
+            if (validate_impname(funcname, funclen, 0) == 0) {                      \
                 cli_dbgmsg("scan_pe: invalid name for imported function\n");        \
                 ret = CL_EFORMAT;                                                   \
                 break;                                                              \
@@ -2315,14 +2373,17 @@ static inline int hash_impfns(cli_ctx *ctx, void **hashctx, uint32_t *impsz, str
                 if (!err && offset <= fsize && fsize - offset > sizeof(uint16_t)) {
                     /* Hint field is a uint16_t and precedes the Name field */
                     const size_t name_offset = (size_t)offset + sizeof(uint16_t);
-                    const size_t name_size   = MIN(PE_MAXNAMESIZE, fsize - name_offset);
+                    size_t name_len;
 
-                    if ((buffer = fmap_need_off_once(map, name_offset, name_size)) != NULL) {
-                        funcname = CLI_STRNDUP(buffer, name_size);
-                        if (funcname == NULL) {
-                            cli_dbgmsg("scan_pe: cannot duplicate function name\n");
-                            return CL_EMEM;
-                        }
+                    ret = read_pe_impname(map, name_offset, fsize, "function", &buffer, &name_len);
+                    if (ret != CL_SUCCESS) {
+                        return ret;
+                    }
+
+                    funcname = CLI_STRNDUP(buffer, name_len);
+                    if (funcname == NULL) {
+                        cli_dbgmsg("scan_pe: cannot duplicate function name\n");
+                        return CL_EMEM;
                     }
                 }
             } else {
@@ -2359,14 +2420,17 @@ static inline int hash_impfns(cli_ctx *ctx, void **hashctx, uint32_t *impsz, str
                 if (!err && offset <= fsize && fsize - offset > sizeof(uint16_t)) {
                     /* Hint field is a uint16_t and precedes the Name field */
                     const size_t name_offset = (size_t)offset + sizeof(uint16_t);
-                    const size_t name_size   = MIN(PE_MAXNAMESIZE, fsize - name_offset);
+                    size_t name_len;
 
-                    if ((buffer = fmap_need_off_once(map, name_offset, name_size)) != NULL) {
-                        funcname = CLI_STRNDUP(buffer, name_size);
-                        if (funcname == NULL) {
-                            cli_dbgmsg("scan_pe: cannot duplicate function name\n");
-                            return CL_EMEM;
-                        }
+                    ret = read_pe_impname(map, name_offset, fsize, "function", &buffer, &name_len);
+                    if (ret != CL_SUCCESS) {
+                        return ret;
+                    }
+
+                    funcname = CLI_STRNDUP(buffer, name_len);
+                    if (funcname == NULL) {
+                        cli_dbgmsg("scan_pe: cannot duplicate function name\n");
+                        return CL_EMEM;
                     }
                 }
             } else {
@@ -2447,6 +2511,7 @@ static cl_error_t hash_imptbl(cli_ctx *ctx, uint8_t **digest, uint32_t *impsz, b
 
     while (left > sizeof(struct pe_image_import_descriptor) && nimps < PE_MAXIMPORTS) {
         char *dllname = NULL;
+        size_t dllname_len = 0;
 
         // Temporary variable so we don't have overlapping writes with the EC32 reads.
         uint32_t temp;
@@ -2489,20 +2554,19 @@ static cl_error_t hash_imptbl(cli_ctx *ctx, uint8_t **digest, uint32_t *impsz, b
             goto done;
         }
 
-        buffer = fmap_need_off_once(map, offset, MIN(PE_MAXNAMESIZE, fsize - offset));
-        if (buffer == NULL) {
-            cli_dbgmsg("scan_pe: failed to read name for dll\n");
-            status = CL_EREAD;
+        ret = read_pe_impname(map, offset, fsize, "dll", &buffer, &dllname_len);
+        if (ret != CL_SUCCESS) {
+            status = ret;
             goto done;
         }
 
-        if (validate_impname(dllname, MIN(PE_MAXNAMESIZE, fsize - offset), 1) == 0) {
+        if (validate_impname(buffer, dllname_len, 1) == 0) {
             cli_dbgmsg("scan_pe: invalid name for imported dll\n");
             status = CL_EFORMAT;
             goto done;
         }
 
-        dllname = CLI_STRNDUP(buffer, MIN(PE_MAXNAMESIZE, fsize - offset));
+        dllname = CLI_STRNDUP(buffer, dllname_len);
         if (dllname == NULL) {
             cli_dbgmsg("scan_pe: cannot duplicate dll name\n");
             status = CL_EMEM;

--- a/libclamav/pe.c
+++ b/libclamav/pe.c
@@ -2312,10 +2312,13 @@ static inline int hash_impfns(cli_ctx *ctx, void **hashctx, uint32_t *impsz, str
             if (!(thunk32.u.Ordinal & PE_IMAGEDIR_ORDINAL_FLAG32)) {
                 offset = cli_rawaddr(thunk32.u.Function, peinfo->sections, peinfo->nsections, &err, fsize, peinfo->hdr_size);
 
-                if (!ret) {
+                if (!err && offset <= fsize && fsize - offset > sizeof(uint16_t)) {
                     /* Hint field is a uint16_t and precedes the Name field */
-                    if ((buffer = fmap_need_off_once(map, offset + sizeof(uint16_t), MIN(PE_MAXNAMESIZE, fsize - offset))) != NULL) {
-                        funcname = CLI_STRNDUP(buffer, MIN(PE_MAXNAMESIZE, fsize - offset));
+                    const size_t name_offset = (size_t)offset + sizeof(uint16_t);
+                    const size_t name_size   = MIN(PE_MAXNAMESIZE, fsize - name_offset);
+
+                    if ((buffer = fmap_need_off_once(map, name_offset, name_size)) != NULL) {
+                        funcname = CLI_STRNDUP(buffer, name_size);
                         if (funcname == NULL) {
                             cli_dbgmsg("scan_pe: cannot duplicate function name\n");
                             return CL_EMEM;
@@ -2353,10 +2356,13 @@ static inline int hash_impfns(cli_ctx *ctx, void **hashctx, uint32_t *impsz, str
             if (!(thunk64.u.Ordinal & PE_IMAGEDIR_ORDINAL_FLAG64)) {
                 offset = cli_rawaddr(thunk64.u.Function, peinfo->sections, peinfo->nsections, &err, fsize, peinfo->hdr_size);
 
-                if (!err) {
+                if (!err && offset <= fsize && fsize - offset > sizeof(uint16_t)) {
                     /* Hint field is a uint16_t and precedes the Name field */
-                    if ((buffer = fmap_need_off_once(map, offset + sizeof(uint16_t), MIN(PE_MAXNAMESIZE, fsize - offset))) != NULL) {
-                        funcname = CLI_STRNDUP(buffer, MIN(PE_MAXNAMESIZE, fsize - offset));
+                    const size_t name_offset = (size_t)offset + sizeof(uint16_t);
+                    const size_t name_size   = MIN(PE_MAXNAMESIZE, fsize - name_offset);
+
+                    if ((buffer = fmap_need_off_once(map, name_offset, name_size)) != NULL) {
+                        funcname = CLI_STRNDUP(buffer, name_size);
                         if (funcname == NULL) {
                             cli_dbgmsg("scan_pe: cannot duplicate function name\n");
                             return CL_EMEM;

--- a/libclamav/pe.c
+++ b/libclamav/pe.c
@@ -2191,7 +2191,7 @@ static char *pe_ordinal(const char *dll, uint16_t ord)
     return cli_safer_strdup(name);
 }
 
-static int validate_impname(const char *name, uint32_t length, int dll)
+static int validate_impname(const char *name, uint32_t length, bool dll)
 {
     uint32_t i    = 0;
     const char *c = name;
@@ -2200,13 +2200,14 @@ static int validate_impname(const char *name, uint32_t length, int dll)
         return 1;
 
     while (i < length && *c != '\0') {
-        if ((*c >= '0' && *c <= '9') ||
-            (*c >= 'a' && *c <= 'z') ||
-            (*c >= 'A' && *c <= 'Z') ||
-            (*c == '_') ||
-            (*c == '.') ||
-            (dll && *c == '+') ||
-            (dll && *c == '-')) {
+        unsigned char ch = (unsigned char)*c;
+
+        if ((dll && ch >= ' ' && ch <= '~') ||
+            (!dll && ((ch >= '0' && ch <= '9') ||
+                      (ch >= 'a' && ch <= 'z') ||
+                      (ch >= 'A' && ch <= 'Z') ||
+                      ch == '_' ||
+                      ch == '.'))) {
 
             c++;
             i++;
@@ -2320,7 +2321,7 @@ static inline int hash_impfns(cli_ctx *ctx, void **hashctx, uint32_t *impsz, str
                 break;                                                              \
             }                                                                       \
                                                                                     \
-            if (validate_impname(funcname, funclen, 0) == 0) {                      \
+            if (validate_impname(funcname, funclen, false) == 0) {                  \
                 cli_dbgmsg("scan_pe: invalid name for imported function\n");        \
                 ret = CL_EFORMAT;                                                   \
                 break;                                                              \
@@ -2560,7 +2561,7 @@ static cl_error_t hash_imptbl(cli_ctx *ctx, uint8_t **digest, uint32_t *impsz, b
             goto done;
         }
 
-        if (validate_impname(buffer, dllname_len, 1) == 0) {
+        if (validate_impname(buffer, dllname_len, true) == 0) {
             cli_dbgmsg("scan_pe: invalid name for imported dll\n");
             status = CL_EFORMAT;
             goto done;

--- a/libclamav/rtf.c
+++ b/libclamav/rtf.c
@@ -373,15 +373,15 @@ static int rtf_object_process(struct rtf_state* state, const unsigned char* inpu
                 break;
             }
             case WAIT_ZERO: {
-                if (out_cnt < 8 - data->bread) {
-                    out_cnt = 0;
+                const size_t zero_remaining = 8 - data->bread;
+
+                if (out_cnt < zero_remaining) {
                     data->bread += out_cnt;
+                    out_data += out_cnt;
+                    out_cnt = 0;
                 } else {
-                    out_cnt -= 8 - data->bread;
-                    data->bread = 8;
-                }
-                if (data->bread == 8) {
-                    out_data += 8;
+                    out_cnt -= zero_remaining;
+                    out_data += zero_remaining;
                     data->bread = 0;
                     cli_dbgmsg("RTF: next state: wait_data_size\n");
                     data->internal_state = WAIT_DATA_SIZE;

--- a/unit_tests/clamscan/allmatch_test.py
+++ b/unit_tests/clamscan/allmatch_test.py
@@ -131,6 +131,35 @@ class TC(testcase.TestCase):
         ]
         self.verify_output(output.out, expected=expected_results)
 
+    def test_imphash_dll_name_with_spaces(self):
+        self.step_name('Test an import hash for a DLL name containing spaces.')
+
+        source = TC.path_build / 'unit_tests' / 'input' / 'clamav_hdb_scanfiles' / 'clam.exe'
+        testfile = TC.path_tmp / 'clam-spaced-dll.exe'
+        source_bytes = source.read_bytes()
+
+        assert source_bytes.count(b'KERNEL32.DLL') == 1
+        testfile.write_bytes(source_bytes.replace(b'KERNEL32.DLL', b'My Lib 1.dll'))
+
+        signature = TC.path_tmp / 'spaced-dll.imp'
+        signature.write_text(
+            "adde318b8c1d940e336fbb4451d30692:39:Test.Import.Hash.SpacedDll\n"
+        )
+
+        command = '{valgrind} {valgrind_args} {clamscan} -d {signature} {testfile}'.format(
+            valgrind=TC.valgrind, valgrind_args=TC.valgrind_args, clamscan=TC.clamscan,
+            signature=signature,
+            testfile=testfile,
+        )
+        output = self.execute_command(command)
+
+        assert output.ec == 1  # virus
+
+        expected_results = [
+            'Test.Import.Hash.SpacedDll.UNOFFICIAL FOUND',
+        ]
+        self.verify_output(output.out, expected=expected_results)
+
     def test_regression_cbc_and_ndb(self):
         self.step_name('Test that bytecode rules will run after content match alerts in all-match mode.')
 


### PR DESCRIPTION
## Summary

This PR fixes a set of small parser edge cases in libclamav that were found during review of parser memory-safety behavior.

The fixes are split into separate commits:

- Bound PDF name `#XX` escape parsing so malformed names cannot read past the bounded dictionary content.
- Reject out-of-range PDF integer values before casting from `long` back to `int`.
- Check PE imphash thunk RVA resolution errors using the correct `cli_rawaddr()` error flag.
- Validate PE import DLL-name bytes before duplicating the DLL name.
- Advance the RTF object parser zero-skip state correctly when the zero field is split across chunks.
- Bound UTF-8 continuation-byte reads in the internal iconv fallback for truncated multibyte input.

Reported-by: Tristan (@TristanInSec)

## Notes

We have determined that these specific fixed issues are not security issues.