### PR TITLE
libclamav: cache EVP_MD handles to fix per-hash provider-fetch churn and a FIPS memory leak

### DIFF
--- a/libclamav/crypto.c
+++ b/libclamav/crypto.c
@@ -68,6 +68,10 @@
 #include "str.h"
 #include "iowrap.h"
 
+#ifdef CL_THREAD_SAFE
+#include <pthread.h>
+#endif
+
 #if defined(_WIN32)
 char *strptime(const char *buf, const char *fmt, struct tm *tm);
 #endif
@@ -162,6 +166,103 @@ void cl_cleanup_crypto(void)
     return;
 }
 
+#if OPENSSL_VERSION_MAJOR >= 3
+/*
+ * Digest handle cache.
+ *
+ * On OpenSSL 3, EVP_MD_fetch() into a freshly-allocated OSSL_LIB_CTX is
+ * expensive: the empty context must bootstrap a provider and construct the
+ * method from scratch (on the order of hundreds of microseconds). ClamAV
+ * hashes md5/sha1/sha2-256 for essentially every scanned object, so fetching
+ * per hash would dominate scan time while doing no actual hashing.
+ *
+ * Fetch each FIPS-bypass digest once into a single shared non-FIPS library
+ * context and reuse it (a fetched EVP_MD is reference counted and safe to share
+ * across threads). cli_get_md() returns a reference the caller owns and must
+ * release with EVP_MD_free().
+ *
+ * Only the bypass digests are cached. The FIPS-compliant path is fetched from
+ * the default library context on every call, so it keeps honoring the current
+ * default property query -- e.g. if the embedding process enables FIPS at
+ * runtime, a non-bypass MD5/SHA1 request must start failing rather than return
+ * a stale non-FIPS handle. That default-context fetch is already inexpensive
+ * because OpenSSL caches provider methods per library context.
+ */
+#ifdef CL_THREAD_SAFE
+static pthread_mutex_t md_cache_mutex = PTHREAD_MUTEX_INITIALIZER;
+#endif
+
+/* Single shared non-FIPS library context backing all "-fips" (bypass) fetches. */
+static OSSL_LIB_CTX *nonfips_libctx = NULL;
+
+static struct {
+    const char *alg; /* string literal returned by to_openssl_alg(); stable */
+    EVP_MD *md;
+} md_cache[8];
+static size_t md_cache_len = 0;
+
+static EVP_MD *cli_get_md(const char *alg, bool fips_bypass)
+{
+    const char *ossl_alg = to_openssl_alg(alg);
+    EVP_MD *result       = NULL;
+    bool cached          = false; /* true if md_cache owns `result` */
+    size_t i;
+
+    if (NULL == ossl_alg) {
+        return NULL;
+    }
+
+    if (!fips_bypass) {
+        /* FIPS-compliant path: fetch from the default library context every
+         * time so the current default property query -- including any runtime
+         * FIPS change -- is honored. */
+        return EVP_MD_fetch(NULL, ossl_alg, NULL);
+    }
+
+#ifdef CL_THREAD_SAFE
+    pthread_mutex_lock(&md_cache_mutex);
+#endif
+
+    for (i = 0; i < md_cache_len; i++) {
+        if (0 == strcmp(md_cache[i].alg, ossl_alg)) {
+            result = md_cache[i].md;
+            cached = true;
+            goto done;
+        }
+    }
+
+    /* Miss: create the shared non-FIPS context on first use and fetch once. */
+    if (NULL == nonfips_libctx) {
+        nonfips_libctx = OSSL_LIB_CTX_new();
+        if (NULL == nonfips_libctx) {
+            cli_errmsg("cli_get_md: Failed to create OpenSSL library context\n");
+            goto done;
+        }
+    }
+    result = EVP_MD_fetch(nonfips_libctx, ossl_alg, "-fips");
+    if (NULL != result && md_cache_len < sizeof(md_cache) / sizeof(md_cache[0])) {
+        md_cache[md_cache_len].alg = ossl_alg;
+        md_cache[md_cache_len].md  = result; /* cache holds this reference */
+        md_cache_len++;
+        cached = true;
+    }
+
+done:
+    /* A cached digest belongs to md_cache, so give the caller its own reference
+     * to EVP_MD_free(). If that reference can't be acquired, fail instead of
+     * handing back one the caller would free out from under the cache.
+     * A digest that was fetched but not cached is already the caller's to free. */
+    if (cached && NULL != result && 1 != EVP_MD_up_ref(result)) {
+        cli_errmsg("cli_get_md: Failed to acquire a reference to the %s digest\n", ossl_alg);
+        result = NULL;
+    }
+#ifdef CL_THREAD_SAFE
+    pthread_mutex_unlock(&md_cache_mutex);
+#endif
+    return result;
+}
+#endif /* OPENSSL_VERSION_MAJOR >= 3 */
+
 /**
  * @brief Generate a hash of data.
  *
@@ -196,8 +297,7 @@ extern cl_error_t cl_hash_data_ex(
     EVP_MD_CTX *ctx = NULL;
 
 #if OPENSSL_VERSION_MAJOR >= 3
-    OSSL_LIB_CTX *ossl_ctx = NULL;
-    EVP_MD *md             = NULL;
+    EVP_MD *md = NULL;
 #else
     const EVP_MD *md = NULL;
 #endif
@@ -218,20 +318,7 @@ extern cl_error_t cl_hash_data_ex(
     }
 
 #if OPENSSL_VERSION_MAJOR >= 3
-    if (flags & CL_HASH_FLAG_FIPS_BYPASS) {
-        /* Bypass FIPS restrictions the OpenSSL 3.0 way */
-        ossl_ctx = OSSL_LIB_CTX_new();
-        if (NULL == ossl_ctx) {
-            cli_errmsg("cl_hash_data_ex: Failed to create new OpenSSL library context\n");
-            status = CL_EMEM;
-            goto done;
-        }
-
-        md = EVP_MD_fetch(ossl_ctx, to_openssl_alg(alg), "-fips");
-    } else {
-        /* Use FIPS compliant algorithms */
-        md = EVP_MD_fetch(NULL, to_openssl_alg(alg), NULL);
-    }
+    md = cli_get_md(alg, (flags & CL_HASH_FLAG_FIPS_BYPASS) != 0);
 #else
     md = EVP_get_digestbyname(to_openssl_alg(alg));
 #endif
@@ -330,9 +417,6 @@ done:
     if (NULL != md) {
         EVP_MD_free(md);
     }
-    if (NULL != ossl_ctx) {
-        OSSL_LIB_CTX_free(ossl_ctx);
-    }
 #endif
     return status;
 }
@@ -356,8 +440,7 @@ extern cl_error_t cl_hash_init_ex(
     EVP_MD_CTX *ctx   = NULL;
 
 #if OPENSSL_VERSION_MAJOR >= 3
-    OSSL_LIB_CTX *ossl_ctx = NULL;
-    EVP_MD *md             = NULL;
+    EVP_MD *md = NULL;
 #else
     const EVP_MD *md = NULL;
 #endif
@@ -369,20 +452,7 @@ extern cl_error_t cl_hash_init_ex(
     }
 
 #if OPENSSL_VERSION_MAJOR >= 3
-    if (flags & CL_HASH_FLAG_FIPS_BYPASS) {
-        /* Bypass FIPS restrictions the OpenSSL 3.0 way */
-        ossl_ctx = OSSL_LIB_CTX_new();
-        if (NULL == ossl_ctx) {
-            cli_errmsg("cl_hash_data_ex: Failed to create new OpenSSL library context\n");
-            status = CL_EMEM;
-            goto done;
-        }
-
-        md = EVP_MD_fetch(ossl_ctx, to_openssl_alg(alg), "-fips");
-    } else {
-        /* Use FIPS compliant algorithms */
-        md = EVP_MD_fetch(NULL, to_openssl_alg(alg), NULL);
-    }
+    md = cli_get_md(alg, (flags & CL_HASH_FLAG_FIPS_BYPASS) != 0);
 #else
     md = EVP_get_digestbyname(to_openssl_alg(alg));
 #endif
@@ -424,9 +494,6 @@ done:
 #if OPENSSL_VERSION_MAJOR >= 3
     if (NULL != md) {
         EVP_MD_free(md);
-    }
-    if (NULL != ossl_ctx) {
-        OSSL_LIB_CTX_free(ossl_ctx);
     }
 #endif
     return status;
@@ -592,8 +659,7 @@ extern cl_error_t cl_hash_file_fd_ex(
     EVP_MD_CTX *ctx = NULL;
 
 #if OPENSSL_VERSION_MAJOR >= 3
-    OSSL_LIB_CTX *ossl_ctx = NULL;
-    EVP_MD *md             = NULL;
+    EVP_MD *md = NULL;
 #else
     const EVP_MD *md = NULL;
 #endif
@@ -641,20 +707,7 @@ extern cl_error_t cl_hash_file_fd_ex(
     }
 
 #if OPENSSL_VERSION_MAJOR >= 3
-    if (flags & CL_HASH_FLAG_FIPS_BYPASS) {
-        /* Bypass FIPS restrictions the OpenSSL 3.0 way */
-        ossl_ctx = OSSL_LIB_CTX_new();
-        if (NULL == ossl_ctx) {
-            cli_errmsg("cl_hash_data_ex: Failed to create new OpenSSL library context\n");
-            status = CL_EMEM;
-            goto done;
-        }
-
-        md = EVP_MD_fetch(ossl_ctx, to_openssl_alg(alg), "-fips");
-    } else {
-        /* Use FIPS compliant algorithms */
-        md = EVP_MD_fetch(NULL, to_openssl_alg(alg), NULL);
-    }
+    md = cli_get_md(alg, (flags & CL_HASH_FLAG_FIPS_BYPASS) != 0);
 #else
     md = EVP_get_digestbyname(to_openssl_alg(alg));
 #endif
@@ -780,9 +833,6 @@ done:
     if (NULL != md) {
         EVP_MD_free(md);
     }
-    if (NULL != ossl_ctx) {
-        OSSL_LIB_CTX_free(ossl_ctx);
-    }
 #endif
     return status;
 }
@@ -794,8 +844,7 @@ unsigned char *cl_hash_data(const char *alg, const void *buf, size_t len, unsign
     size_t mdsz;
 
 #if OPENSSL_VERSION_MAJOR >= 3
-    OSSL_LIB_CTX *ossl_ctx = NULL;
-    EVP_MD *md             = NULL;
+    EVP_MD *md = NULL;
 #else
     const EVP_MD *md = NULL;
 #endif
@@ -807,14 +856,7 @@ unsigned char *cl_hash_data(const char *alg, const void *buf, size_t len, unsign
 #endif
 
 #if OPENSSL_VERSION_MAJOR >= 3
-    /* Bypass FIPS restrictions the OpenSSL 3.0 way */
-    ossl_ctx = OSSL_LIB_CTX_new();
-    if (NULL == ossl_ctx) {
-        cli_errmsg("cl_hash_data_ex: Failed to create new OpenSSL library context\n");
-        return NULL;
-    }
-
-    md = EVP_MD_fetch(ossl_ctx, to_openssl_alg(alg), "-fips");
+    md = cli_get_md(alg, true);
 #else
     md = EVP_get_digestbyname(to_openssl_alg(alg));
 #endif
@@ -827,7 +869,6 @@ unsigned char *cl_hash_data(const char *alg, const void *buf, size_t len, unsign
     if (!(ret)) {
 #if OPENSSL_VERSION_MAJOR >= 3
         EVP_MD_free(md);
-        OSSL_LIB_CTX_free(ossl_ctx);
 #endif
         return NULL;
     }
@@ -839,7 +880,6 @@ unsigned char *cl_hash_data(const char *alg, const void *buf, size_t len, unsign
 
 #if OPENSSL_VERSION_MAJOR >= 3
         EVP_MD_free(md);
-        OSSL_LIB_CTX_free(ossl_ctx);
 #endif
         return NULL;
     }
@@ -860,7 +900,6 @@ unsigned char *cl_hash_data(const char *alg, const void *buf, size_t len, unsign
 
 #if OPENSSL_VERSION_MAJOR >= 3
         EVP_MD_free(md);
-        OSSL_LIB_CTX_free(ossl_ctx);
 #endif
         EVP_MD_CTX_destroy(ctx);
         return NULL;
@@ -880,7 +919,6 @@ unsigned char *cl_hash_data(const char *alg, const void *buf, size_t len, unsign
 
 #if OPENSSL_VERSION_MAJOR >= 3
             EVP_MD_free(md);
-            OSSL_LIB_CTX_free(ossl_ctx);
 #endif
             EVP_MD_CTX_destroy(ctx);
             return NULL;
@@ -897,7 +935,6 @@ unsigned char *cl_hash_data(const char *alg, const void *buf, size_t len, unsign
 
 #if OPENSSL_VERSION_MAJOR >= 3
             EVP_MD_free(md);
-            OSSL_LIB_CTX_free(ossl_ctx);
 #endif
             EVP_MD_CTX_destroy(ctx);
             return NULL;
@@ -916,7 +953,6 @@ unsigned char *cl_hash_data(const char *alg, const void *buf, size_t len, unsign
 
 #if OPENSSL_VERSION_MAJOR >= 3
         EVP_MD_free(md);
-        OSSL_LIB_CTX_free(ossl_ctx);
 #endif
         EVP_MD_CTX_destroy(ctx);
         return NULL;
@@ -924,7 +960,6 @@ unsigned char *cl_hash_data(const char *alg, const void *buf, size_t len, unsign
 
 #if OPENSSL_VERSION_MAJOR >= 3
     EVP_MD_free(md);
-    OSSL_LIB_CTX_free(ossl_ctx);
 #endif
     EVP_MD_CTX_destroy(ctx);
 
@@ -939,8 +974,7 @@ unsigned char *cl_hash_file_fd(int fd, const char *alg, unsigned int *olen)
     EVP_MD_CTX *ctx;
 
 #if OPENSSL_VERSION_MAJOR >= 3
-    OSSL_LIB_CTX *ossl_ctx = NULL;
-    EVP_MD *md             = NULL;
+    EVP_MD *md = NULL;
 #else
     const EVP_MD *md = NULL;
 #endif
@@ -948,14 +982,7 @@ unsigned char *cl_hash_file_fd(int fd, const char *alg, unsigned int *olen)
     unsigned char *res;
 
 #if OPENSSL_VERSION_MAJOR >= 3
-    /* Bypass FIPS restrictions the OpenSSL 3.0 way */
-    ossl_ctx = OSSL_LIB_CTX_new();
-    if (NULL == ossl_ctx) {
-        cli_errmsg("cl_hash_data_ex: Failed to create new OpenSSL library context\n");
-        return NULL;
-    }
-
-    md = EVP_MD_fetch(ossl_ctx, to_openssl_alg(alg), "-fips");
+    md = cli_get_md(alg, true);
 #else
     md = EVP_get_digestbyname(to_openssl_alg(alg));
 #endif
@@ -966,7 +993,6 @@ unsigned char *cl_hash_file_fd(int fd, const char *alg, unsigned int *olen)
     if (!(ctx)) {
 #if OPENSSL_VERSION_MAJOR >= 3
         EVP_MD_free(md);
-        OSSL_LIB_CTX_free(ossl_ctx);
 #endif
         return NULL;
     }
@@ -981,7 +1007,6 @@ unsigned char *cl_hash_file_fd(int fd, const char *alg, unsigned int *olen)
     if (!EVP_DigestInit_ex(ctx, md, NULL)) {
 #if OPENSSL_VERSION_MAJOR >= 3
         EVP_MD_free(md);
-        OSSL_LIB_CTX_free(ossl_ctx);
 #endif
         EVP_MD_CTX_free(ctx);
         return NULL;
@@ -990,7 +1015,6 @@ unsigned char *cl_hash_file_fd(int fd, const char *alg, unsigned int *olen)
     res = cl_hash_file_fd_ctx(ctx, fd, olen);
 #if OPENSSL_VERSION_MAJOR >= 3
     EVP_MD_free(md);
-    OSSL_LIB_CTX_free(ossl_ctx);
 #endif
     EVP_MD_CTX_free(ctx);
 
@@ -1780,21 +1804,13 @@ void *cl_hash_init(const char *alg)
     EVP_MD_CTX *ctx;
 
 #if OPENSSL_VERSION_MAJOR >= 3
-    OSSL_LIB_CTX *ossl_ctx = NULL;
-    EVP_MD *md             = NULL;
+    EVP_MD *md = NULL;
 #else
     const EVP_MD *md = NULL;
 #endif
 
 #if OPENSSL_VERSION_MAJOR >= 3
-    /* Bypass FIPS restrictions the OpenSSL 3.0 way */
-    ossl_ctx = OSSL_LIB_CTX_new();
-    if (NULL == ossl_ctx) {
-        cli_errmsg("cl_hash_data_ex: Failed to create new OpenSSL library context\n");
-        return NULL;
-    }
-
-    md = EVP_MD_fetch(ossl_ctx, to_openssl_alg(alg), "-fips");
+    md = cli_get_md(alg, true);
 #else
     md = EVP_get_digestbyname(to_openssl_alg(alg));
 #endif
@@ -1805,7 +1821,6 @@ void *cl_hash_init(const char *alg)
     if (!(ctx)) {
 #if OPENSSL_VERSION_MAJOR >= 3
         EVP_MD_free(md);
-        OSSL_LIB_CTX_free(ossl_ctx);
 #endif
         return NULL;
     }
@@ -1820,7 +1835,6 @@ void *cl_hash_init(const char *alg)
     if (!EVP_DigestInit_ex(ctx, md, NULL)) {
 #if OPENSSL_VERSION_MAJOR >= 3
         EVP_MD_free(md);
-        OSSL_LIB_CTX_free(ossl_ctx);
 #endif
         EVP_MD_CTX_free(ctx);
         return NULL;
@@ -1828,7 +1842,6 @@ void *cl_hash_init(const char *alg)
 
 #if OPENSSL_VERSION_MAJOR >= 3
     EVP_MD_free(md);
-    OSSL_LIB_CTX_free(ossl_ctx);
 #endif
     return (void *)ctx;
 }

--- a/libclamav/crypto.c
+++ b/libclamav/crypto.c
@@ -178,8 +178,8 @@ void cl_cleanup_crypto(void)
  *
  * Fetch each FIPS-bypass digest once into a single shared non-FIPS library
  * context and reuse it (a fetched EVP_MD is reference counted and safe to share
- * across threads). cli_get_md() returns a reference the caller owns and must
- * release with EVP_MD_free().
+ * across threads). On success, cli_get_md() returns a reference through its
+ * output parameter that the caller owns and must release with EVP_MD_free().
  *
  * Only the bypass digests are cached. The FIPS-compliant path is fetched from
  * the default library context on every call, so it keeps honoring the current
@@ -201,32 +201,47 @@ static struct {
 } md_cache[8];
 static size_t md_cache_len = 0;
 
-static EVP_MD *cli_get_md(const char *alg, bool fips_bypass)
+static cl_error_t cli_get_md(const char *alg, bool fips_bypass, EVP_MD **md_out)
 {
-    const char *ossl_alg = to_openssl_alg(alg);
-    EVP_MD *result       = NULL;
-    bool cached          = false; /* true if md_cache owns `result` */
+    const char *ossl_alg      = to_openssl_alg(alg);
+    const char *error_message = NULL;
+    EVP_MD *result            = NULL;
+    cl_error_t status         = CL_ERROR;
+    bool result_is_cached     = false;
     size_t i;
 
+    if (NULL == md_out) {
+        return CL_ENULLARG;
+    }
+    *md_out = NULL;
+
     if (NULL == ossl_alg) {
-        return NULL;
+        return CL_EARG;
     }
 
     if (!fips_bypass) {
         /* FIPS-compliant path: fetch from the default library context every
          * time so the current default property query -- including any runtime
          * FIPS change -- is honored. */
-        return EVP_MD_fetch(NULL, ossl_alg, NULL);
+        result = EVP_MD_fetch(NULL, ossl_alg, NULL);
+        if (NULL == result) {
+            return CL_EARG;
+        }
+        *md_out = result;
+        return CL_SUCCESS;
     }
 
 #ifdef CL_THREAD_SAFE
-    pthread_mutex_lock(&md_cache_mutex);
+    if (0 != pthread_mutex_lock(&md_cache_mutex)) {
+        cli_errmsg("cli_get_md: Failed to lock OpenSSL digest cache\n");
+        return CL_ELOCK;
+    }
 #endif
 
     for (i = 0; i < md_cache_len; i++) {
         if (0 == strcmp(md_cache[i].alg, ossl_alg)) {
-            result = md_cache[i].md;
-            cached = true;
+            result           = md_cache[i].md;
+            result_is_cached = true;
             goto done;
         }
     }
@@ -235,31 +250,41 @@ static EVP_MD *cli_get_md(const char *alg, bool fips_bypass)
     if (NULL == nonfips_libctx) {
         nonfips_libctx = OSSL_LIB_CTX_new();
         if (NULL == nonfips_libctx) {
-            cli_errmsg("cli_get_md: Failed to create OpenSSL library context\n");
+            error_message = "cli_get_md: Failed to create OpenSSL library context\n";
+            status        = CL_EMEM;
             goto done;
         }
     }
     result = EVP_MD_fetch(nonfips_libctx, ossl_alg, "-fips");
+    if (NULL == result) {
+        status = CL_EARG;
+        goto done;
+    }
     if (NULL != result && md_cache_len < sizeof(md_cache) / sizeof(md_cache[0])) {
         md_cache[md_cache_len].alg = ossl_alg;
         md_cache[md_cache_len].md  = result; /* cache holds this reference */
         md_cache_len++;
-        cached = true;
+        result_is_cached = true;
     }
 
 done:
-    /* A cached digest belongs to md_cache, so give the caller its own reference
-     * to EVP_MD_free(). If that reference can't be acquired, fail instead of
-     * handing back one the caller would free out from under the cache.
-     * A digest that was fetched but not cached is already the caller's to free. */
-    if (cached && NULL != result && 1 != EVP_MD_up_ref(result)) {
-        cli_errmsg("cli_get_md: Failed to acquire a reference to the %s digest\n", ossl_alg);
-        result = NULL;
+    if (result_is_cached && 1 != EVP_MD_up_ref(result)) {
+        error_message = "cli_get_md: Failed to retain OpenSSL digest handle\n";
+        result        = NULL;
+        status        = CL_EMEM;
+    } else if (NULL != result) {
+        status = CL_SUCCESS;
     }
 #ifdef CL_THREAD_SAFE
     pthread_mutex_unlock(&md_cache_mutex);
 #endif
-    return result;
+    if (NULL != error_message) {
+        cli_errmsg("%s", error_message);
+    }
+    if (CL_SUCCESS == status) {
+        *md_out = result;
+    }
+    return status;
 }
 #endif /* OPENSSL_VERSION_MAJOR >= 3 */
 
@@ -318,15 +343,21 @@ extern cl_error_t cl_hash_data_ex(
     }
 
 #if OPENSSL_VERSION_MAJOR >= 3
-    md = cli_get_md(alg, (flags & CL_HASH_FLAG_FIPS_BYPASS) != 0);
+    status = cli_get_md(alg, (flags & CL_HASH_FLAG_FIPS_BYPASS) != 0, &md);
+    if (CL_SUCCESS != status) {
+        if (CL_EARG == status) {
+            cli_errmsg("cl_hash_data_ex: Unsupported hash algorithm: %s\n", alg);
+        }
+        goto done;
+    }
 #else
     md = EVP_get_digestbyname(to_openssl_alg(alg));
-#endif
     if (NULL == md) {
         cli_errmsg("cl_hash_data_ex: Unsupported hash algorithm: %s\n", alg);
         status = CL_EARG;
         goto done;
     }
+#endif
 
     required_hash_len = (size_t)EVP_MD_size(md);
 
@@ -452,15 +483,21 @@ extern cl_error_t cl_hash_init_ex(
     }
 
 #if OPENSSL_VERSION_MAJOR >= 3
-    md = cli_get_md(alg, (flags & CL_HASH_FLAG_FIPS_BYPASS) != 0);
+    status = cli_get_md(alg, (flags & CL_HASH_FLAG_FIPS_BYPASS) != 0, &md);
+    if (CL_SUCCESS != status) {
+        if (CL_EARG == status) {
+            cli_errmsg("cl_hash_init_ex: Unsupported hash algorithm: %s\n", alg);
+        }
+        goto done;
+    }
 #else
     md = EVP_get_digestbyname(to_openssl_alg(alg));
-#endif
     if (NULL == md) {
-        cli_errmsg("cl_hash_data_ex: Unsupported hash algorithm: %s\n", alg);
+        cli_errmsg("cl_hash_init_ex: Unsupported hash algorithm: %s\n", alg);
         status = CL_EARG;
         goto done;
     }
+#endif
 
     ctx = EVP_MD_CTX_new();
     if (NULL == ctx) {
@@ -707,15 +744,21 @@ extern cl_error_t cl_hash_file_fd_ex(
     }
 
 #if OPENSSL_VERSION_MAJOR >= 3
-    md = cli_get_md(alg, (flags & CL_HASH_FLAG_FIPS_BYPASS) != 0);
+    status = cli_get_md(alg, (flags & CL_HASH_FLAG_FIPS_BYPASS) != 0, &md);
+    if (CL_SUCCESS != status) {
+        if (CL_EARG == status) {
+            cli_errmsg("cl_hash_file_fd_ex: Unsupported hash algorithm: %s\n", alg);
+        }
+        goto done;
+    }
 #else
     md = EVP_get_digestbyname(to_openssl_alg(alg));
-#endif
     if (NULL == md) {
-        cli_errmsg("cl_hash_data_ex: Unsupported hash algorithm: %s\n", alg);
+        cli_errmsg("cl_hash_file_fd_ex: Unsupported hash algorithm: %s\n", alg);
         status = CL_EARG;
         goto done;
     }
+#endif
 
     required_hash_len = (size_t)EVP_MD_size(md);
 
@@ -856,12 +899,14 @@ unsigned char *cl_hash_data(const char *alg, const void *buf, size_t len, unsign
 #endif
 
 #if OPENSSL_VERSION_MAJOR >= 3
-    md = cli_get_md(alg, true);
+    if (CL_SUCCESS != cli_get_md(alg, true, &md)) {
+        return NULL;
+    }
 #else
     md = EVP_get_digestbyname(to_openssl_alg(alg));
-#endif
     if (!(md))
         return NULL;
+#endif
 
     mdsz = EVP_MD_size(md);
 
@@ -982,12 +1027,14 @@ unsigned char *cl_hash_file_fd(int fd, const char *alg, unsigned int *olen)
     unsigned char *res;
 
 #if OPENSSL_VERSION_MAJOR >= 3
-    md = cli_get_md(alg, true);
+    if (CL_SUCCESS != cli_get_md(alg, true, &md)) {
+        return NULL;
+    }
 #else
     md = EVP_get_digestbyname(to_openssl_alg(alg));
-#endif
     if (!(md))
         return NULL;
+#endif
 
     ctx = EVP_MD_CTX_new();
     if (!(ctx)) {
@@ -1810,12 +1857,14 @@ void *cl_hash_init(const char *alg)
 #endif
 
 #if OPENSSL_VERSION_MAJOR >= 3
-    md = cli_get_md(alg, true);
+    if (CL_SUCCESS != cli_get_md(alg, true, &md)) {
+        return NULL;
+    }
 #else
     md = EVP_get_digestbyname(to_openssl_alg(alg));
-#endif
     if (!(md))
         return NULL;
+#endif
 
     ctx = EVP_MD_CTX_new();
     if (!(ctx)) {

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -115,7 +115,8 @@ target_link_libraries(check_clamav
     PRIVATE
         ClamAV::libclamav
         ClamAV::common
-        libcheck::check)
+        libcheck::check
+        OpenSSL::Crypto)
 if (ENABLE_UNRAR)
     if(ENABLE_SHARED_LIB)
         target_link_libraries(check_clamav

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -115,8 +115,7 @@ target_link_libraries(check_clamav
     PRIVATE
         ClamAV::libclamav
         ClamAV::common
-        libcheck::check
-        OpenSSL::Crypto)
+        libcheck::check)
 if (ENABLE_UNRAR)
     if(ENABLE_SHARED_LIB)
         target_link_libraries(check_clamav
@@ -139,6 +138,19 @@ target_include_directories(check_clamav PRIVATE ${PROJECT_SOURCE_DIR} ${PROJECT_
 target_compile_definitions(check_clamav PUBLIC OBJDIR="${OBJDIR}" SRCDIR="${SRCDIR}")
 ADD_CUSTOM_COMMAND(TARGET check_clamav POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/input/clamav.hdb ${CMAKE_CURRENT_BINARY_DIR}/input/.)
+
+# The OpenSSL 3 digest-cache failure paths need a deterministic provider
+# failure that normal host and FIPS configurations do not reliably provide.
+# Use a Linux test-only interposer when libcrypto is dynamically linked. Avoid
+# LD_PRELOAD in sanitizer builds, where it can precede the sanitizer runtime.
+if(C_LINUX AND
+   OPENSSL_VERSION VERSION_GREATER_EQUAL "3.0.0" AND
+   NOT OPENSSL_CRYPTO_LIBRARY MATCHES "\\.a$" AND
+   NOT CMAKE_C_FLAGS MATCHES "-fsanitize")
+    add_library(force_hash_provider_failure SHARED force_hash_provider_failure.c)
+    target_include_directories(force_hash_provider_failure PRIVATE ${OPENSSL_INCLUDE_DIR})
+    target_link_libraries(force_hash_provider_failure PRIVATE ${CMAKE_DL_LIBS})
+endif()
 
 #
 # Paths to pass to our tests via environment variables
@@ -345,6 +357,51 @@ if(Valgrind_FOUND)
     add_test(NAME libclamav_valgrind COMMAND ${PythonTest_COMMAND};libclamav_test.py
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
     set_property(TEST libclamav_valgrind PROPERTY ENVIRONMENT ${ENVIRONMENT} VALGRIND=${Valgrind_EXECUTABLE})
+endif()
+
+if(TARGET force_hash_provider_failure)
+    add_test(NAME libclamav_hash_fetch_failure
+        COMMAND $<TARGET_FILE:check_clamav>
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+    set_property(TEST libclamav_hash_fetch_failure PROPERTY
+        ENVIRONMENT
+            ${ENVIRONMENT}
+            CK_RUN_SUITE=cli
+            "CK_RUN_CASE=hash fetch failure"
+            CLAMAV_TEST_MD5_FETCH_FAILURE=1
+            "LD_PRELOAD=$<TARGET_FILE:force_hash_provider_failure>:$ENV{LD_PRELOAD}")
+    set_property(TEST libclamav_hash_fetch_failure PROPERTY TIMEOUT 300)
+
+    add_test(NAME libclamav_hash_libctx_failure
+        COMMAND $<TARGET_FILE:check_clamav>
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+    set_property(TEST libclamav_hash_libctx_failure PROPERTY
+        ENVIRONMENT
+            ${ENVIRONMENT}
+            CK_RUN_SUITE=cli
+            "CK_RUN_CASE=hash library context failure"
+            CLAMAV_TEST_OSSL_LIBCTX_FAILURE=1
+            "LD_PRELOAD=$<TARGET_FILE:force_hash_provider_failure>:$ENV{LD_PRELOAD}")
+    set_property(TEST libclamav_hash_libctx_failure PROPERTY TIMEOUT 300)
+
+    if(Valgrind_FOUND)
+        add_test(NAME libclamav_hash_fetch_failure_valgrind
+            COMMAND ${Valgrind_EXECUTABLE}
+                --leak-check=full
+                --show-leak-kinds=all
+                --errors-for-leak-kinds=definite,indirect,possible
+                --error-exitcode=1
+                $<TARGET_FILE:check_clamav>
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+        set_property(TEST libclamav_hash_fetch_failure_valgrind PROPERTY
+            ENVIRONMENT
+                ${ENVIRONMENT}
+                CK_RUN_SUITE=cli
+                "CK_RUN_CASE=hash fetch failure"
+                CLAMAV_TEST_MD5_FETCH_FAILURE=1
+                "LD_PRELOAD=$<TARGET_FILE:force_hash_provider_failure>:$ENV{LD_PRELOAD}")
+        set_property(TEST libclamav_hash_fetch_failure_valgrind PROPERTY TIMEOUT 300)
+    endif()
 endif()
 
 add_rust_test(NAME libclamav_rust

--- a/unit_tests/check_clamav.c
+++ b/unit_tests/check_clamav.c
@@ -21,6 +21,8 @@
 
 #include <libxml/parser.h>
 
+#include <openssl/evp.h>
+
 #include "platform.h"
 
 // libclamav
@@ -34,6 +36,10 @@
 #include "actions.h"
 
 #include "checks.h"
+
+#ifdef CL_THREAD_SAFE
+#include <pthread.h>
+#endif
 
 static int fpu_words = FPU_ENDIAN_INITME;
 #define NO_FPU_ENDIAN (fpu_words == FPU_ENDIAN_UNKNOWN)
@@ -1693,6 +1699,200 @@ START_TEST(test_sha2_256)
 }
 END_TEST
 
+/* Number of times to repeat a *failing* digest fetch.
+ *
+ * Before the shared EVP_MD cache, each hash allocated its own OSSL_LIB_CTX
+ * before fetching the digest and then returned early without freeing it when
+ * the fetch failed -- so every failed hash leaked a library context. On a
+ * strict-FIPS host, where MD5 cannot be fetched at all, that was one leak per
+ * scanned object. Repeating the failing call this many times makes such a
+ * per-call leak unmistakable to the Valgrind and sanitizer jobs that run this
+ * binary, while still being quick when nothing leaks. */
+#define HASH_FETCH_FAIL_ITERS 2000
+
+/* Whether OpenSSL itself can supply this digest, asked directly rather than
+ * through libclamav. This is the independent signal that keeps the checks below
+ * from silently excusing a NULL hash context: if OpenSSL can produce the digest
+ * but libclamav cannot, that is a real regression in the cache, whereas if
+ * OpenSSL cannot either (a FIPS policy withholding MD5/SHA1) then libclamav
+ * failing is expected host behavior. */
+static bool openssl_has_digest(const char *ossl_alg)
+{
+#if OPENSSL_VERSION_MAJOR >= 3
+    EVP_MD *md = EVP_MD_fetch(NULL, ossl_alg, NULL);
+
+    if (NULL == md) {
+        return false;
+    }
+
+    EVP_MD_free(md);
+    return true;
+#else
+    return NULL != EVP_get_digestbyname(ossl_alg);
+#endif
+}
+
+/* Hash "abc" with the incremental (FIPS-bypass) API and compare against a
+ * known digest. Used as the always-must-work control. */
+static bool hash_abc_matches(const char *alg, const uint8_t *expect, size_t expect_len)
+{
+    uint8_t out[SHA256_HASH_SIZE];
+    void *ctx = cl_hash_init(alg);
+
+    if (NULL == ctx) {
+        return false;
+    }
+
+    if (0 != cl_update_hash(ctx, "abc", 3)) {
+        cl_hash_destroy(ctx);
+        return false;
+    }
+
+    /* cl_finish_hash() frees the context either way. */
+    if (0 != cl_finish_hash(ctx, out)) {
+        return false;
+    }
+
+    return 0 == memcmp(out, expect, expect_len);
+}
+
+START_TEST(test_hash_md5_sha1)
+{
+    /* The incremental cl_hash_* API is routed through the shared EVP_MD cache
+     * by this change; verify it still returns correct MD5/SHA1 digests. A NULL
+     * context is only acceptable where a FIPS policy withholds the algorithm --
+     * on any host that can hash it at all, a NULL is a failure, not a skip. */
+    static const uint8_t md5_abc[MD5_HASH_SIZE] = {
+        0x90, 0x01, 0x50, 0x98, 0x3c, 0xd2, 0x4f, 0xb0,
+        0xd6, 0x96, 0x3f, 0x7d, 0x28, 0xe1, 0x7f, 0x72};
+    static const uint8_t sha1_abc[SHA1_HASH_SIZE] = {
+        0xa9, 0x99, 0x3e, 0x36, 0x47, 0x06, 0x81, 0x6a, 0xba, 0x3e,
+        0x25, 0x71, 0x78, 0x50, 0xc2, 0x6c, 0x9c, 0xd0, 0xd8, 0x9d};
+    static const struct {
+        const char *alg;
+        const uint8_t *expect;
+        size_t expect_len;
+    } vectors[] = {
+        {"md5", md5_abc, MD5_HASH_SIZE},
+        {"sha1", sha1_abc, SHA1_HASH_SIZE}};
+    uint8_t out[SHA256_HASH_SIZE];
+    size_t i;
+    unsigned j;
+
+    for (i = 0; i < sizeof(vectors) / sizeof(vectors[0]); i++) {
+        void *ctx = cl_hash_init(vectors[i].alg);
+
+        if (NULL == ctx) {
+            /* Tolerated only where OpenSSL itself withholds the digest (a FIPS
+             * policy). On an ordinary host this is a failure, not a skip. */
+            ck_assert_msg(!openssl_has_digest(vectors[i].alg),
+                          "cl_hash_init(\"%s\") returned NULL even though OpenSSL can fetch %s",
+                          vectors[i].alg, vectors[i].alg);
+
+            /* Strict FIPS: this is the fetch-failure path that used to leak an
+             * OSSL_LIB_CTX per hash. Repeated failures must stay clean and
+             * consistent -- under Valgrind/LeakSanitizer this asserts that no
+             * per-call allocation survives. */
+            for (j = 0; j < HASH_FETCH_FAIL_ITERS; j++) {
+                ck_assert_msg(NULL == cl_hash_init(vectors[i].alg),
+                              "cl_hash_init(\"%s\") failed once but then succeeded",
+                              vectors[i].alg);
+            }
+            continue;
+        }
+
+        ck_assert_msg(0 == cl_update_hash(ctx, "abc", 3),
+                      "cl_update_hash() failed for %s", vectors[i].alg);
+        ck_assert_msg(0 == cl_finish_hash(ctx, out),
+                      "cl_finish_hash() failed for %s", vectors[i].alg);
+        ck_assert_msg(0 == memcmp(out, vectors[i].expect, vectors[i].expect_len),
+                      "%s(\"abc\") mismatch", vectors[i].alg);
+    }
+}
+END_TEST
+
+START_TEST(test_hash_fetch_failure_is_bounded)
+{
+    /* Exercise the digest-fetch failure path on *every* host, not just
+     * strict-FIPS ones: an algorithm libclamav maps to no OpenSSL digest fails
+     * at the same early return that a FIPS-restricted MD5 does -- the return
+     * that used to leak an OSSL_LIB_CTX per call. Repeating it many times means
+     * ordinary (non-FIPS) CI covers the leak as well, since the Valgrind and
+     * sanitizer jobs would report one leaked context per iteration.
+     *
+     * A successful sha2-256 hash on either side is the control: it shows the
+     * shared context and cache still work, and that the repeated failures
+     * neither poison nor exhaust them. */
+    unsigned i;
+
+    ck_assert_msg(hash_abc_matches("sha2-256", res256[0], SHA256_HASH_SIZE),
+                  "sha2-256 control failed before the fetch-failure loop");
+
+    for (i = 0; i < HASH_FETCH_FAIL_ITERS; i++) {
+        ck_assert_msg(NULL == cl_hash_init("not-a-real-hash-algorithm"),
+                      "cl_hash_init() unexpectedly succeeded for an unsupported algorithm");
+    }
+
+    ck_assert_msg(hash_abc_matches("sha2-256", res256[0], SHA256_HASH_SIZE),
+                  "sha2-256 control failed after the fetch-failure loop");
+}
+END_TEST
+
+#ifdef CL_THREAD_SAFE
+#define HASH_TS_THREADS 8
+#define HASH_TS_ITERS 2000
+struct hash_ts_arg {
+    const uint8_t *expect; /* sha2-256("abc") == res256[0] */
+    int failed;
+};
+static void *hash_ts_worker(void *arg)
+{
+    struct hash_ts_arg *a      = (struct hash_ts_arg *)arg;
+    static const uint8_t abc[] = {'a', 'b', 'c'};
+    uint8_t out[SHA256_HASH_SIZE];
+    unsigned i;
+
+    for (i = 0; i < HASH_TS_ITERS; i++) {
+        void *ctx = cl_hash_init("sha2-256");
+        if (NULL == ctx) {
+            a->failed = 1;
+            return NULL;
+        }
+        cl_update_hash(ctx, abc, sizeof(abc));
+        cl_finish_hash(ctx, out);
+        if (0 != memcmp(out, a->expect, SHA256_HASH_SIZE)) {
+            a->failed = 1;
+            return NULL;
+        }
+    }
+    return NULL;
+}
+
+START_TEST(test_hash_cache_threadsafe)
+{
+    /* Concurrently hammer cl_hash_init() to exercise the process-global EVP_MD
+     * cache added by the per-hash provider-fetch fix, catching races on the
+     * cache and its mutex (run under Valgrind/TSan in CI). */
+    pthread_t th[HASH_TS_THREADS];
+    struct hash_ts_arg args[HASH_TS_THREADS];
+    int i, failed = 0;
+
+    for (i = 0; i < HASH_TS_THREADS; i++) {
+        args[i].expect = res256[0];
+        args[i].failed = 0;
+        ck_assert_msg(0 == pthread_create(&th[i], NULL, hash_ts_worker, &args[i]),
+                      "pthread_create failed");
+    }
+    for (i = 0; i < HASH_TS_THREADS; i++) {
+        pthread_join(th[i], NULL);
+        if (args[i].failed)
+            failed = 1;
+    }
+    ck_assert_msg(0 == failed, "concurrent cl_hash_init(sha2-256) returned a wrong digest or NULL context");
+}
+END_TEST
+#endif
+
 START_TEST(test_sanitize_path)
 {
     const char *unsanitized   = NULL;
@@ -2041,6 +2241,11 @@ static Suite *test_cli_suite(void)
     suite_add_tcase(s, tc_cli_dsig);
     tcase_add_loop_test(tc_cli_dsig, test_cli_dsig, 0, dsig_tests_cnt);
     tcase_add_test(tc_cli_dsig, test_sha2_256);
+    tcase_add_test(tc_cli_dsig, test_hash_md5_sha1);
+    tcase_add_test(tc_cli_dsig, test_hash_fetch_failure_is_bounded);
+#ifdef CL_THREAD_SAFE
+    tcase_add_test(tc_cli_dsig, test_hash_cache_threadsafe);
+#endif
 
     suite_add_tcase(s, tc_cli_assorted);
     tcase_add_test(tc_cli_assorted, test_sanitize_path);

--- a/unit_tests/check_clamav.c
+++ b/unit_tests/check_clamav.c
@@ -20,7 +20,6 @@
 #endif
 
 #include <libxml/parser.h>
-
 #include <openssl/evp.h>
 
 #include "platform.h"
@@ -1699,144 +1698,114 @@ START_TEST(test_sha2_256)
 }
 END_TEST
 
-/* Number of times to repeat a *failing* digest fetch.
- *
- * Before the shared EVP_MD cache, each hash allocated its own OSSL_LIB_CTX
- * before fetching the digest and then returned early without freeing it when
- * the fetch failed -- so every failed hash leaked a library context. On a
- * strict-FIPS host, where MD5 cannot be fetched at all, that was one leak per
- * scanned object. Repeating the failing call this many times makes such a
- * per-call leak unmistakable to the Valgrind and sanitizer jobs that run this
- * binary, while still being quick when nothing leaks. */
-#define HASH_FETCH_FAIL_ITERS 2000
-
-/* Whether OpenSSL itself can supply this digest, asked directly rather than
- * through libclamav. This is the independent signal that keeps the checks below
- * from silently excusing a NULL hash context: if OpenSSL can produce the digest
- * but libclamav cannot, that is a real regression in the cache, whereas if
- * OpenSSL cannot either (a FIPS policy withholding MD5/SHA1) then libclamav
- * failing is expected host behavior. */
-static bool openssl_has_digest(const char *ossl_alg)
-{
-#if OPENSSL_VERSION_MAJOR >= 3
-    EVP_MD *md = EVP_MD_fetch(NULL, ossl_alg, NULL);
-
-    if (NULL == md) {
-        return false;
-    }
-
-    EVP_MD_free(md);
-    return true;
-#else
-    return NULL != EVP_get_digestbyname(ossl_alg);
-#endif
-}
-
-/* Hash "abc" with the incremental (FIPS-bypass) API and compare against a
- * known digest. Used as the always-must-work control. */
-static bool hash_abc_matches(const char *alg, const uint8_t *expect, size_t expect_len)
-{
-    uint8_t out[SHA256_HASH_SIZE];
-    void *ctx = cl_hash_init(alg);
-
-    if (NULL == ctx) {
-        return false;
-    }
-
-    if (0 != cl_update_hash(ctx, "abc", 3)) {
-        cl_hash_destroy(ctx);
-        return false;
-    }
-
-    /* cl_finish_hash() frees the context either way. */
-    if (0 != cl_finish_hash(ctx, out)) {
-        return false;
-    }
-
-    return 0 == memcmp(out, expect, expect_len);
-}
-
 START_TEST(test_hash_md5_sha1)
 {
     /* The incremental cl_hash_* API is routed through the shared EVP_MD cache
-     * by this change; verify it still returns correct MD5/SHA1 digests. A NULL
-     * context is only acceptable where a FIPS policy withholds the algorithm --
-     * on any host that can hash it at all, a NULL is a failure, not a skip. */
-    static const uint8_t md5_abc[MD5_HASH_SIZE] = {
+     * by this change; verify it still returns correct MD5/SHA1 digests for the
+     * "abc" vectors. These algorithms must remain available through the
+     * private non-FIPS context even when the default context enables FIPS. */
+    static const uint8_t abc[]                    = {'a', 'b', 'c'};
+    static const uint8_t md5_abc[MD5_HASH_SIZE]   = {
         0x90, 0x01, 0x50, 0x98, 0x3c, 0xd2, 0x4f, 0xb0,
         0xd6, 0x96, 0x3f, 0x7d, 0x28, 0xe1, 0x7f, 0x72};
     static const uint8_t sha1_abc[SHA1_HASH_SIZE] = {
         0xa9, 0x99, 0x3e, 0x36, 0x47, 0x06, 0x81, 0x6a, 0xba, 0x3e,
         0x25, 0x71, 0x78, 0x50, 0xc2, 0x6c, 0x9c, 0xd0, 0xd8, 0x9d};
-    static const struct {
-        const char *alg;
-        const uint8_t *expect;
-        size_t expect_len;
-    } vectors[] = {
-        {"md5", md5_abc, MD5_HASH_SIZE},
-        {"sha1", sha1_abc, SHA1_HASH_SIZE}};
     uint8_t out[SHA256_HASH_SIZE];
-    size_t i;
-    unsigned j;
+    void *ctx;
 
-    for (i = 0; i < sizeof(vectors) / sizeof(vectors[0]); i++) {
-        void *ctx = cl_hash_init(vectors[i].alg);
+    ctx = cl_hash_init("md5");
+    ck_assert_msg(NULL != ctx, "cl_hash_init(md5) failed");
+    ck_assert_msg(0 == cl_update_hash(ctx, abc, sizeof(abc)), "cl_update_hash(md5) failed");
+    ck_assert_msg(0 == cl_finish_hash(ctx, out), "cl_finish_hash(md5) failed");
+    ck_assert_msg(!memcmp(out, md5_abc, MD5_HASH_SIZE), "md5(\"abc\") mismatch");
 
-        if (NULL == ctx) {
-            /* Tolerated only where OpenSSL itself withholds the digest (a FIPS
-             * policy). On an ordinary host this is a failure, not a skip. */
-            ck_assert_msg(!openssl_has_digest(vectors[i].alg),
-                          "cl_hash_init(\"%s\") returned NULL even though OpenSSL can fetch %s",
-                          vectors[i].alg, vectors[i].alg);
+    ctx = cl_hash_init("sha1");
+    ck_assert_msg(NULL != ctx, "cl_hash_init(sha1) failed");
+    ck_assert_msg(0 == cl_update_hash(ctx, abc, sizeof(abc)), "cl_update_hash(sha1) failed");
+    ck_assert_msg(0 == cl_finish_hash(ctx, out), "cl_finish_hash(sha1) failed");
+    ck_assert_msg(!memcmp(out, sha1_abc, SHA1_HASH_SIZE), "sha1(\"abc\") mismatch");
 
-            /* Strict FIPS: this is the fetch-failure path that used to leak an
-             * OSSL_LIB_CTX per hash. Repeated failures must stay clean and
-             * consistent -- under Valgrind/LeakSanitizer this asserts that no
-             * per-call allocation survives. */
-            for (j = 0; j < HASH_FETCH_FAIL_ITERS; j++) {
-                ck_assert_msg(NULL == cl_hash_init(vectors[i].alg),
-                              "cl_hash_init(\"%s\") failed once but then succeeded",
-                              vectors[i].alg);
-            }
-            continue;
-        }
-
-        ck_assert_msg(0 == cl_update_hash(ctx, "abc", 3),
-                      "cl_update_hash() failed for %s", vectors[i].alg);
-        ck_assert_msg(0 == cl_finish_hash(ctx, out),
-                      "cl_finish_hash() failed for %s", vectors[i].alg);
-        ck_assert_msg(0 == memcmp(out, vectors[i].expect, vectors[i].expect_len),
-                      "%s(\"abc\") mismatch", vectors[i].alg);
-    }
+    ctx = cl_hash_init("sha2-256");
+    ck_assert_msg(NULL != ctx, "cl_hash_init(sha2-256) failed");
+    ck_assert_msg(0 == cl_update_hash(ctx, abc, sizeof(abc)), "cl_update_hash(sha2-256) failed");
+    ck_assert_msg(0 == cl_finish_hash(ctx, out), "cl_finish_hash(sha2-256) failed");
+    ck_assert_msg(!memcmp(out, res256[0], SHA256_HASH_SIZE), "sha2-256(\"abc\") mismatch");
 }
 END_TEST
 
-START_TEST(test_hash_fetch_failure_is_bounded)
+#if defined(C_LINUX) && OPENSSL_VERSION_MAJOR >= 3
+START_TEST(test_hash_md5_fetch_failure)
 {
-    /* Exercise the digest-fetch failure path on *every* host, not just
-     * strict-FIPS ones: an algorithm libclamav maps to no OpenSSL digest fails
-     * at the same early return that a FIPS-restricted MD5 does -- the return
-     * that used to leak an OSSL_LIB_CTX per call. Repeating it many times means
-     * ordinary (non-FIPS) CI covers the leak as well, since the Valgrind and
-     * sanitizer jobs would report one leaked context per iteration.
-     *
-     * A successful sha2-256 hash on either side is the control: it shows the
-     * shared context and cache still work, and that the repeated failures
-     * neither poison nor exhaust them. */
+    static const uint8_t abc[] = {'a', 'b', 'c'};
+    void *ctx;
+    uint8_t out[SHA256_HASH_SIZE];
     unsigned i;
 
-    ck_assert_msg(hash_abc_matches("sha2-256", res256[0], SHA256_HASH_SIZE),
-                  "sha2-256 control failed before the fetch-failure loop");
-
-    for (i = 0; i < HASH_FETCH_FAIL_ITERS; i++) {
-        ck_assert_msg(NULL == cl_hash_init("not-a-real-hash-algorithm"),
-                      "cl_hash_init() unexpectedly succeeded for an unsupported algorithm");
+    if (NULL == getenv("CLAMAV_TEST_MD5_FETCH_FAILURE")) {
+        return;
     }
 
-    ck_assert_msg(hash_abc_matches("sha2-256", res256[0], SHA256_HASH_SIZE),
-                  "sha2-256 control failed after the fetch-failure loop");
+    /* Repeatedly exercise the failure path so a per-attempt context leak is
+     * visible under Valgrind or LeakSanitizer. */
+    for (i = 0; i < 10000; i++) {
+        ck_assert_msg(NULL == cl_hash_init("md5"),
+                      "cl_hash_init(md5) unexpectedly succeeded when EVP_MD_fetch was forced to fail");
+    }
+
+    ctx = cl_hash_init("sha2-256");
+    ck_assert_msg(NULL != ctx, "cl_hash_init(sha2-256) failed while only MD5 fetches were disabled");
+    ck_assert_msg(0 == cl_update_hash(ctx, abc, sizeof(abc)), "cl_update_hash(sha2-256) failed");
+    ck_assert_msg(0 == cl_finish_hash(ctx, out), "cl_finish_hash(sha2-256) failed");
+    ck_assert_msg(!memcmp(out, res256[0], SHA256_HASH_SIZE), "sha2-256(\"abc\") mismatch");
 }
 END_TEST
+
+static bool hash_error_callback_called = false;
+static bool hash_error_callback_failed = false;
+
+static void hash_error_reentrant_callback(enum cl_msg severity, const char *fullmsg, const char *msg, void *context)
+{
+    void *ctx;
+
+    UNUSEDPARAM(fullmsg);
+    UNUSEDPARAM(msg);
+    UNUSEDPARAM(context);
+
+    if (CL_MSG_ERROR != severity || hash_error_callback_called) {
+        return;
+    }
+    hash_error_callback_called = true;
+
+    /* Permit the callback's nested bypass request to create the context. If
+     * the outer diagnostic is emitted while md_cache_mutex is held, this call
+     * deadlocks trying to acquire the same mutex. */
+    unsetenv("CLAMAV_TEST_OSSL_LIBCTX_FAILURE");
+    ctx = cl_hash_init("sha2-256");
+    if (NULL == ctx) {
+        hash_error_callback_failed = true;
+        return;
+    }
+    cl_hash_destroy(ctx);
+}
+
+START_TEST(test_hash_libctx_failure)
+{
+    if (NULL == getenv("CLAMAV_TEST_OSSL_LIBCTX_FAILURE")) {
+        return;
+    }
+
+    hash_error_callback_called = false;
+    hash_error_callback_failed = false;
+    cl_set_clcb_msg(hash_error_reentrant_callback);
+
+    ck_assert_msg(NULL == cl_hash_init("md5"),
+                  "cl_hash_init(md5) returned a context after OSSL_LIB_CTX_new failed");
+    ck_assert_msg(hash_error_callback_called, "digest-cache failure did not invoke the message callback");
+    ck_assert_msg(!hash_error_callback_failed, "hashing from the message callback failed");
+}
+END_TEST
+#endif
 
 #ifdef CL_THREAD_SAFE
 #define HASH_TS_THREADS 8
@@ -2231,6 +2200,10 @@ static Suite *test_cli_suite(void)
     TCase *tc_cli_others   = tcase_create("byteorder_macros");
     TCase *tc_cli_dsig     = tcase_create("digital signatures");
     TCase *tc_cli_assorted = tcase_create("assorted functions");
+#if defined(C_LINUX) && OPENSSL_VERSION_MAJOR >= 3
+    TCase *tc_cli_hash_fetch_failure  = tcase_create("hash fetch failure");
+    TCase *tc_cli_hash_libctx_failure = tcase_create("hash library context failure");
+#endif
 
     suite_add_tcase(s, tc_cli_others);
     tcase_add_checked_fixture(tc_cli_others, data_setup, data_teardown);
@@ -2242,9 +2215,15 @@ static Suite *test_cli_suite(void)
     tcase_add_loop_test(tc_cli_dsig, test_cli_dsig, 0, dsig_tests_cnt);
     tcase_add_test(tc_cli_dsig, test_sha2_256);
     tcase_add_test(tc_cli_dsig, test_hash_md5_sha1);
-    tcase_add_test(tc_cli_dsig, test_hash_fetch_failure_is_bounded);
 #ifdef CL_THREAD_SAFE
     tcase_add_test(tc_cli_dsig, test_hash_cache_threadsafe);
+#endif
+
+#if defined(C_LINUX) && OPENSSL_VERSION_MAJOR >= 3
+    suite_add_tcase(s, tc_cli_hash_fetch_failure);
+    tcase_add_test(tc_cli_hash_fetch_failure, test_hash_md5_fetch_failure);
+    suite_add_tcase(s, tc_cli_hash_libctx_failure);
+    tcase_add_test(tc_cli_hash_libctx_failure, test_hash_libctx_failure);
 #endif
 
     suite_add_tcase(s, tc_cli_assorted);

--- a/unit_tests/force_hash_provider_failure.c
+++ b/unit_tests/force_hash_provider_failure.c
@@ -1,0 +1,58 @@
+/*
+ * Test-only OpenSSL interposer for deterministic digest-cache failure tests.
+ */
+
+#define _GNU_SOURCE
+
+#include <dlfcn.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <openssl/evp.h>
+
+typedef EVP_MD *(*evp_md_fetch_fn)(OSSL_LIB_CTX *, const char *, const char *);
+typedef OSSL_LIB_CTX *(*ossl_lib_ctx_new_fn)(void);
+
+static void resolve_symbol(void *function_out, size_t function_size, const char *name)
+{
+    void *symbol = dlsym(RTLD_NEXT, name);
+
+    if (function_size == sizeof(symbol)) {
+        memcpy(function_out, &symbol, function_size);
+    }
+}
+
+EVP_MD *EVP_MD_fetch(OSSL_LIB_CTX *ctx, const char *algorithm, const char *properties)
+{
+    static evp_md_fetch_fn real_fetch = NULL;
+
+    if (NULL != ctx && NULL != algorithm && NULL != getenv("CLAMAV_TEST_MD5_FETCH_FAILURE") &&
+        0 == strcmp(algorithm, "md5")) {
+        return NULL;
+    }
+
+    if (NULL == real_fetch) {
+        resolve_symbol(&real_fetch, sizeof(real_fetch), "EVP_MD_fetch");
+    }
+    if (NULL == real_fetch) {
+        return NULL;
+    }
+    return real_fetch(ctx, algorithm, properties);
+}
+
+OSSL_LIB_CTX *OSSL_LIB_CTX_new(void)
+{
+    static ossl_lib_ctx_new_fn real_new = NULL;
+
+    if (NULL != getenv("CLAMAV_TEST_OSSL_LIBCTX_FAILURE")) {
+        return NULL;
+    }
+
+    if (NULL == real_new) {
+        resolve_symbol(&real_new, sizeof(real_new), "OSSL_LIB_CTX_new");
+    }
+    if (NULL == real_new) {
+        return NULL;
+    }
+    return real_new();
+}


### PR DESCRIPTION
## Summary

On OpenSSL 3, libclamav re-acquires the digest implementation on **every** hash operation. `cl_hash_init()`, `cl_hash_data()`, `cl_hash_file_fd()` and their `*_ex` variants each allocate a brand-new `OSSL_LIB_CTX` (`OSSL_LIB_CTX_new()`), `EVP_MD_fetch()` the algorithm with the `"-fips"` property (so non-approved MD5/SHA1 signature hashing works on FIPS-enabled hosts), then free the digest and the context.

Because the provider/method cache lives *inside* a library context ([`OSSL_LIB_CTX(3)`](https://docs.openssl.org/3.0/man3/OSSL_LIB_CTX/)), a freshly-allocated context starts with an empty cache, so each `EVP_MD_fetch()` pays the full provider-bootstrap + method-construction cost — on the order of hundreds of microseconds — and it runs for md5/sha1/sha2-256 on essentially every scanned object (whole-file and section hashes, plus the SHA2-256 clean-cache lookup in `fmap_get_hash()`). The per-object hashing plumbing ends up costing far more than the hashing itself.

This is not FIPS-specific: the throwaway-context path is compiled unconditionally for OpenSSL 3, so it slows scanning whether or not the host is in FIPS mode.

The per-call throwaway context was introduced in 83fd7f14 (#1589, CLAM-2879) to fix a genuine correctness bug — MD5 hashing failing on strict-FIPS hosts when fetched from the default context. That fix is correct in *what* it does; the only problem is that it does it on every hash instead of once.

## Fix

Per the [FIPS module guide](https://docs.openssl.org/3.0/man7/fips_module/#programmatically-loading-the-fips-module-nondefault-library-context), a non-default `OSSL_LIB_CTX` is the correct way to reach non-FIPS digests — but per [`EVP_MD_fetch` / `EVP_DigestInit(3)`](https://docs.openssl.org/3.0/man3/EVP_DigestInit/) and the [3.0 migration guide](https://docs.openssl.org/3.0/man7/migration_guide/) (explicit fetching / performance), a fetched `EVP_MD` is a reference-counted object that should be created **once and reused**, not rebuilt on every operation.

So: create the shared non-FIPS `OSSL_LIB_CTX` once and cache each fetched bypass `EVP_MD` for the process lifetime, handing callers an owned reference (their existing `EVP_MD_free()` cleanup is unchanged). This preserves #1589's FIPS-bypass semantics exactly — the shared context is still created with `OSSL_LIB_CTX_new()` and digests are still fetched with the `"-fips"` property, so MD5/SHA1 signature hashing keeps working on strict-FIPS hosts.

The FIPS-*compliant* (non-bypass) path is deliberately **not** cached: it is still fetched from the default library context on every call, so it continues to honor the current default property query — e.g. if the embedding process enables FIPS at runtime, a non-bypass MD5/SHA1 request correctly starts failing instead of returning a stale non-FIPS handle. That default-context fetch is already inexpensive because OpenSSL caches provider methods per library context.

## Benchmarks

Isolated micro-benchmark: identical hashing work both ways, differing only in how the digest is obtained — a fresh `OSSL_LIB_CTX` + `EVP_MD_fetch()` per hash vs. fetch-once-and-reuse (this change). OpenSSL 3, aarch64, 200k hashes of a 4 KiB buffer:

| algorithm | per-hash (stock) | per-hash (cached) | speedup |
|---|---|---|---|
| sha2-256 | 214 µs | 1.8 µs | **~118×** |
| md5 | 214 µs | 6.8 µs | **~31×** |

- The per-hash overhead (~210 µs) is essentially identical across algorithms, confirming the cost is the fetch/context machinery, not the digest computation.
- Interposing `OSSL_LIB_CTX_new()`/`EVP_MD_fetch()` confirms the bypass path drops from one call **per hash** (e.g. 5000 fetches for 5000 hashes) to **one per algorithm for the entire process** (→ 1).

libclamav hashes md5/sha1/sha2-256 for essentially every scanned object — whole-file and section hashes, plus the SHA2-256 clean-cache lookup in `fmap_get_hash()` — so this per-object overhead is paid throughout a scan. No functional or API change; hashing outputs are identical.

## Also fixes a memory leak on FIPS hosts

Independent of the performance win, removing the per-hash `OSSL_LIB_CTX_new()` fixes a memory leak. The pre-existing code allocates the context *before* the fetch and does not free it on the `md == NULL` return path in `cl_hash_init`, `cl_hash_data`, and `cl_hash_file_fd` (e.g. `crypto.c:1866`). On a host whose FIPS policy makes MD5 unavailable, `EVP_MD_fetch(..., "md5", "-fips")` returns `NULL`, so **every hashed object leaks an `OSSL_LIB_CTX`** — and libclamav hashes MD5 for essentially every scanned file.

Reproduced on a FIPS-enabled Ubuntu 22.04 / OpenSSL 3.0.2 host (ClamAV 1.5.3), during a recursive scan:

```
LibClamAV Error: cli_scan_fmap: Error initializing md5 hash context
RSS: 0.66 GB → 2.57 GB in ~25 s (~75 MB/s), monotonic, no plateau  → OOM on a full scan
```

(SHA-256 succeeds — it is FIPS-approved; MD5 is the one that fails.)

Stock vs. patched, exercising the exact `cl_hash_init` (fresh `OSSL_LIB_CTX` per hash) vs. shared-context code paths against a real FIPS OpenSSL 3.0.2 host — 100k MD5 hashes, each returning NULL under FIPS:

| variant | RSS over 100k MD5 hashes |
|---|---|
| stock (fresh `OSSL_LIB_CTX` per hash) | **+20.6 GB** |
| patched (one shared context) | **+4.2 MB** (flat) |
| control — SHA-256, stock (fetch succeeds) | +3.9 MB (bounded) |

The control confirms it is specifically the NULL-fetch path that leaks: when the fetch succeeds (SHA-256, or any algorithm on a non-FIPS host), even the stock per-hash-context churn stays bounded.

With a single shared context there is no per-hash context to leak. On such a host MD5 remains unavailable, but the fetch now fails cleanly and bounded (MD5-based signatures simply don't match) instead of growing without bound — graceful degradation rather than OOM.

## References

- [`EVP_MD_fetch` / `EVP_DigestInit(3)`](https://docs.openssl.org/3.0/man3/EVP_DigestInit/) — a fetched `EVP_MD` is reference-counted and intended to be fetched once and reused.
- [`migration_guide(7)`](https://docs.openssl.org/3.0/man7/migration_guide/) — explicit fetching and its performance characteristics when moving from 1.1.1 to 3.0.
- [`fips_module(7)` — nondefault library context](https://docs.openssl.org/3.0/man7/fips_module/#programmatically-loading-the-fips-module-nondefault-library-context) — the approach #1589 used to reach non-FIPS digests, preserved here (created once instead of per hash).
- [`OSSL_LIB_CTX(3)`](https://docs.openssl.org/3.0/man3/OSSL_LIB_CTX/) — the provider/method cache lives in the library context, which is why allocating a fresh one per hash defeats caching.
