### PR TITLE
Jenkinsfile: throttle concurrent builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,176 +58,185 @@ properties(
 
 pipeline {
 
-    agent {
-        label "default"
-    }
+    agent none
 
     stages {
-
-        stage('Generate Tarball') {
-            steps {
-                cleanWs()
-
-                checkout scm
-
-                dir(path: 'clamav_documentation') {
-                    git(url: 'https://github.com/Cisco-Talos/clamav-documentation.git', branch: "gh-pages")
-                }
-
-                dir(path: 'docs/html') {
-                    sh """# Move the clamav-documentation here.
-                        cp -r ../../clamav_documentation/* .
-                        # Clean-up
-                        rm -rf ../../clamav_documentation
-                        rm -rf .git .nojekyll CNAME Placeholder || true
-                    """
-                }
-
-                dir(path: 'build') {
-                    sh """# CPack
-                        cmake .. -D VENDOR_DEPENDENCIES=ON \
-                            -D JSONC_INCLUDE_DIR="$HOME/.mussels/install/host-static/include/json-c" \
-                            -D JSONC_LIBRARY="$HOME/.mussels/install/host-static/lib/libjson-c.a" \
-                            -D ENABLE_JSON_SHARED=OFF \
-                            -D BZIP2_INCLUDE_DIR="$HOME/.mussels/install/host-static/include" \
-                            -D BZIP2_LIBRARY_RELEASE="$HOME/bzip2-1.0.8-install/lib/libbz2.a" \
-                            -D OPENSSL_ROOT_DIR="$HOME/.mussels/install/host-static" \
-                            -D OPENSSL_INCLUDE_DIR="$HOME/.mussels/install/host-static/include" \
-                            -D OPENSSL_CRYPTO_LIBRARY="$HOME/.mussels/install/host-static/lib/libcrypto.a" \
-                            -D OPENSSL_SSL_LIBRARY="$HOME/.mussels/install/host-static/lib/libssl.a" \
-                            -D LIBXML2_INCLUDE_DIR="$HOME/.mussels/install/host-static/include/libxml2" \
-                            -D LIBXML2_LIBRARY="$HOME/.mussels/install/host-static/lib/libxml2.a" \
-                            -D PCRE2_INCLUDE_DIR="$HOME/.mussels/install/host-static/include" \
-                            -D PCRE2_LIBRARY="$HOME/.mussels/install/host-static/lib/libpcre2-8.a" \
-                            -D NCURSES_INCLUDE_DIR="$HOME/.mussels/install/host-static/include" \
-                            -D CURSES_LIBRARY="$HOME/.mussels/install/host-static/lib/libncurses.a" \
-                            -D TINFO_LIBRARY="$HOME/.mussels/install/host-static/lib/libtinfo.a" \
-                            -D ZLIB_INCLUDE_DIR="$HOME/.mussels/install/host-static/include" \
-                            -D ZLIB_LIBRARY="$HOME/.mussels/install/host-static/lib/libz.a" \
-                            -D LIBCHECK_INCLUDE_DIR="$HOME/.mussels/install/host-static/include" \
-                            -D LIBCHECK_LIBRARY="$HOME/.mussels/install/host-static/lib/libcheck.a"
-
-                        cpack --config CPackSourceConfig.cmake
-                    """
-                    archiveArtifacts(artifacts: "clamav-${params.VERSION}*.tar.gz", onlyIfSuccessful: true)
-
-                    sh """
-                        jq -n '[ inputs | .package_version = (input_filename | split("/") | .[-2])]' $HOME/.cargo/registry/src/*/*/.cargo_vcs_info.json > clamav_cargo_vcs_info.json
-                    """
-
-                    archiveArtifacts(artifacts: "clamav_cargo_vcs_info.json", onlyIfSuccessful: true)
-
-                }
-                cleanWs()
+        stage('ClamAV pipeline') {
+            agent {
+                label "default"
             }
-        }
-
-        stage('Build') {
-            steps {
-                script{
-                    buildResult = build(job: "${params.BUILD_PIPELINES_PATH}/${params.BUILD_PIPELINE}",
-                        propagate: true,
-                        wait: true,
-                        parameters: [
-                            [$class: 'StringParameterValue', name: 'CLAMAV_JOB_NAME', value: "${JOB_NAME}"],
-                            [$class: 'StringParameterValue', name: 'CLAMAV_JOB_NUMBER', value: "${BUILD_NUMBER}"],
-                            [$class: 'StringParameterValue', name: 'FRAMEWORK_BRANCH', value: "${params.FRAMEWORK_BRANCH}"],
-                            [$class: 'StringParameterValue', name: 'VERSION', value: "${params.VERSION}"],
-                            [$class: 'StringParameterValue', name: 'SHARED_LIB_BRANCH', value: "${params.SHARED_LIB_BRANCH}"]
-                        ]
-                    )
-                    echo "${params.BUILD_PIPELINES_PATH}/${params.BUILD_PIPELINE} #${buildResult.number} succeeded."
-                }
+            options {
+                // The step also throttles the first build of a multibranch job.
+                throttle(['clamav'])
             }
-        }
+            stages {
 
-        stage('Tests') {
-            failFast false
-            parallel {
-                stage('Pipeline') {
-                    stages{
-                        stage("Package") {
-                            steps {
-                                catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-                                    script{
-                                        packageResult = build(job: "${params.TEST_PIPELINES_PATH}/${params.PACKAGE_PIPELINE}",
-                                            propagate: true,
-                                            wait: true,
-                                            parameters: [
-                                                [$class: 'StringParameterValue', name: 'CLAMAV_JOB_NAME', value: "${JOB_NAME}"],
-                                                [$class: 'StringParameterValue', name: 'CLAMAV_JOB_NUMBER', value: "${BUILD_NUMBER}"],
-                                                [$class: 'StringParameterValue', name: 'TESTS_BRANCH', value: "${params.TESTS_BRANCH}"],
-                                                [$class: 'StringParameterValue', name: 'BUILD_JOB_NAME', value: "${params.BUILD_PIPELINES_PATH}/${params.BUILD_PIPELINE}"],
-                                                [$class: 'StringParameterValue', name: 'BUILD_JOB_NUMBER', value: "${buildResult.number}"],
-                                                [$class: 'StringParameterValue', name: 'FRAMEWORK_BRANCH', value: "${params.FRAMEWORK_BRANCH}"],
-                                                [$class: 'StringParameterValue', name: 'VERSION', value: "${params.VERSION}"],
-                                                [$class: 'StringParameterValue', name: 'SHARED_LIB_BRANCH', value: "${params.SHARED_LIB_BRANCH}"]
-                                            ]
-                                        )
-                                        echo "${params.TEST_PIPELINES_PATH}/${params.PACKAGE_PIPELINE} #${packageResult.number} succeeded."
-                                    }
-                                }
-                            }
+                stage('Generate Tarball') {
+                    steps {
+                        cleanWs()
+
+                        checkout scm
+
+                        dir(path: 'clamav_documentation') {
+                            git(url: 'https://github.com/Cisco-Talos/clamav-documentation.git', branch: "gh-pages")
                         }
 
-                        stage("Regular From-Source") {
-                            steps {
-                                catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-                                    script{
-                                        regularResult = build(job: "${params.TEST_PIPELINES_PATH}/${params.REGULAR_PIPELINE}",
-                                            propagate: true,
-                                            wait: true,
-                                            parameters: [
-                                                [$class: 'StringParameterValue', name: 'CLAMAV_JOB_NAME', value: "${JOB_NAME}"],
-                                                [$class: 'StringParameterValue', name: 'CLAMAV_JOB_NUMBER', value: "${BUILD_NUMBER}"],
-                                                [$class: 'StringParameterValue', name: 'TESTS_BRANCH', value: "${params.TESTS_BRANCH}"],
-                                                [$class: 'StringParameterValue', name: 'FRAMEWORK_BRANCH', value: "${params.FRAMEWORK_BRANCH}"],
-                                                [$class: 'StringParameterValue', name: 'VERSION', value: "${params.VERSION}"],
-                                                [$class: 'StringParameterValue', name: 'SHARED_LIB_BRANCH', value: "${params.SHARED_LIB_BRANCH}"]
-                                            ]
-                                        )
-                                        echo "${params.TEST_PIPELINES_PATH}/${params.REGULAR_PIPELINE} #${regularResult.number} succeeded."
-                                    }
-                                }
-                            }
+                        dir(path: 'docs/html') {
+                            sh """# Move the clamav-documentation here.
+                                cp -r ../../clamav_documentation/* .
+                                # Clean-up
+                                rm -rf ../../clamav_documentation
+                                rm -rf .git .nojekyll CNAME Placeholder || true
+                            """
                         }
 
-                        stage("Custom From-Source") {
-                            steps {
-                                script{
-                                    customResult = build(job: "${params.TEST_PIPELINES_PATH}/${params.CUSTOM_PIPELINE}",
-                                        propagate: true,
-                                        wait: true,
-                                        parameters: [
-                                            [$class: 'StringParameterValue', name: 'CLAMAV_JOB_NAME', value: "${JOB_NAME}"],
-                                            [$class: 'StringParameterValue', name: 'CLAMAV_JOB_NUMBER', value: "${BUILD_NUMBER}"],
-                                            [$class: 'StringParameterValue', name: 'TESTS_BRANCH', value: "${params.TESTS_CUSTOM_BRANCH}"],
-                                            [$class: 'StringParameterValue', name: 'FRAMEWORK_BRANCH', value: "${params.FRAMEWORK_BRANCH}"],
-                                            [$class: 'StringParameterValue', name: 'VERSION', value: "${params.VERSION}"],
-                                            [$class: 'StringParameterValue', name: 'SHARED_LIB_BRANCH', value: "${params.SHARED_LIB_BRANCH}"]
-                                        ]
-                                    )
-                                    echo "${params.TEST_PIPELINES_PATH}/${params.CUSTOM_PIPELINE} #${customResult.number} succeeded."
-                                }
-                            }
+                        dir(path: 'build') {
+                            sh """# CPack
+                                cmake .. -D VENDOR_DEPENDENCIES=ON \
+                                    -D JSONC_INCLUDE_DIR="$HOME/.mussels/install/host-static/include/json-c" \
+                                    -D JSONC_LIBRARY="$HOME/.mussels/install/host-static/lib/libjson-c.a" \
+                                    -D ENABLE_JSON_SHARED=OFF \
+                                    -D BZIP2_INCLUDE_DIR="$HOME/.mussels/install/host-static/include" \
+                                    -D BZIP2_LIBRARY_RELEASE="$HOME/bzip2-1.0.8-install/lib/libbz2.a" \
+                                    -D OPENSSL_ROOT_DIR="$HOME/.mussels/install/host-static" \
+                                    -D OPENSSL_INCLUDE_DIR="$HOME/.mussels/install/host-static/include" \
+                                    -D OPENSSL_CRYPTO_LIBRARY="$HOME/.mussels/install/host-static/lib/libcrypto.a" \
+                                    -D OPENSSL_SSL_LIBRARY="$HOME/.mussels/install/host-static/lib/libssl.a" \
+                                    -D LIBXML2_INCLUDE_DIR="$HOME/.mussels/install/host-static/include/libxml2" \
+                                    -D LIBXML2_LIBRARY="$HOME/.mussels/install/host-static/lib/libxml2.a" \
+                                    -D PCRE2_INCLUDE_DIR="$HOME/.mussels/install/host-static/include" \
+                                    -D PCRE2_LIBRARY="$HOME/.mussels/install/host-static/lib/libpcre2-8.a" \
+                                    -D NCURSES_INCLUDE_DIR="$HOME/.mussels/install/host-static/include" \
+                                    -D CURSES_LIBRARY="$HOME/.mussels/install/host-static/lib/libncurses.a" \
+                                    -D TINFO_LIBRARY="$HOME/.mussels/install/host-static/lib/libtinfo.a" \
+                                    -D ZLIB_INCLUDE_DIR="$HOME/.mussels/install/host-static/include" \
+                                    -D ZLIB_LIBRARY="$HOME/.mussels/install/host-static/lib/libz.a" \
+                                    -D LIBCHECK_INCLUDE_DIR="$HOME/.mussels/install/host-static/include" \
+                                    -D LIBCHECK_LIBRARY="$HOME/.mussels/install/host-static/lib/libcheck.a"
+
+                                cpack --config CPackSourceConfig.cmake
+                            """
+                            archiveArtifacts(artifacts: "clamav-${params.VERSION}*.tar.gz", onlyIfSuccessful: true)
+
+                            sh """
+                                jq -n '[ inputs | .package_version = (input_filename | split("/") | .[-2])]' $HOME/.cargo/registry/src/*/*/.cargo_vcs_info.json > clamav_cargo_vcs_info.json
+                            """
+
+                            archiveArtifacts(artifacts: "clamav_cargo_vcs_info.json", onlyIfSuccessful: true)
+
                         }
+                        cleanWs()
                     }
                 }
-                stage("Fuzz Regression") {
+
+                stage('Build') {
                     steps {
                         script{
-                            fuzzResult = build(job: "${params.TEST_PIPELINES_PATH}/${params.FUZZ_PIPELINE}",
+                            buildResult = build(job: "${params.BUILD_PIPELINES_PATH}/${params.BUILD_PIPELINE}",
                                 propagate: true,
                                 wait: true,
                                 parameters: [
                                     [$class: 'StringParameterValue', name: 'CLAMAV_JOB_NAME', value: "${JOB_NAME}"],
                                     [$class: 'StringParameterValue', name: 'CLAMAV_JOB_NUMBER', value: "${BUILD_NUMBER}"],
-                                    [$class: 'StringParameterValue', name: 'TESTS_FUZZ_BRANCH', value: "${params.TESTS_FUZZ_BRANCH}"],
-                                    [$class: 'StringParameterValue', name: 'FUZZ_CORPUS_BRANCH', value: "${params.FUZZ_CORPUS_BRANCH}"],
-                                    [$class: 'StringParameterValue', name: 'VERSION', value: "${params.VERSION}"]
+                                    [$class: 'StringParameterValue', name: 'FRAMEWORK_BRANCH', value: "${params.FRAMEWORK_BRANCH}"],
+                                    [$class: 'StringParameterValue', name: 'VERSION', value: "${params.VERSION}"],
+                                    [$class: 'StringParameterValue', name: 'SHARED_LIB_BRANCH', value: "${params.SHARED_LIB_BRANCH}"]
                                 ]
                             )
-                            echo "${params.TEST_PIPELINES_PATH}/${params.FUZZ_PIPELINE} #${fuzzResult.number} succeeded."
+                            echo "${params.BUILD_PIPELINES_PATH}/${params.BUILD_PIPELINE} #${buildResult.number} succeeded."
+                        }
+                    }
+                }
+
+                stage('Tests') {
+                    failFast false
+                    parallel {
+                        stage('Pipeline') {
+                            stages{
+                                stage("Package") {
+                                    steps {
+                                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                                            script{
+                                                packageResult = build(job: "${params.TEST_PIPELINES_PATH}/${params.PACKAGE_PIPELINE}",
+                                                    propagate: true,
+                                                    wait: true,
+                                                    parameters: [
+                                                        [$class: 'StringParameterValue', name: 'CLAMAV_JOB_NAME', value: "${JOB_NAME}"],
+                                                        [$class: 'StringParameterValue', name: 'CLAMAV_JOB_NUMBER', value: "${BUILD_NUMBER}"],
+                                                        [$class: 'StringParameterValue', name: 'TESTS_BRANCH', value: "${params.TESTS_BRANCH}"],
+                                                        [$class: 'StringParameterValue', name: 'BUILD_JOB_NAME', value: "${params.BUILD_PIPELINES_PATH}/${params.BUILD_PIPELINE}"],
+                                                        [$class: 'StringParameterValue', name: 'BUILD_JOB_NUMBER', value: "${buildResult.number}"],
+                                                        [$class: 'StringParameterValue', name: 'FRAMEWORK_BRANCH', value: "${params.FRAMEWORK_BRANCH}"],
+                                                        [$class: 'StringParameterValue', name: 'VERSION', value: "${params.VERSION}"],
+                                                        [$class: 'StringParameterValue', name: 'SHARED_LIB_BRANCH', value: "${params.SHARED_LIB_BRANCH}"]
+                                                    ]
+                                                )
+                                                echo "${params.TEST_PIPELINES_PATH}/${params.PACKAGE_PIPELINE} #${packageResult.number} succeeded."
+                                            }
+                                        }
+                                    }
+                                }
+
+                                stage("Regular From-Source") {
+                                    steps {
+                                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                                            script{
+                                                regularResult = build(job: "${params.TEST_PIPELINES_PATH}/${params.REGULAR_PIPELINE}",
+                                                    propagate: true,
+                                                    wait: true,
+                                                    parameters: [
+                                                        [$class: 'StringParameterValue', name: 'CLAMAV_JOB_NAME', value: "${JOB_NAME}"],
+                                                        [$class: 'StringParameterValue', name: 'CLAMAV_JOB_NUMBER', value: "${BUILD_NUMBER}"],
+                                                        [$class: 'StringParameterValue', name: 'TESTS_BRANCH', value: "${params.TESTS_BRANCH}"],
+                                                        [$class: 'StringParameterValue', name: 'FRAMEWORK_BRANCH', value: "${params.FRAMEWORK_BRANCH}"],
+                                                        [$class: 'StringParameterValue', name: 'VERSION', value: "${params.VERSION}"],
+                                                        [$class: 'StringParameterValue', name: 'SHARED_LIB_BRANCH', value: "${params.SHARED_LIB_BRANCH}"]
+                                                    ]
+                                                )
+                                                echo "${params.TEST_PIPELINES_PATH}/${params.REGULAR_PIPELINE} #${regularResult.number} succeeded."
+                                            }
+                                        }
+                                    }
+                                }
+
+                                stage("Custom From-Source") {
+                                    steps {
+                                        script{
+                                            customResult = build(job: "${params.TEST_PIPELINES_PATH}/${params.CUSTOM_PIPELINE}",
+                                                propagate: true,
+                                                wait: true,
+                                                parameters: [
+                                                    [$class: 'StringParameterValue', name: 'CLAMAV_JOB_NAME', value: "${JOB_NAME}"],
+                                                    [$class: 'StringParameterValue', name: 'CLAMAV_JOB_NUMBER', value: "${BUILD_NUMBER}"],
+                                                    [$class: 'StringParameterValue', name: 'TESTS_BRANCH', value: "${params.TESTS_CUSTOM_BRANCH}"],
+                                                    [$class: 'StringParameterValue', name: 'FRAMEWORK_BRANCH', value: "${params.FRAMEWORK_BRANCH}"],
+                                                    [$class: 'StringParameterValue', name: 'VERSION', value: "${params.VERSION}"],
+                                                    [$class: 'StringParameterValue', name: 'SHARED_LIB_BRANCH', value: "${params.SHARED_LIB_BRANCH}"]
+                                                ]
+                                            )
+                                            echo "${params.TEST_PIPELINES_PATH}/${params.CUSTOM_PIPELINE} #${customResult.number} succeeded."
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        stage("Fuzz Regression") {
+                            steps {
+                                script{
+                                    fuzzResult = build(job: "${params.TEST_PIPELINES_PATH}/${params.FUZZ_PIPELINE}",
+                                        propagate: true,
+                                        wait: true,
+                                        parameters: [
+                                            [$class: 'StringParameterValue', name: 'CLAMAV_JOB_NAME', value: "${JOB_NAME}"],
+                                            [$class: 'StringParameterValue', name: 'CLAMAV_JOB_NUMBER', value: "${BUILD_NUMBER}"],
+                                            [$class: 'StringParameterValue', name: 'TESTS_FUZZ_BRANCH', value: "${params.TESTS_FUZZ_BRANCH}"],
+                                            [$class: 'StringParameterValue', name: 'FUZZ_CORPUS_BRANCH', value: "${params.FUZZ_CORPUS_BRANCH}"],
+                                            [$class: 'StringParameterValue', name: 'VERSION', value: "${params.VERSION}"]
+                                        ]
+                                    )
+                                    echo "${params.TEST_PIPELINES_PATH}/${params.FUZZ_PIPELINE} #${fuzzResult.number} succeeded."
+                                }
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
This replaces #1780 with runtime throttling that also covers the first build of a newly discovered multibranch job.

A Jenkinsfile-defined `throttleJobProperty` is not present when Jenkins queues the first run of a new branch or pull-request job. Consequently, that first run can bypass the global category limit, as described in [jenkinsci/throttle-concurrent-builds-plugin#448](https://github.com/jenkinsci/throttle-concurrent-builds-plugin/issues/448).

Use the plugin's runtime `throttle()` step instead. The pipeline now has no top-level agent. A parent sequential stage named `ClamAV pipeline` enters `throttle(['clamav'])` before allocating the existing `default` agent, then runs the existing Generate Tarball, Build, and Tests stages within that agent and throttle scope.

This structure holds one category slot for the complete orchestration run, preserves the existing internal Tests parallelism, and prevents first runs from acquiring an executor while another ClamAV orchestration run is active.

Validation:

- `git diff --check`
- Confirmed the branch contains one commit changing only `Jenkinsfile`
- Matched the plugin's tested Declarative first-run pattern: top-level `agent none`, then stage-level `agent` and `options { throttle(...) }`
- Used Jenkins-supported sequential nested stages so the throttle remains active for the whole run
- Confirmed that no `agent` is declared on the `Tests` stage containing `parallel`
- Confirmed the obsolete `throttleJobProperty` is absent

The replacement PR intentionally uses a new head branch so Jenkins creates a new multibranch PR job and exercises first-run throttling.
