### PR TITLE
FreshClam: use the configured outdated hook in daemon mode

### DIFF
--- a/freshclam/freshclam.c
+++ b/freshclam/freshclam.c
@@ -2092,7 +2092,7 @@ int main(int argc, char **argv)
                 bPrivate ? 0 : optget(opts, "ScriptedUpdates")->enabled,
                 bPrune,
                 optget(opts, "OnUpdateExecute")->enabled ? optget(opts, "OnUpdateExecute")->strarg : NULL,
-                optget(opts, "OnOutdatedExecute")->enabled ? optget(opts, "OnUpdateExecute")->strarg : NULL,
+                optget(opts, "OnOutdatedExecute")->enabled ? optget(opts, "OnOutdatedExecute")->strarg : NULL,
                 optget(opts, "daemon")->enabled,
                 optget(opts, "NotifyClamd")->active ? optget(opts, "NotifyClamd")->strarg : NULL,
                 &fc_context);


### PR DESCRIPTION
## Summary

- Fix the FreshClam daemon update loop to pass `OnOutdatedExecute` to the database update helper when the outdated-version hook is enabled.
- Preserve the existing non-daemon behavior, which already passed the correct hook.

## Rationale

The non-daemon update path correctly passes `OnOutdatedExecute` when the outdated hook is configured. The daemon loop checked whether `OnOutdatedExecute` was enabled, but accidentally passed the `OnUpdateExecute` command string. That could cause daemon-mode outdated-version events to run the update hook, or to run no hook when only `OnOutdatedExecute` was configured.

## Validation

- `git diff --check`
- `cmake --build build --target freshclam-bin -j12`

## Credit

Reported by Nir Yehoshua, Cipher Security Labs.