### PR TITLE
unit_tests: Don't set TMP

### DIFF
--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -214,7 +214,10 @@ else()
 
     set(SOURCE             ${CMAKE_SOURCE_DIR})
     set(BUILD              ${CMAKE_BINARY_DIR})
-    set(TMP                ${CMAKE_CURRENT_BINARY_DIR})
+    set(TMP                $ENV{TMPDIR})
+    if(NOT TMP)
+        set(TMP "/tmp")
+    endif()
 
     set(NEW_PATH "$ENV{PATH}")
 


### PR DESCRIPTION
Setting TMP to CMAKE_CURRENT_BINARY_DIR can result in a "long" path such as "/build/reproducible-path/clamav-1.4.5+dfsg/obj-arm-linux-gnueabihf/unit_tests" together with the temporary filename the testsuite can abort with "OSError: AF_UNIX path too long" during "TC.mock_mirror.start()" because the resulting unix socket name gets too long.

That is because python3.14 switch from fork to a forkserver in Process.start().

Without setting, it ends up under /tmp/ which is brief enough.