### PR TITLE
Apply clang-format to CI paths

### DIFF
--- a/clamd/scanner.c
+++ b/clamd/scanner.c
@@ -140,8 +140,8 @@ cl_error_t scan_callback(STATBUF *sb, char *filename, const char *msg, enum cli_
 {
     struct scan_cb_data *scandata = data->data;
     const char *virname           = NULL;
-    cl_error_t ret = CL_SUCCESS;
-    int type = scandata->type;
+    cl_error_t ret                = CL_SUCCESS;
+    int type                      = scandata->type;
     struct cb_context context;
     char *scan_filename = NULL;
     const char *scan_path;
@@ -244,11 +244,11 @@ cl_error_t scan_callback(STATBUF *sb, char *filename, const char *msg, enum cli_
                 scan_filename                 = NULL;
             }
             filename             = NULL;
-            client_conn->cmdtype  = COMMAND_MULTISCANFILE;
-            client_conn->term     = scandata->conn->term;
-            client_conn->options  = scandata->options;
-            client_conn->opts     = scandata->opts;
-            client_conn->group    = scandata->group;
+            client_conn->cmdtype = COMMAND_MULTISCANFILE;
+            client_conn->term    = scandata->conn->term;
+            client_conn->options = scandata->options;
+            client_conn->opts    = scandata->opts;
+            client_conn->group   = scandata->group;
             if (cl_engine_addref(scandata->engine)) {
                 logg(LOGG_ERROR, "cl_engine_addref() failed\n");
                 free(client_conn->filename);

--- a/clamd/session.c
+++ b/clamd/session.c
@@ -278,8 +278,7 @@ int command(client_conn_t *conn, int *virus)
             }
             break;
         }
-        case COMMAND_MULTISCANFILE:
-        {
+        case COMMAND_MULTISCANFILE: {
             char *scan_filename    = conn->filename;
             char *display_filename = (NULL != conn->display_filename) ? conn->display_filename : conn->filename;
 

--- a/clamdscan/client.c
+++ b/clamdscan/client.c
@@ -314,7 +314,7 @@ static char *makeabs(const char *basepath)
 static int client_scan(const char *file, int scantype, int *infected, int *err, int maxlevel, int session, int flags)
 {
     int ret;
-    char *fullpath  = NULL;
+    char *fullpath = NULL;
 
     /* Convert relative path to fullpath without resolving symlinks. */
     fullpath = makeabs(file);
@@ -409,8 +409,8 @@ int client(const struct optstruct *opts, int *infected, int *err)
         }
     }
 
-    scandash = (opts->filename && opts->filename[0] && !strcmp(opts->filename[0], "-") && !optget(opts, "file-list")->enabled && !opts->filename[1]);
-    remote = isremote(opts) | optget(opts, "stream")->enabled;
+    scandash         = (opts->filename && opts->filename[0] && !strcmp(opts->filename[0], "-") && !optget(opts, "file-list")->enabled && !opts->filename[1]);
+    remote           = isremote(opts) | optget(opts, "stream")->enabled;
     action_requested = (NULL != action) ||
                        optget(opts, "move")->enabled ||
                        optget(opts, "copy")->enabled ||
@@ -434,7 +434,7 @@ int client(const struct optstruct *opts, int *infected, int *err)
         session  = optget(opts, "multiscan")->enabled;
     } else
 #endif
-    if (action_requested || remote || scandash || client_side_multiscan) {
+        if (action_requested || remote || scandash || client_side_multiscan) {
         scantype = STREAM;
         session  = optget(opts, "multiscan")->enabled;
     } else if (optget(opts, "multiscan")->enabled)

--- a/clamdscan/proto.c
+++ b/clamdscan/proto.c
@@ -310,7 +310,7 @@ int serial_client_scan(char *file, int scantype, int *infected, int *err, int ma
     cdata.flags    = flags;
     cdata.maxlevel = maxlevel ? maxlevel : INT_MAX;
     client_walk_policy_init(&cdata.walk_policy, file);
-    data.data      = &cdata;
+    data.data = &cdata;
 
     ftw = cli_ftw(file, flags, maxlevel ? maxlevel : INT_MAX, serial_callback, &data, ftw_chkpath);
     *infected += cdata.infected;
@@ -378,7 +378,7 @@ static int dspresult(struct client_parallel_data *c)
             logg(LOGG_ERROR, "Bogus session id from clamd\n");
             return 1;
         }
-        filename = (*id)->file;
+        filename      = (*id)->file;
         action_source = (*id)->action_source;
         if (len > 7) {
             char *colon = strrchr(bol, ':');
@@ -620,7 +620,7 @@ int parallel_client_scan(char *file, int scantype, int *infected, int *err, int 
     cdata.action_sources     = 0;
     cdata.max_action_sources = get_max_action_sources();
     client_walk_policy_init(&cdata.walk_policy, file);
-    data.data                = &cdata;
+    data.data = &cdata;
 
     ftw = cli_ftw(file, flags, maxlevel ? maxlevel : INT_MAX, parallel_callback, &data, ftw_chkpath);
 

--- a/clamonacc/client/client.c
+++ b/clamonacc/client/client.c
@@ -428,7 +428,7 @@ cl_error_t onas_setup_client(struct onas_context **ctx)
         return CL_EARG;
     }
 
-    remote = (*ctx)->isremote | optget(opts, "stream")->enabled;
+    remote           = (*ctx)->isremote | optget(opts, "stream")->enabled;
     action_requested = (NULL != action) ||
                        optget(opts, "move")->enabled ||
                        optget(opts, "copy")->enabled ||
@@ -549,9 +549,9 @@ int onas_client_scan(const char *tcpaddr, int64_t portnum, int32_t scantype, uin
     cl_error_t status = CL_CLEAN;
     action_source_t action_source;
     char *resolved_action_path = NULL;
-    bool have_action_source = false;
-    bool regular_file        = S_ISREG(sb.st_mode);
-    static bool disconnected = false;
+    bool have_action_source    = false;
+    bool regular_file          = S_ISREG(sb.st_mode);
+    static bool disconnected   = false;
 
     action_source_init(&action_source);
 
@@ -590,7 +590,7 @@ int onas_client_scan(const char *tcpaddr, int64_t portnum, int32_t scantype, uin
     if (CURLE_OK != curlcode) {
         logg(LOGG_ERROR, "ClamClient: could not init curl for scanning, %s\n", curl_easy_strerror(curlcode));
         /* curl cleanup done in onas_curl_init on error */
-        curl = NULL;
+        curl   = NULL;
         status = CL_ECREAT;
         goto done;
     }
@@ -602,7 +602,7 @@ int onas_client_scan(const char *tcpaddr, int64_t portnum, int32_t scantype, uin
             disconnected = true;
         }
         curl_easy_cleanup(curl);
-        curl = NULL;
+        curl   = NULL;
         status = CL_ECREAT;
         goto done;
     }

--- a/clamonacc/client/protocol.c
+++ b/clamonacc/client/protocol.c
@@ -285,8 +285,8 @@ int onas_dsresult(CURL *curl, int scantype, uint64_t maxstream, const char *file
     STATBUF sb;
     int sockd                                                        = -1;
     int (*recv_func)(struct onas_rcvln *, char **, char **, int64_t) = NULL;
-    const char *display_filename = (NULL != action_source) ? action_source->display_path : filename;
-    int scan_fd                  = (NULL != action_source) ? action_source->scan_fd : fd;
+    const char *display_filename                                     = (NULL != action_source) ? action_source->display_path : filename;
+    int scan_fd                                                      = (NULL != action_source) ? action_source->scan_fd : fd;
 
 #ifdef HAVE_FD_PASSING
     if (FILDES == scantype) {

--- a/clamscan/manager.c
+++ b/clamscan/manager.c
@@ -312,10 +312,10 @@ static void scanfile(const char *filename, struct cl_engine *engine, const struc
     char **file_type_out         = NULL;
     char *file_type              = NULL;
     action_source_t action_source;
-    bool have_action_source      = false;
-    bool have_stat               = false;
-    const char *scan_path        = filename;
-    char *real_filter_path       = NULL;
+    bool have_action_source = false;
+    bool have_stat          = false;
+    const char *scan_path   = filename;
+    char *real_filter_path  = NULL;
 
     action_source_init(&action_source);
 
@@ -394,7 +394,7 @@ static void scanfile(const char *filename, struct cl_engine *engine, const struc
         if (action_source.has_stat) {
             sb.st_dev  = action_source.statbuf.st_dev;
             sb.st_size = action_source.statbuf.st_size;
-            have_stat = true;
+            have_stat  = true;
         }
     }
 
@@ -584,9 +584,9 @@ static void scandirs(const char *dirname, struct cl_engine *engine, const struct
     STATBUF sb;
     char *fname;
 #ifdef _WIN32
-    char **entries               = NULL;
-    size_t entries_count         = 0;
-    size_t entries_capacity      = 0;
+    char **entries          = NULL;
+    size_t entries_count    = 0;
+    size_t entries_capacity = 0;
     size_t entry_index;
 #endif
     int included;
@@ -670,7 +670,7 @@ static void scandirs(const char *dirname, struct cl_engine *engine, const struct
         dd = NULL;
 
         for (entry_index = 0; entry_index < entries_count; entry_index++) {
-            dent = NULL;
+            dent  = NULL;
             fname = malloc(strlen(dirname) + strlen(entries[entry_index]) + 2);
             if (fname == NULL) {
                 logg(LOGG_ERROR, "scandirs: Memory allocation failed for fname\n");

--- a/common/actions.c
+++ b/common/actions.c
@@ -87,12 +87,12 @@ unsigned int notmoved = 0, notremoved = 0;
 static char *actarget;
 static int targlen;
 #ifndef _WIN32
-static int actarget_fd = -1;
+static int actarget_fd         = -1;
 static char *actarget_lockname = NULL;
 static int action_unlinkat_nointr(int dirfd, const char *path, int flags);
 static int traverse_to(const char *directory, bool want_directory_handle, int *out_handle);
 #else
-static HANDLE actarget_handle = NULL;
+static HANDLE actarget_handle    = NULL;
 static char *actarget_normalized = NULL;
 static int traverse_to(const char *directory, bool want_directory_handle, HANDLE *out_handle);
 static size_t win32_path_root_length(const char *path, size_t path_len);
@@ -540,7 +540,7 @@ static char *action_gen_quarantine_lockname(unsigned int attempt)
 int action_setup_quarantine_lock_at(int directory_fd, const char *directory_path, char **lockname_out)
 {
     char *lockname = NULL;
-    int fd        = -1;
+    int fd         = -1;
     unsigned int i;
 
     if (directory_fd < 0 || NULL == lockname_out) {
@@ -1095,7 +1095,7 @@ static int win32_open_existing_directory_at(HANDLE current_handle, const char *d
         goto done;
     }
 
-    *out_handle = directory_handle;
+    *out_handle      = directory_handle;
     directory_handle = NULL;
     status           = 0;
 
@@ -1261,8 +1261,8 @@ done:
 
 static int win32_copy_alternate_streams(HANDLE src_handle, HANDLE dest_handle)
 {
-    LPVOID backup_context       = NULL;
-    const DWORD stream_id_size  = (DWORD)offsetof(WIN32_STREAM_ID, cStreamName);
+    LPVOID backup_context      = NULL;
+    const DWORD stream_id_size = (DWORD)offsetof(WIN32_STREAM_ID, cStreamName);
     WIN32_STREAM_ID stream_id;
     LARGE_INTEGER zero;
     int status = -1;
@@ -1278,10 +1278,10 @@ static int win32_copy_alternate_streams(HANDLE src_handle, HANDLE dest_handle)
     }
 
     while (TRUE) {
-        WCHAR *stream_name_w        = NULL;
-        char *stream_name_utf8      = NULL;
-        HANDLE dest_stream_handle   = INVALID_HANDLE_VALUE;
-        DWORD bytes_read            = 0;
+        WCHAR *stream_name_w      = NULL;
+        char *stream_name_utf8    = NULL;
+        HANDLE dest_stream_handle = INVALID_HANDLE_VALUE;
+        DWORD bytes_read          = 0;
 
         if (FALSE == BackupRead(src_handle, (BYTE *)&stream_id, stream_id_size, &bytes_read, FALSE, FALSE, &backup_context)) {
             goto done;
@@ -1360,10 +1360,10 @@ done:
 
 static int filecopy_to_fd(const action_source_t *source, const char *dest_path, int dest_fd)
 {
-    const char *src                  = NULL;
-    HANDLE src_handle                = INVALID_HANDLE_VALUE;
-    HANDLE dest_handle               = INVALID_HANDLE_VALUE;
-    int status                       = -1;
+    const char *src    = NULL;
+    HANDLE src_handle  = INVALID_HANDLE_VALUE;
+    HANDLE dest_handle = INVALID_HANDLE_VALUE;
+    int status         = -1;
 
     if ((NULL == source) || (NULL == dest_path) || (dest_fd < 0)) {
         return -1;
@@ -1492,7 +1492,7 @@ static int win32_open_delete_handle_for_source(
         goto done;
     }
 
-    *out_handle  = delete_handle;
+    *out_handle   = delete_handle;
     delete_handle = INVALID_HANDLE_VALUE;
     status        = 0;
 
@@ -1794,10 +1794,10 @@ static size_t win32_path_root_length(const char *path, size_t path_len)
 
 static char *win32_trim_trailing_path_separators_dup(const char *path)
 {
-    char *trimmed     = NULL;
-    size_t path_len   = 0;
-    size_t root_len   = 0;
-    size_t trim_len   = 0;
+    char *trimmed   = NULL;
+    size_t path_len = 0;
+    size_t root_len = 0;
+    size_t trim_len = 0;
 
     if (NULL == path) {
         return NULL;
@@ -1985,11 +1985,11 @@ static int action_validate_actarget_path(void)
 
 static int win32_open_existing_path(const char *path, bool is_directory, ACCESS_MASK desired_access, HANDLE *out_handle)
 {
-    WCHAR *path_w         = NULL;
+    WCHAR *path_w          = NULL;
     WCHAR *extended_path_w = NULL;
-    HANDLE handle         = INVALID_HANDLE_VALUE;
-    DWORD flags           = FILE_FLAG_OPEN_REPARSE_POINT;
-    int status            = -1;
+    HANDLE handle          = INVALID_HANDLE_VALUE;
+    DWORD flags            = FILE_FLAG_OPEN_REPARSE_POINT;
+    int status             = -1;
 
     if ((NULL == path) || (NULL == out_handle)) {
         return -1;
@@ -2645,7 +2645,7 @@ cl_error_t action_source_from_fd(const char *display_path, int fd, action_source
     source->scan_fd = dup_fd;
     dup_fd          = -1;
 #else
-    source_osfhandle = _get_osfhandle(fd);
+    source_osfhandle          = _get_osfhandle(fd);
     if (-1 == source_osfhandle) {
         status = CL_EOPEN;
         goto done;
@@ -2781,7 +2781,7 @@ static int action_unlink_dest_at(const char *dest_path)
 
 static int action_link_source_to_dest(const action_source_t *source, char **newname, STATBUF *source_stat_out)
 {
-    char *tmps = NULL;
+    char *tmps      = NULL;
     char *dest_path = NULL;
     char *filename;
     const char *dest_basename;
@@ -2837,9 +2837,9 @@ static int action_link_source_to_dest(const action_source_t *source, char **newn
             if (NULL != source_stat_out) {
                 *source_stat_out = source->statbuf;
             }
-            *newname = dest_path;
+            *newname  = dest_path;
             dest_path = NULL;
-            status = 0;
+            status    = 0;
             goto done;
         }
 
@@ -3329,15 +3329,15 @@ static int traverse_unlink(
     int status = -1;
     cl_error_t ret;
 #ifndef _WIN32
-    int target_directory_fd = -1;
-    int private_directory_fd = -1;
+    int target_directory_fd                                      = -1;
+    int private_directory_fd                                     = -1;
     char private_directory_name[ACTION_PRIVATE_UNLINK_NAME_SIZE] = {0};
     STATBUF current_stat;
     STATBUF captured_stat;
     int rc;
     bool supports_noreplace_restore = false;
 #else
-    HANDLE delete_handle = INVALID_HANDLE_VALUE;
+    HANDLE delete_handle     = INVALID_HANDLE_VALUE;
     bool close_delete_handle = true;
 #endif
     char *target_basename = NULL;
@@ -3519,9 +3519,9 @@ static void action_move(const action_source_t *source)
     STATBUF source_stat;
 #endif
 
-    filename          = action_source_display_path(source);
-    action_filename   = action_source_action_path(source);
-    show_action_path  = action_source_show_action_path(source);
+    filename         = action_source_display_path(source);
+    action_filename  = action_source_action_path(source);
+    show_action_path = action_source_show_action_path(source);
 
     if ((NULL == source) || (NULL == action_filename)) {
         logg(LOGG_ERROR, "Can't move file '%s'\n", filename);
@@ -3655,9 +3655,9 @@ static void action_copy(const action_source_t *source)
     const char *action_filename;
     bool show_action_path;
 
-    filename          = action_source_display_path(source);
-    action_filename   = action_source_action_path(source);
-    show_action_path  = action_source_show_action_path(source);
+    filename         = action_source_display_path(source);
+    action_filename  = action_source_action_path(source);
+    show_action_path = action_source_show_action_path(source);
 
     if ((NULL == source) || (NULL == action_filename)) {
         logg(LOGG_ERROR, "Can't copy file '%s'\n", filename);
@@ -3729,9 +3729,9 @@ static void action_remove(const action_source_t *source)
     const char *action_filename;
     bool show_action_path;
 
-    filename          = action_source_display_path(source);
-    action_filename   = action_source_action_path(source);
-    show_action_path  = action_source_show_action_path(source);
+    filename         = action_source_display_path(source);
+    action_filename  = action_source_action_path(source);
+    show_action_path = action_source_show_action_path(source);
 
     if ((NULL == source) || (NULL == action_filename)) {
         logg(LOGG_ERROR, "Can't remove file '%s'\n", filename);
@@ -3798,7 +3798,7 @@ int actsetup(const struct optstruct *opts)
         const char *requested_actarget = optget(opts, move ? "move" : "copy")->strarg;
 #ifndef _WIN32
         cl_error_t ret;
-        int actarget_parent_fd = -1;
+        int actarget_parent_fd  = -1;
         char *actarget_basename = NULL;
         char *resolved_actarget = NULL;
 
@@ -3817,7 +3817,7 @@ int actsetup(const struct optstruct *opts)
             logg(LOGG_INFO, "action_setup: Failed to normalize quarantine directory path %s\n", requested_actarget);
             return 1;
         }
-        actarget = actarget_normalized;
+        actarget                      = actarget_normalized;
 #endif
         if (!isdir()) return 1;
         targlen = strlen(actarget);
@@ -3877,7 +3877,7 @@ int actsetup(const struct optstruct *opts)
             return 1;
         }
 #endif
-        action  = move ? action_move : action_copy;
+        action = move ? action_move : action_copy;
     } else if (optget(opts, "remove")->enabled)
         action = action_remove;
     return 0;

--- a/common/clamdcom.c
+++ b/common/clamdcom.c
@@ -179,7 +179,7 @@ int send_fdpass_fd(int sockd, int fd)
     struct msghdr msg;
     struct cmsghdr *cmsg;
     unsigned char fdbuf[CMSG_SPACE(sizeof(int))];
-    char dummy[] = "";
+    char dummy[]         = "";
     const char zFILDES[] = "zFILDES";
 
     if (fd < 0) {

--- a/common/scanmem.c
+++ b/common/scanmem.c
@@ -593,20 +593,20 @@ cl_error_t scanfile(
 {
     int fd = -1;
     int scantype;
-    cl_error_t status = CL_CLEAN;
-    int infected = 0;
-    const char *scan_path = (NULL != scan_open_path) ? scan_open_path : filename;
+    cl_error_t status                   = CL_CLEAN;
+    int infected                        = 0;
+    const char *scan_path               = (NULL != scan_open_path) ? scan_open_path : filename;
     const char *action_display_filename = (NULL != action_target) ? action_target : filename;
     bool action_target_is_scan_target =
         ((NULL == action_target) || (0 == strcmp(action_target, filename))) &&
         ((NULL == action_open_path) || (0 == strcmp(action_open_path, scan_path)));
     action_source_t action_source;
-    bool have_action_source = false;
-    bool action_source_open_failed = false;
-    bool scan_uses_action_source = false;
+    bool have_action_source         = false;
+    bool action_source_open_failed  = false;
+    bool scan_uses_action_source    = false;
     cl_error_t action_source_status = CL_SUCCESS;
-    int scan_errors_before = 0;
-    int scan_result        = 0;
+    int scan_errors_before          = 0;
+    int scan_result                 = 0;
 
     cl_verdict_t verdict   = CL_VERDICT_NOTHING_FOUND;
     const char *alert_name = NULL;
@@ -678,7 +678,7 @@ cl_error_t scanfile(
         scan_result        = dsresult(sock, scantype, scan_path, scan_uses_action_source ? &action_source : NULL, false, NULL, &info->errors, clamdopts);
         if (scan_result > 0) {
             info->ifiles++;
-            status = CL_VIRUS;
+            status   = CL_VIRUS;
             infected = 1;
         } else if ((scan_result < 0) || (info->errors > scan_errors_before)) {
             status = CL_EOPEN;
@@ -713,7 +713,7 @@ cl_error_t scanfile(
             case CL_VERDICT_POTENTIALLY_UNWANTED: {
                 logg(LOGG_INFO, "%s: %s FOUND\n", filename, alert_name);
                 info->ifiles++;
-                status = CL_VIRUS;
+                status   = CL_VIRUS;
                 infected = 1;
             } break;
         }
@@ -755,20 +755,20 @@ cl_error_t scanfile(
 
 int scanmem_cb(PROCESSENTRY32 ProcStruct, MODULEENTRY32 me32, void *data, struct mem_info *info)
 {
-    scanmem_data *scan_data     = data;
-    int rc                      = 0;
-    int isprocess               = 0;
-    char modulename[MAX_PATH]   = "";
-    char expandmodule[MAX_PATH] = "";
+    scanmem_data *scan_data             = data;
+    int rc                              = 0;
+    int isprocess                       = 0;
+    char modulename[MAX_PATH]           = "";
+    char expandmodule[MAX_PATH]         = "";
     char *resolved_modulename           = NULL;
     const char *module_scan_path        = modulename;
     const char *module_action_open_path = NULL;
     action_source_t deferred_action_source;
-    cl_error_t cached_result        = CL_CLEAN;
-    cl_error_t resolve_status       = CL_CLEAN;
-    bool cache_hit                  = false;
-    bool module_filter_enabled      = false;
-    bool module_excluded            = false;
+    cl_error_t cached_result   = CL_CLEAN;
+    cl_error_t resolve_status  = CL_CLEAN;
+    bool cache_hit             = false;
+    bool module_filter_enabled = false;
+    bool module_excluded       = false;
 
     if (!scan_data)
         return 0;
@@ -799,7 +799,7 @@ int scanmem_cb(PROCESSENTRY32 ProcStruct, MODULEENTRY32 me32, void *data, struct
     if (cache_hit) {
         scan_data->res = cached_result;
     }
-    isprocess      = !_stricmp(ProcStruct.szExeFile, modulename) ||
+    isprocess = !_stricmp(ProcStruct.szExeFile, modulename) ||
                 !_stricmp(ProcStruct.szExeFile, me32.szModule);
 
     if (!cache_hit) {
@@ -811,7 +811,7 @@ int scanmem_cb(PROCESSENTRY32 ProcStruct, MODULEENTRY32 me32, void *data, struct
         info->files++;
 
         /* check for module exclusion */
-        scan_data->res = CL_CLEAN;
+        scan_data->res        = CL_CLEAN;
         module_filter_enabled = info->d || scan_data->exclude;
         module_excluded       = module_filter_enabled && chkpath(modulename, clamdopts);
 


### PR DESCRIPTION
## Summary

Apply clang-format to files currently reported by the clang-format GitHub Actions workflow. This PR is formatting-only and is split out from the CLAM-3002 parser-fix PR so the style cleanup can be reviewed and merged independently.

## Validation

- Ran clang-format 16 dry-run on the formatted files.
- Ran clang-format 16 dry-run on the full common path.
- Ran git diff --check.