### PR TITLE
Tests: Avoid DNS lookup in freshclam mock mirror

### DIFF
--- a/unit_tests/freshclam_test.py
+++ b/unit_tests/freshclam_test.py
@@ -15,6 +15,7 @@ import unittest
 from functools import partial
 
 from http.server import HTTPServer, BaseHTTPRequestHandler
+from socketserver import TCPServer
 
 import testcase
 
@@ -25,7 +26,17 @@ MOCK_MIRROR_IPV6_HOST = '::1'
 MOCK_MIRROR_START_TIMEOUT = 10
 
 
-class IPv6HTTPServer(HTTPServer):
+class MockMirrorHTTPServer(HTTPServer):
+    '''
+    HTTPServer variant that avoids reverse DNS during local test server startup.
+    '''
+    def server_bind(self):
+        TCPServer.server_bind(self)
+        self.server_name = self.server_address[0]
+        self.server_port = self.server_address[1]
+
+
+class IPv6HTTPServer(MockMirrorHTTPServer):
     address_family = socket.AF_INET6
 
 
@@ -861,7 +872,7 @@ def create_mock_database_mirror_server(handler, port):
     last_error = None
 
     for server_class, host in (
-        (HTTPServer, MOCK_MIRROR_IPV4_HOST),
+        (MockMirrorHTTPServer, MOCK_MIRROR_IPV4_HOST),
         (IPv6HTTPServer, MOCK_MIRROR_IPV6_HOST),
     ):
         try:


### PR DESCRIPTION
## Summary

The macOS CMake Build job has started failing on newer `macos-latest` runners when the `freshclam` tests wait for the mock database mirror to report readiness. The failure happens before freshclam is exercised: the child process starts the Python `HTTPServer`, but never sends the readiness message before the 10-second timeout.

Python's standard `HTTPServer.server_bind()` performs a reverse DNS lookup with `socket.getfqdn()` after binding. The mock mirror only needs a loopback socket and does not need DNS, so this PR adds a test-only `MockMirrorHTTPServer` that binds through `TCPServer.server_bind()` and records the bound address directly. Both the IPv4 and IPv6 mock mirror paths now avoid reverse DNS during startup.

## Verification

- `PYTHONPYCACHEPREFIX=/private/tmp/clamav-pycache python3 -m py_compile unit_tests/freshclam_test.py`
- `cmake --build build --target freshclam -j12`
- `ctest -V -R freshclam`

The targeted local `freshclam` CTest passed: 10 passed, 1 skipped.
