### PR TITLE
libclamav: Harden XLM formula record parsing

### DIFF
--- a/libclamav/xlm_extract.c
+++ b/libclamav/xlm_extract.c
@@ -3835,17 +3835,17 @@ static const char *get_function_name(unsigned index)
     }
 }
 
-static cl_error_t parse_formula(FILE *out_file, char data[], unsigned data_size)
+static cl_error_t parse_formula(FILE *out_file, const uint8_t data[], size_t data_size)
 {
     cl_error_t status = CL_EFORMAT;
-    unsigned data_pos = 0;
+    size_t data_pos   = 0;
     int len;
     size_t size_written;
 
     while (data_pos < data_size) {
         ptg_expr ptg = data[data_pos] & 0x7f;
 
-        if (((uint8_t)data[data_pos]) < sizeof(TOKENS) / sizeof(TOKENS[0])) {
+        if (ptg < sizeof(TOKENS) / sizeof(TOKENS[0]) && NULL != TOKENS[ptg]) {
             len = fprintf(out_file, " %s", TOKENS[ptg]);
             if (len < 0) {
                 cli_dbgmsg("[cli_extract_xlm_macros_and_images:parse_formula] Error formatting token name\n");
@@ -3869,21 +3869,28 @@ static cl_error_t parse_formula(FILE *out_file, char data[], unsigned data_size)
             case ptgRange:
                 data_pos += 1;
                 break;
-            case ptgStr:
-                if (data_pos + 2 >= data_size) {
+            case ptgStr: {
+                size_t char_count;
+                size_t str_len;
+
+                if (data_size - data_pos < 3) {
                     cli_dbgmsg("[cli_extract_xlm_macros_and_images:parse_formula] Malformed ptgStr record\n");
                     goto done;
                 }
 
-                if (data[data_pos + 2] == 1 && data_pos + 2 + 2 * data[data_pos + 1] <= data_size) {
+                char_count = data[data_pos + 1];
+
+                if (data[data_pos + 2] == 1) {
                     char *utf8       = NULL;
                     size_t utf8_size = 0;
-                    // TODO: Is this really times two here? Or is the string length in bytes?
-                    size_t str_len = data[data_pos + 1] * 2;
-                    if (str_len > data_size - data_pos) {
-                        str_len = data_size - data_pos;
+
+                    if (char_count > (data_size - data_pos - 3) / 2) {
+                        cli_dbgmsg("[cli_extract_xlm_macros_and_images:parse_formula] Truncated UTF16 ptgStr record\n");
+                        goto done;
                     }
-                    if (CL_SUCCESS == cli_codepage_to_utf8(&data[data_pos + 3], str_len, CODEPAGE_UTF16_LE, &utf8, &utf8_size)) {
+
+                    str_len = char_count * 2;
+                    if (CL_SUCCESS == cli_codepage_to_utf8((char *)&data[data_pos + 3], str_len, CODEPAGE_UTF16_LE, &utf8, &utf8_size)) {
                         if (0 < utf8_size) {
                             size_written = fwrite(utf8, 1, utf8_size, out_file);
                             free(utf8);
@@ -3901,15 +3908,17 @@ static cl_error_t parse_formula(FILE *out_file, char data[], unsigned data_size)
                         }
                     }
                     data_pos += 3 + str_len;
-                } else if (data[data_pos + 2] == 0 && data_pos + 2 + data[data_pos + 1] <= data_size) {
-                    unsigned str_len = data[data_pos + 1];
-                    if (str_len > data_size - data_pos) {
-                        str_len = data_size - data_pos;
+                } else if (data[data_pos + 2] == 0) {
+                    if (char_count > data_size - data_pos - 3) {
+                        cli_dbgmsg("[cli_extract_xlm_macros_and_images:parse_formula] Truncated ANSI ptgStr record\n");
+                        goto done;
                     }
+
+                    str_len = char_count;
                     if (0 < str_len) {
-                        size_written = fwrite(&data[data_pos], 1, str_len, out_file);
+                        size_written = fwrite(&data[data_pos + 3], 1, str_len, out_file);
                         if (size_written < str_len) {
-                            cli_dbgmsg("[cli_extract_xlm_macros_and_images] Error writing STRING record message with UTF16LE content\n");
+                            cli_dbgmsg("[cli_extract_xlm_macros_and_images] Error writing ptgStr record with ANSI content\n");
                             goto done;
                         }
                     }
@@ -3919,8 +3928,9 @@ static cl_error_t parse_formula(FILE *out_file, char data[], unsigned data_size)
                     goto done;
                 }
                 break;
+            }
             case ptgAttr:
-                if (data_pos + 1 >= data_size) {
+                if (data_size - data_pos < 4) {
                     cli_dbgmsg("[cli_extract_xlm_macros_and_images:parse_formula] Malformed ptgAttr record\n");
                     goto done;
                 }
@@ -3928,12 +3938,12 @@ static cl_error_t parse_formula(FILE *out_file, char data[], unsigned data_size)
                 if (data[data_pos + 1] & 0x40) {
                     uint16_t coffset;
 
-                    if (data_pos + 3 >= data_size) {
+                    coffset = data[data_pos + 2] | (data[data_pos + 3] << 8);
+
+                    if ((size_t)coffset + 1 > (data_size - data_pos - 4) / 2) {
                         cli_dbgmsg("[cli_extract_xlm_macros_and_images:parse_formula] Malformed ptgAttrChoose record\n");
                         goto done;
                     }
-
-                    coffset = data[data_pos + 2] | (data[data_pos + 3] << 8);
 
                     len = fprintf(out_file, " CHOOSE (%u)", (unsigned)(coffset + 1));
                     if (len < 0) {
@@ -3947,7 +3957,7 @@ static cl_error_t parse_formula(FILE *out_file, char data[], unsigned data_size)
                 }
                 break;
             case ptgBool:
-                if (data_pos + 1 >= data_size) {
+                if (data_size - data_pos < 2) {
                     cli_dbgmsg("[cli_extract_xlm_macros_and_images:parse_formula] Malformed ptgBool record\n");
                     goto done;
                 }
@@ -3961,7 +3971,7 @@ static cl_error_t parse_formula(FILE *out_file, char data[], unsigned data_size)
                 data_pos += 2;
                 break;
             case ptgInt:
-                if (data_pos + 2 >= data_size) {
+                if (data_size - data_pos < 3) {
                     cli_dbgmsg("[cli_extract_xlm_macros_and_images:parse_formula] Malformed ptgInt record\n");
                     goto done;
                 }
@@ -3977,7 +3987,7 @@ static cl_error_t parse_formula(FILE *out_file, char data[], unsigned data_size)
             case ptgFunc:
             case ptgFuncV:
             case ptgFuncA: {
-                if (data_pos + 2 >= data_size) {
+                if (data_size - data_pos < 3) {
                     cli_dbgmsg("[cli_extract_xlm_macros_and_images:parse_formula] Malformed ptgFunc record\n");
                     goto done;
                 }
@@ -3997,7 +4007,7 @@ static cl_error_t parse_formula(FILE *out_file, char data[], unsigned data_size)
             case ptgFuncVar:
             case ptgFuncVarV:
             case ptgFuncVarA: {
-                if (data_pos + 3 >= data_size) {
+                if (data_size - data_pos < 4) {
                     cli_dbgmsg("[cli_extract_xlm_macros_and_images:parse_formula] Malformed ptgFuncVar record\n");
                     goto done;
                 }
@@ -4018,12 +4028,16 @@ static cl_error_t parse_formula(FILE *out_file, char data[], unsigned data_size)
 
                 data_pos += 4;
                 if (func_id == 0x806d) {
+                    if (data_size - data_pos < 9) {
+                        cli_dbgmsg("[cli_extract_xlm_macros_and_images:parse_formula] Malformed extended ptgFuncVar record\n");
+                        goto done;
+                    }
                     data_pos += 9;
                 }
                 break;
             }
             case ptgName: {
-                if (data_pos + 4 >= data_size) {
+                if (data_size - data_pos < 5) {
                     cli_dbgmsg("[cli_extract_xlm_macros_and_images:parse_formula] Malformed ptgName record\n");
                     goto done;
                 }
@@ -4040,7 +4054,7 @@ static cl_error_t parse_formula(FILE *out_file, char data[], unsigned data_size)
                 break;
             }
             case ptgNum: {
-                if (data_pos + 8 >= data_size) {
+                if (data_size - data_pos < 9) {
                     cli_dbgmsg("[cli_extract_xlm_macros_and_images:parse_formula] Malformed ptgNum record\n");
                     goto done;
                 }
@@ -4059,7 +4073,7 @@ static cl_error_t parse_formula(FILE *out_file, char data[], unsigned data_size)
                 break;
             }
             case ptgMemArea: {
-                if (data_pos + 6 >= data_size) {
+                if (data_size - data_pos < 7) {
                     cli_dbgmsg("[cli_extract_xlm_macros_and_images:parse_formula] Malformed ptgMemArea record\n");
                     goto done;
                 }
@@ -4074,7 +4088,7 @@ static cl_error_t parse_formula(FILE *out_file, char data[], unsigned data_size)
                 break;
             }
             case ptgExp: {
-                if (data_pos + 4 >= data_size) {
+                if (data_size - data_pos < 5) {
                     cli_dbgmsg("[cli_extract_xlm_macros_and_images:parse_formula] Malformed ptgExp record\n");
                     goto done;
                 }
@@ -4092,7 +4106,7 @@ static cl_error_t parse_formula(FILE *out_file, char data[], unsigned data_size)
             }
             case ptgRef:
             case ptgRefV: {
-                if (data_pos + 4 >= data_size) {
+                if (data_size - data_pos < 5) {
                     cli_dbgmsg("[cli_extract_xlm_macros_and_images:parse_formula] Malformed ptgRef record\n");
                     goto done;
                 }
@@ -4115,7 +4129,7 @@ static cl_error_t parse_formula(FILE *out_file, char data[], unsigned data_size)
                 break;
             }
             case ptgArea: {
-                if (data_pos + 8 >= data_size) {
+                if (data_size - data_pos < 9) {
                     cli_dbgmsg("[cli_extract_xlm_macros_and_images:parse_formula] Malformed ptgArea record\n");
                     goto done;
                 }
@@ -4146,7 +4160,7 @@ static cl_error_t parse_formula(FILE *out_file, char data[], unsigned data_size)
             }
             case ptgRef3d:
             case ptgRef3dV: {
-                if (data_pos + 6 >= data_size) {
+                if (data_size - data_pos < 7) {
                     cli_dbgmsg("[cli_extract_xlm_macros_and_images:parse_formula] Malformed ptgRef3d record\n");
                     goto done;
                 }
@@ -4170,7 +4184,7 @@ static cl_error_t parse_formula(FILE *out_file, char data[], unsigned data_size)
                 break;
             }
             case ptgNameX: {
-                if (data_pos + 6 >= data_size) {
+                if (data_size - data_pos < 7) {
                     cli_dbgmsg("[cli_extract_xlm_macros_and_images:parse_formula] Malformed ptgNameX record\n");
                     goto done;
                 }
@@ -4190,7 +4204,7 @@ static cl_error_t parse_formula(FILE *out_file, char data[], unsigned data_size)
                 break;
             }
             default:
-                if (ptg < sizeof(TOKENS) / sizeof(char *)) {
+                if (ptg < sizeof(TOKENS) / sizeof(TOKENS[0]) && NULL != TOKENS[ptg]) {
                     cli_dbgmsg("[cli_extract_xlm_macros_and_images:parse_formula] Encountered unexpected ptg token: %s\n", TOKENS[ptg]);
                 } else {
                     cli_dbgmsg("[cli_extract_xlm_macros_and_images:parse_formula] Encountered unknown ptg token: 0x%02x\n", ptg);
@@ -4709,7 +4723,7 @@ cl_error_t cli_extract_xlm_macros_and_images(const char *dir, cli_ctx *ctx, char
                     uint16_t length;
                 } formula_header;
 
-                if (biff_header.length >= 21) {
+                if (biff_header.length >= 22) {
                     formula_header.row    = data[0] | (data[1] << 8);
                     formula_header.column = data[2] | (data[3] << 8);
                     formula_header.length = data[20] | (data[21] << 8);
@@ -4727,7 +4741,12 @@ cl_error_t cli_extract_xlm_macros_and_images(const char *dir, cli_ctx *ctx, char
                         break;
                     }
 
-                    ret = parse_formula(out_file, &data[22], biff_header.length - 21);
+                    if (formula_header.length > biff_header.length - 22) {
+                        cli_dbgmsg("[cli_extract_xlm_macros_and_images] FORMULA token data exceeds record length\n");
+                        break;
+                    }
+
+                    ret = parse_formula(out_file, (const uint8_t *)&data[22], formula_header.length);
                     if (CL_SUCCESS != ret) {
                         cli_dbgmsg("[cli_extract_xlm_macros_and_images] Error parsing formula in FORMULA record message\n");
 

--- a/libclamav/xlm_extract.c
+++ b/libclamav/xlm_extract.c
@@ -4983,6 +4983,12 @@ cl_error_t cli_extract_xlm_macros_and_images(const char *dir, cli_ctx *ctx, char
     }
 
     /* Scan the extracted content */
+    if (0 != fflush(out_file)) {
+        cli_dbgmsg("cli_extract_xlm_macros_and_images: Failed to flush extracted XLM macro content\n");
+        status = CL_EWRITE;
+        goto done;
+    }
+
     if (lseek(out_fd, 0, SEEK_SET) != 0) {
         cli_dbgmsg("cli_extract_xlm_macros_and_images: Failed to seek to beginning of temporary file\n");
         status = CL_ESEEK;

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -139,6 +139,9 @@ target_compile_definitions(check_clamav PUBLIC OBJDIR="${OBJDIR}" SRCDIR="${SRCD
 ADD_CUSTOM_COMMAND(TARGET check_clamav POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/input/clamav.hdb ${CMAKE_CURRENT_BINARY_DIR}/input/.)
 
+add_executable(check_xlm_scanmap check_xlm_scanmap.c)
+target_link_libraries(check_xlm_scanmap PRIVATE ClamAV::libclamav)
+
 #
 # Paths to pass to our tests via environment variables
 #
@@ -182,6 +185,7 @@ if(WIN32)
     endif()
     file(TO_NATIVE_PATH $<TARGET_FILE:${LIBMSPACK}>                             LIBCLAMMSPACK)
     file(TO_NATIVE_PATH $<TARGET_FILE:check_clamav>                             CHECK_CLAMAV)
+    file(TO_NATIVE_PATH $<TARGET_FILE:check_xlm_scanmap>                        CHECK_XLM_SCANMAP)
     if(ENABLE_APP)
         file(TO_NATIVE_PATH $<TARGET_FILE:check_clamd>                          CHECK_CLAMD)
         file(TO_NATIVE_PATH $<TARGET_FILE:check_fpu_endian>                     CHECK_FPU_ENDIAN)
@@ -244,6 +248,7 @@ else()
     endif()
     set(LIBCLAMMSPACK          $<TARGET_FILE:${LIBMSPACK}>)
     set(CHECK_CLAMAV           $<TARGET_FILE:check_clamav>)
+    set(CHECK_XLM_SCANMAP      $<TARGET_FILE:check_xlm_scanmap>)
     if(ENABLE_APP)
         set(CHECK_CLAMD        $<TARGET_FILE:check_clamd>)
         set(CHECK_FPU_ENDIAN   $<TARGET_FILE:check_fpu_endian>)
@@ -297,6 +302,7 @@ set(ENVIRONMENT
     LIBCLAMUNRARIFACE=${LIBCLAMUNRARIFACE}
     LIBCLAMUNRAR=${LIBCLAMUNRAR}
     CHECK_CLAMAV=${CHECK_CLAMAV}
+    CHECK_XLM_SCANMAP=${CHECK_XLM_SCANMAP}
     CHECK_CLAMD=${CHECK_CLAMD}
     CHECK_FPU_ENDIAN=${CHECK_FPU_ENDIAN}
     CLAMBC=${CLAMBC}

--- a/unit_tests/check_xlm_scanmap.c
+++ b/unit_tests/check_xlm_scanmap.c
@@ -61,17 +61,26 @@ done:
 int main(int argc, char **argv)
 {
     cl_error_t status;
-    struct cl_engine *engine = NULL;
+    struct cl_engine *engine     = NULL;
+    unsigned int signature_count = 0;
+    cl_error_t expected_status;
     int i;
 
-    if (argc < 2) {
-        fprintf(stderr, "Usage: %s FILE...\n", argv[0]);
+    if (argc < 4 || (0 != strcmp(argv[2], "clean") && 0 != strcmp(argv[2], "virus"))) {
+        fprintf(stderr, "Usage: %s DATABASE {clean|virus} FILE...\n", argv[0]);
         return 2;
     }
+    expected_status = 0 == strcmp(argv[2], "virus") ? CL_VIRUS : CL_SUCCESS;
 
     status = cl_init(CL_INIT_DEFAULT);
     if (CL_SUCCESS != status || NULL == (engine = cl_engine_new())) {
         fprintf(stderr, "Failed to initialize ClamAV: %s\n", cl_strerror(status));
+        return 2;
+    }
+    status = cl_load(argv[1], engine, &signature_count, CL_DB_STDOPT);
+    if (CL_SUCCESS != status) {
+        fprintf(stderr, "Failed to load signature database %s: %s\n", argv[1], cl_strerror(status));
+        cl_engine_free(engine);
         return 2;
     }
     status = cl_engine_compile(engine);
@@ -81,10 +90,11 @@ int main(int argc, char **argv)
         return 2;
     }
 
-    for (i = 1; i < argc; i++) {
+    for (i = 3; i < argc; i++) {
         status = scan_file_as_map(argv[i], engine);
-        if (CL_SUCCESS != status) {
-            fprintf(stderr, "Scan-map failed for %s: %s\n", argv[i], cl_strerror(status));
+        if (expected_status != status) {
+            fprintf(stderr, "Scan-map returned %s for %s; expected %s\n",
+                    cl_strerror(status), argv[i], cl_strerror(expected_status));
             cl_engine_free(engine);
             return 1;
         }

--- a/unit_tests/check_xlm_scanmap.c
+++ b/unit_tests/check_xlm_scanmap.c
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2026 Cisco Systems, Inc. and/or its affiliates. All rights reserved.
+ *
+ * Exercise the public scan-map API with XLM regression inputs.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "clamav.h"
+
+static cl_error_t scan_file_as_map(const char *path, const struct cl_engine *engine)
+{
+    cl_error_t status   = CL_EOPEN;
+    cl_fmap_t *map      = NULL;
+    FILE *file          = NULL;
+    unsigned char *data = NULL;
+    long file_size;
+    const char *virus_name = NULL;
+    unsigned long scanned  = 0;
+    struct cl_scan_options options;
+
+    file = fopen(path, "rb");
+    if (NULL == file || 0 != fseek(file, 0, SEEK_END) || 0 > (file_size = ftell(file)) ||
+        0 != fseek(file, 0, SEEK_SET)) {
+        goto done;
+    }
+
+    data = malloc((size_t)file_size);
+    if (NULL == data) {
+        status = CL_EMEM;
+        goto done;
+    }
+    if ((size_t)file_size != fread(data, 1, (size_t)file_size, file)) {
+        status = CL_EREAD;
+        goto done;
+    }
+
+    map = cl_fmap_open_memory(data, (size_t)file_size);
+    if (NULL == map) {
+        status = CL_EMEM;
+        goto done;
+    }
+
+    memset(&options, 0, sizeof(options));
+    options.parse = CL_SCAN_PARSE_OLE2;
+    status        = cl_scanmap_callback(map, path, &virus_name, &scanned, engine, &options, NULL);
+
+done:
+    if (NULL != map) {
+        cl_fmap_close(map);
+    }
+    free(data);
+    if (NULL != file) {
+        fclose(file);
+    }
+    return status;
+}
+
+int main(int argc, char **argv)
+{
+    cl_error_t status;
+    struct cl_engine *engine = NULL;
+    int i;
+
+    if (argc < 2) {
+        fprintf(stderr, "Usage: %s FILE...\n", argv[0]);
+        return 2;
+    }
+
+    status = cl_init(CL_INIT_DEFAULT);
+    if (CL_SUCCESS != status || NULL == (engine = cl_engine_new())) {
+        fprintf(stderr, "Failed to initialize ClamAV: %s\n", cl_strerror(status));
+        return 2;
+    }
+    status = cl_engine_compile(engine);
+    if (CL_SUCCESS != status) {
+        fprintf(stderr, "Failed to compile ClamAV engine: %s\n", cl_strerror(status));
+        cl_engine_free(engine);
+        return 2;
+    }
+
+    for (i = 1; i < argc; i++) {
+        status = scan_file_as_map(argv[i], engine);
+        if (CL_SUCCESS != status) {
+            fprintf(stderr, "Scan-map failed for %s: %s\n", argv[i], cl_strerror(status));
+            cl_engine_free(engine);
+            return 1;
+        }
+    }
+
+    cl_engine_free(engine);
+    return 0;
+}

--- a/unit_tests/clamscan/xlm_test.py
+++ b/unit_tests/clamscan/xlm_test.py
@@ -121,6 +121,7 @@ class TC(testcase.TestCase):
     def test_formula_record_boundaries(self):
         self.step_name('Test XLM FORMULA records at the BIFF8 size boundary')
 
+        valid_string = b'XLM_VALID_FORMULA'
         testfiles = [
             TC.path_tmp / 'formula-8228.xls',
             TC.path_tmp / 'formula-8227.xls',
@@ -132,7 +133,9 @@ class TC(testcase.TestCase):
             TC.path_tmp / 'formula-8228-truncated-extended-function.xls',
             TC.path_tmp / 'formula-22-overdeclared-token-length.xls',
             TC.path_tmp / 'formula-8228-non-macro.xls',
+            TC.path_tmp / 'formula-valid-ptgstr.xls',
         ]
+        valid_token = b'\x17' + bytes([len(valid_string)]) + b'\x00' + valid_string
         _write_xlm_formula_workbook(testfiles[0], 8228)
         _write_xlm_formula_workbook(testfiles[1], 8227)
         _write_xlm_formula_workbook(testfiles[2], 100)
@@ -143,6 +146,7 @@ class TC(testcase.TestCase):
         _write_xlm_formula_workbook(testfiles[7], 8228, token_tail=b'\x22\x00\x6d\x80')
         _write_xlm_formula_workbook(testfiles[8], 22, declared_token_length=1)
         _write_xlm_formula_workbook(testfiles[9], 8228, macro_sheet=False)
+        _write_xlm_formula_workbook(testfiles[-1], 22 + len(valid_token), token_tail=valid_token)
 
         command = '{valgrind} {valgrind_args} {clamscan} -d {path_db} --debug {testfiles}'.format(
             valgrind=TC.valgrind,
@@ -160,10 +164,42 @@ class TC(testcase.TestCase):
         )
         assert output.err.count('[cli_extract_xlm_macros_and_images] Extracting macros to') == len(testfiles) - 1
 
-        scanmap_command = '{} {}'.format(
+        scanmap_command = '{} {} clean {}'.format(
             TC.check_xlm_scanmap,
+            TC.path_build / 'unit_tests' / 'input' / 'clamav.hdb',
             ' '.join(str(path) for path in testfiles),
         )
         scanmap_output = self.execute_command(scanmap_command)
 
         assert scanmap_output.ec == 0
+
+        signature = TC.path_tmp / 'xlm-formula.ndb'
+        signature.write_text(
+            'XLM.Formula.ptgStr:0:*:{}\n'.format(
+                (b' ptgStr' + valid_string).hex(),
+            )
+        )
+
+        detection_command = '{valgrind} {valgrind_args} {clamscan} -d {signature} {testfile}'.format(
+            valgrind=TC.valgrind,
+            valgrind_args=TC.valgrind_args,
+            clamscan=TC.clamscan,
+            signature=signature,
+            testfile=testfiles[-1],
+        )
+        detection_output = self.execute_command(detection_command)
+
+        assert detection_output.ec == 1
+        self.verify_output(
+            detection_output.out,
+            expected=['{}: XLM.Formula.ptgStr.UNOFFICIAL FOUND'.format(testfiles[-1].name)],
+        )
+
+        scanmap_detection_command = '{} {} virus {}'.format(
+            TC.check_xlm_scanmap,
+            signature,
+            testfiles[-1],
+        )
+        scanmap_detection_output = self.execute_command(scanmap_detection_command)
+
+        assert scanmap_detection_output.ec == 0

--- a/unit_tests/clamscan/xlm_test.py
+++ b/unit_tests/clamscan/xlm_test.py
@@ -1,0 +1,169 @@
+# Copyright (C) 2026 Cisco Systems, Inc. and/or its affiliates. All rights reserved.
+
+"""
+Run clamscan tests for Excel 4.0 (XLM) macro extraction.
+"""
+
+import struct
+import sys
+
+sys.path.append('../unit_tests')
+import testcase
+
+
+SECTOR_SIZE = 512
+FREESECT = 0xFFFFFFFF
+ENDOFCHAIN = 0xFFFFFFFE
+FATSECT = 0xFFFFFFFD
+
+
+def _directory_entry(name, entry_type, child=FREESECT, start=ENDOFCHAIN, size=0):
+    encoded_name = (name.encode('utf-16-le') + b'\x00\x00')[:64].ljust(64, b'\x00')
+    name_length = min(len(name) * 2 + 2, 64)
+
+    entry = encoded_name
+    entry += struct.pack('<HBB', name_length, entry_type, 1)
+    entry += struct.pack('<III', FREESECT, FREESECT, child)
+    entry += b'\x00' * 16
+    entry += struct.pack('<I', 0)
+    entry += b'\x00' * 16
+    entry += struct.pack('<IQ', start, size)
+
+    assert len(entry) == 128
+    return entry
+
+
+def _write_xlm_formula_workbook(
+    path,
+    record_length,
+    macro_sheet=True,
+    token_tail=None,
+    declared_token_length=None,
+):
+    """Write a minimal OLE2 workbook with a BIFF8 FORMULA record."""
+    assert 0 <= record_length <= 8228
+
+    boundsheet_data = struct.pack('<IBB', 0, 0, 1 if macro_sheet else 0)
+    boundsheet = struct.pack('<HH', 0x0085, len(boundsheet_data)) + boundsheet_data
+
+    token_length = max(record_length - 22, 0)
+    if record_length >= 22:
+        if declared_token_length is None:
+            declared_token_length = token_length
+        formula_header = b'\x00' * 20 + struct.pack('<H', declared_token_length)
+    else:
+        formula_header = b'\x00' * record_length
+    if token_tail is None:
+        formula_tokens = b'\x03' * token_length
+    else:
+        assert len(token_tail) <= token_length
+        formula_tokens = b'\x03' * (token_length - len(token_tail)) + token_tail
+    formula = struct.pack('<HH', 0x0006, record_length) + formula_header + formula_tokens
+
+    workbook_stream = boundsheet + formula
+    if len(workbook_stream) < 4096:
+        padding_length = 4096 - len(workbook_stream) - 4
+        workbook_stream += struct.pack('<HH', 0x003C, padding_length) + b'\x00' * padding_length
+
+    stream_sector_count = (len(workbook_stream) + SECTOR_SIZE - 1) // SECTOR_SIZE
+    stream_start = 2
+    total_sector_count = stream_start + stream_sector_count
+    assert total_sector_count <= SECTOR_SIZE // 4
+
+    fat = [FREESECT] * (SECTOR_SIZE // 4)
+    fat[0] = FATSECT
+    fat[1] = ENDOFCHAIN
+    for index in range(stream_sector_count):
+        sector = stream_start + index
+        fat[sector] = sector + 1 if index + 1 < stream_sector_count else ENDOFCHAIN
+
+    root = _directory_entry('Root Entry', 5, child=1)
+    workbook = _directory_entry('Workbook', 2, start=stream_start, size=len(workbook_stream))
+    empty = _directory_entry('', 0)
+    directory = root + workbook + empty + empty
+
+    header = b'\xD0\xCF\x11\xE0\xA1\xB1\x1A\xE1'
+    header += b'\x00' * 16
+    header += struct.pack('<HHHH', 0x003E, 0x0003, 0xFFFE, 0x0009)
+    header += struct.pack('<H', 0x0006)
+    header += b'\x00' * 6
+    header += struct.pack('<IIIIIIIII', 0, 1, 1, 0, 0x1000, ENDOFCHAIN, 0, ENDOFCHAIN, 0)
+    header += b''.join(struct.pack('<I', sector) for sector in [0] + [FREESECT] * 108)
+    assert len(header) == SECTOR_SIZE
+
+    padded_stream = workbook_stream.ljust(stream_sector_count * SECTOR_SIZE, b'\x00')
+    sectors = [b''.join(struct.pack('<I', value) for value in fat), directory]
+    sectors.extend(
+        padded_stream[offset:offset + SECTOR_SIZE]
+        for offset in range(0, len(padded_stream), SECTOR_SIZE)
+    )
+    assert len(sectors) == total_sector_count
+
+    path.write_bytes(header + b''.join(sectors))
+
+
+class TC(testcase.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super(TC, cls).setUpClass()
+
+    @classmethod
+    def tearDownClass(cls):
+        super(TC, cls).tearDownClass()
+
+    def setUp(self):
+        super(TC, self).setUp()
+
+    def tearDown(self):
+        super(TC, self).tearDown()
+        self.verify_valgrind_log()
+
+    def test_formula_record_boundaries(self):
+        self.step_name('Test XLM FORMULA records at the BIFF8 size boundary')
+
+        testfiles = [
+            TC.path_tmp / 'formula-8228.xls',
+            TC.path_tmp / 'formula-8227.xls',
+            TC.path_tmp / 'formula-100.xls',
+            TC.path_tmp / 'formula-21.xls',
+            TC.path_tmp / 'formula-8228-truncated-utf16.xls',
+            TC.path_tmp / 'formula-8228-truncated-ansi.xls',
+            TC.path_tmp / 'formula-8228-truncated-choose.xls',
+            TC.path_tmp / 'formula-8228-truncated-extended-function.xls',
+            TC.path_tmp / 'formula-22-overdeclared-token-length.xls',
+            TC.path_tmp / 'formula-8228-non-macro.xls',
+        ]
+        _write_xlm_formula_workbook(testfiles[0], 8228)
+        _write_xlm_formula_workbook(testfiles[1], 8227)
+        _write_xlm_formula_workbook(testfiles[2], 100)
+        _write_xlm_formula_workbook(testfiles[3], 21)
+        _write_xlm_formula_workbook(testfiles[4], 8228, token_tail=b'\x17\x01\x01A')
+        _write_xlm_formula_workbook(testfiles[5], 8228, token_tail=b'\x17\x02\x00A')
+        _write_xlm_formula_workbook(testfiles[6], 8228, token_tail=b'\x19\x40\x00\x00')
+        _write_xlm_formula_workbook(testfiles[7], 8228, token_tail=b'\x22\x00\x6d\x80')
+        _write_xlm_formula_workbook(testfiles[8], 22, declared_token_length=1)
+        _write_xlm_formula_workbook(testfiles[9], 8228, macro_sheet=False)
+
+        command = '{valgrind} {valgrind_args} {clamscan} -d {path_db} --debug {testfiles}'.format(
+            valgrind=TC.valgrind,
+            valgrind_args=TC.valgrind_args,
+            clamscan=TC.clamscan,
+            path_db=TC.path_build / 'unit_tests' / 'input' / 'clamav.hdb',
+            testfiles=' '.join(str(path) for path in testfiles),
+        )
+        output = self.execute_command(command)
+
+        assert output.ec == 0
+        self.verify_output(
+            output.out,
+            expected=['{}: OK'.format(path.name) for path in testfiles],
+        )
+        assert output.err.count('[cli_extract_xlm_macros_and_images] Extracting macros to') == len(testfiles) - 1
+
+        scanmap_command = '{} {}'.format(
+            TC.check_xlm_scanmap,
+            ' '.join(str(path) for path in testfiles),
+        )
+        scanmap_output = self.execute_command(scanmap_command)
+
+        assert scanmap_output.ec == 0

--- a/unit_tests/testcase.py
+++ b/unit_tests/testcase.py
@@ -53,6 +53,7 @@ class TestCase(unittest.TestCase):
     check_clamav = None
     check_clamd = None
     check_fpu_endian = None
+    check_xlm_scanmap = None
     milter = None
     clambc = None
     clamd = None
@@ -106,6 +107,11 @@ class TestCase(unittest.TestCase):
         cls.check_clamav =     Path(os.getenv("CHECK_CLAMAV"))     if os.getenv("CHECK_CLAMAV") != None else None
         cls.check_clamd =      Path(os.getenv("CHECK_CLAMD"))      if os.getenv("CHECK_CLAMD") != None else None
         cls.check_fpu_endian = Path(os.getenv("CHECK_FPU_ENDIAN")) if os.getenv("CHECK_FPU_ENDIAN") != None else None
+        cls.check_xlm_scanmap = (
+            Path(os.getenv("CHECK_XLM_SCANMAP"))
+            if os.getenv("CHECK_XLM_SCANMAP") != None
+            else None
+        )
         cls.milter =           Path(os.getenv("CLAMAV_MILTER"))    if os.getenv("CLAMAV_MILTER") != None else None
         cls.clambc =           Path(os.getenv("CLAMBC"))           if os.getenv("CLAMBC") != None else None
         cls.clamd =            Path(os.getenv("CLAMD"))            if os.getenv("CLAMD") != None else None


### PR DESCRIPTION
Validate XLM formula record sizes before parsing and honor the declared token-stream length instead of parsing all trailing record data.

Correct the FORMULA record accounting and add bounds checks for token operands, strings, attributes, function arguments, and cell references. Malformed or truncated tokens now terminate parsing without consuming data beyond the declared formula buffer.

Add unit and clamscan regression tests covering boundary-length records, truncated tokens, malformed strings, and scan-map edge cases.

Reported by Alessandro Greco (GitHub user 'aleff-github').

CLAM-3011