### PR TITLE
CMake: Fix Windows shared dependency handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -349,7 +349,29 @@ if (WIN32)
 
     set(CPACK_GENERATOR                  "ZIP;WIX")
     set(CPACK_PACKAGE_VENDOR             "Cisco Systems, Inc.")
-    set(CPACK_PACKAGE_FILE_NAME ${CPACK_PACKAGE_FILE_NAME}.win.${CMAKE_VS_PLATFORM_NAME})
+    # Visual Studio generators provide CMAKE_VS_PLATFORM_NAME, but Ninja does
+    # not. Derive the package architecture from the compiler when necessary so
+    # documented Ninja builds do not produce package names ending in "win.".
+    set(CLAMAV_PACKAGE_ARCHITECTURE "${CMAKE_VS_PLATFORM_NAME}")
+    if(NOT CLAMAV_PACKAGE_ARCHITECTURE)
+        string(TOLOWER "${CMAKE_C_COMPILER_ARCHITECTURE_ID}" COMPILER_ARCHITECTURE_ID_LOWER)
+        if(COMPILER_ARCHITECTURE_ID_LOWER MATCHES "^(x64|amd64|x86_64)$")
+            set(CLAMAV_PACKAGE_ARCHITECTURE x64)
+        elseif(COMPILER_ARCHITECTURE_ID_LOWER MATCHES "^(x86|i[3-6]86)$")
+            set(CLAMAV_PACKAGE_ARCHITECTURE Win32)
+        elseif(COMPILER_ARCHITECTURE_ID_LOWER MATCHES "^(arm64|aarch64)$")
+            set(CLAMAV_PACKAGE_ARCHITECTURE ARM64)
+        elseif(COMPILER_ARCHITECTURE_ID_LOWER MATCHES "^arm")
+            set(CLAMAV_PACKAGE_ARCHITECTURE ARM)
+        elseif(CMAKE_C_COMPILER_ARCHITECTURE_ID)
+            set(CLAMAV_PACKAGE_ARCHITECTURE "${CMAKE_C_COMPILER_ARCHITECTURE_ID}")
+        elseif(CMAKE_SYSTEM_PROCESSOR)
+            set(CLAMAV_PACKAGE_ARCHITECTURE "${CMAKE_SYSTEM_PROCESSOR}")
+        else()
+            message(FATAL_ERROR "Unable to determine the Windows package architecture")
+        endif()
+    endif()
+    set(CPACK_PACKAGE_FILE_NAME ${CPACK_PACKAGE_FILE_NAME}.win.${CLAMAV_PACKAGE_ARCHITECTURE})
 
     NumberToHex(${PROJECT_VERSION_MAJOR} HEX_MAJOR)
     NumberToHex(${PROJECT_VERSION_MINOR} HEX_MINOR)
@@ -512,16 +534,16 @@ find_package(ZLIB REQUIRED)
 find_package(BZip2 REQUIRED)
 
 # Disable CMAKE_FIND_PACKAGE_PREFER_CONFIG, temporarily, because
-# we don't presently support the using libxml2's Config.cmake
+# we don't presently support using the libxml2 or PCRE2 Config.cmake files.
 set(PACKAGE_PREFER_CONFIG_BAK ${CMAKE_FIND_PACKAGE_PREFER_CONFIG})
 set(CMAKE_FIND_PACKAGE_PREFER_CONFIG FALSE)
 
 find_package(LibXml2 REQUIRED)
 
+find_package(PCRE2 REQUIRED)
+
 # Restore the requested CMAKE_FIND_PACKAGE_PREFER_CONFIG setting
 set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ${PACKAGE_PREFER_CONFIG_BAK})
-
-find_package(PCRE2 REQUIRED)
 
 # libclamav feature dependencies
 if(NOT WIN32)

--- a/clamdtop/CMakeLists.txt
+++ b/clamdtop/CMakeLists.txt
@@ -50,6 +50,7 @@ if(WIN32)
                 UNRESOLVED_DEPENDENCIES_VAR _u_deps
                 DIRECTORIES
                     $<TARGET_FILE_DIR:Curses::curses>
+                    $<TARGET_LINKER_FILE_DIR:Curses::curses>/../bin
                 POST_EXCLUDE_REGEXES
                     "[cC]:[\\/][wW][iI][nN][dD][oO][wW][sS]"
             )

--- a/clamsubmit/CMakeLists.txt
+++ b/clamsubmit/CMakeLists.txt
@@ -58,7 +58,9 @@ if(WIN32)
                 UNRESOLVED_DEPENDENCIES_VAR _u_deps
                 DIRECTORIES
                     $<TARGET_FILE_DIR:CURL::libcurl>
+                    $<TARGET_LINKER_FILE_DIR:CURL::libcurl>/../bin
                     $<TARGET_FILE_DIR:JSONC::jsonc>
+                    $<TARGET_LINKER_FILE_DIR:JSONC::jsonc>/../bin
                 POST_EXCLUDE_REGEXES
                     "[cC]:[\\/][wW][iI][nN][dD][oO][wW][sS]"
             )

--- a/cmake/FindLibcheck.cmake
+++ b/cmake/FindLibcheck.cmake
@@ -30,6 +30,9 @@
 #
 # ``LIBCHECK_ROOT_DIR``
 #  The root to search for libcheck.
+#
+# ``LIBCHECK_RUNTIME_LIBRARY``
+#  The Check DLL used with a shared import library on Windows.
 
 # First let's try to find libcheck in the vcpkg cache
 find_package(check CONFIG QUIET)
@@ -76,6 +79,28 @@ else()
         PATH_SUFFIXES
         lib
     )
+    set(_libcheck_is_shared FALSE)
+    if(WIN32 AND LIBCHECK_LIBRARY)
+        get_filename_component(_libcheck_library_name "${LIBCHECK_LIBRARY}" NAME_WE)
+        string(TOLOWER "${_libcheck_library_name}" _libcheck_library_name_lower)
+        if(_libcheck_library_name_lower MATCHES "(dynamic|shared)" OR LIBCHECK_RUNTIME_LIBRARY)
+            set(_libcheck_is_shared TRUE)
+            get_filename_component(_libcheck_library_dir "${LIBCHECK_LIBRARY}" DIRECTORY)
+            find_file(LIBCHECK_RUNTIME_LIBRARY
+                NAMES
+                checkDynamic.dll
+                check.dll
+                HINTS
+                "${_libcheck_library_dir}/../bin"
+                "${_libcheck_library_dir}"
+                PATHS
+                ${LIBCHECK_ROOT_DIR}
+                PATH_SUFFIXES
+                bin
+            )
+        endif()
+    endif()
+
     find_library(LIBCHECK_SUBUNIT_LIBRARY
         NAMES
         subunit
@@ -95,6 +120,9 @@ else()
     if(PC_LIBCHECK_FOUND AND "${PC_LIBCHECK_LIBRARIES}" MATCHES "subunit")
         list(APPEND _libcheck_extra_required LIBCHECK_SUBUNIT_LIBRARY)
     endif()
+    if(_libcheck_is_shared)
+        list(APPEND _libcheck_extra_required LIBCHECK_RUNTIME_LIBRARY)
+    endif()
 
     include(FindPackageHandleStandardArgs)
     find_package_handle_standard_args(Libcheck
@@ -102,18 +130,27 @@ else()
         LIBCHECK_INCLUDE_DIR
         LIBCHECK_LIBRARY
         THREADS_FOUND
+        ${_libcheck_extra_required}
     )
     if(LIBCHECK_FOUND)
         if(NOT TARGET libcheck::check)
-            add_library(libcheck::check UNKNOWN IMPORTED)
+            if(_libcheck_is_shared)
+                add_library(libcheck::check SHARED IMPORTED)
+                set_target_properties(libcheck::check PROPERTIES
+                    IMPORTED_IMPLIB "${LIBCHECK_LIBRARY}"
+                    IMPORTED_LOCATION "${LIBCHECK_RUNTIME_LIBRARY}"
+                    INTERFACE_COMPILE_DEFINITIONS "CK_DLL_EXP=_declspec(dllimport)")
+            else()
+                add_library(libcheck::check UNKNOWN IMPORTED)
+                set_target_properties(libcheck::check PROPERTIES
+                    IMPORTED_LOCATION "${LIBCHECK_LIBRARY}")
+            endif()
 
             set_target_properties(libcheck::check PROPERTIES
-                INTERFACE_INCLUDE_DIRECTORIES "${LIBCHECK_INCLUDE_DIR}")
-            set_target_properties(libcheck::check PROPERTIES
                 IMPORTED_LINK_INTERFACE_LANGUAGES "C"
-                IMPORTED_LOCATION ${LIBCHECK_LIBRARY})
+                INTERFACE_INCLUDE_DIRECTORIES "${LIBCHECK_INCLUDE_DIR}")
             set_property(TARGET libcheck::check PROPERTY
-                    IMPORTED_LINK_INTERFACE_LIBRARIES Threads::Threads)
+                IMPORTED_LINK_INTERFACE_LIBRARIES Threads::Threads)
 
             # if we found librt or libm, link them.
             if(LIBCHECK_LIBRT)
@@ -130,7 +167,7 @@ else()
             endif()
 
         endif()
-        mark_as_advanced(LIBCHECK_INCLUDE_DIR LIBCHECK_LIBRARY LIBCHECK_SUBUNIT_LIBRARY)
+        mark_as_advanced(LIBCHECK_INCLUDE_DIR LIBCHECK_LIBRARY LIBCHECK_RUNTIME_LIBRARY LIBCHECK_SUBUNIT_LIBRARY)
     endif()
     mark_as_advanced(LIBCHECK_ROOT_DIR LIBCHECK_LIBRT LIBCHECK_LIBM)
 endif()

--- a/libclamav/CMakeLists.txt
+++ b/libclamav/CMakeLists.txt
@@ -502,12 +502,21 @@ if(ENABLE_SHARED_LIB)
                     UNRESOLVED_DEPENDENCIES_VAR _u_deps
                     DIRECTORIES
                         $<TARGET_FILE_DIR:OpenSSL::SSL>
+                        $<TARGET_LINKER_FILE_DIR:OpenSSL::SSL>/../bin
                         $<TARGET_FILE_DIR:OpenSSL::Crypto>
+                        $<TARGET_LINKER_FILE_DIR:OpenSSL::Crypto>/../bin
                         $<TARGET_FILE_DIR:ZLIB::ZLIB>
+                        $<TARGET_LINKER_FILE_DIR:ZLIB::ZLIB>/../bin
                         $<TARGET_FILE_DIR:BZip2::BZip2>
+                        $<TARGET_LINKER_FILE_DIR:BZip2::BZip2>/../bin
                         $<TARGET_FILE_DIR:PCRE2::pcre2>
+                        $<TARGET_LINKER_FILE_DIR:PCRE2::pcre2>/../bin
                         $<TARGET_FILE_DIR:LibXml2::LibXml2>
+                        $<TARGET_LINKER_FILE_DIR:LibXml2::LibXml2>/../bin
                         $<TARGET_FILE_DIR:JSONC::jsonc>
+                        $<TARGET_LINKER_FILE_DIR:JSONC::jsonc>/../bin
+                        $<TARGET_FILE_DIR:PThreadW32::pthreadw32>
+                        $<TARGET_LINKER_FILE_DIR:PThreadW32::pthreadw32>/../bin
                     POST_EXCLUDE_REGEXES
                         "[cC]:[\\/][wW][iI][nN][dD][oO][wW][sS]"
                 )

--- a/libclamav_rust/build.rs
+++ b/libclamav_rust/build.rs
@@ -201,13 +201,13 @@ fn execute_cbindgen() -> Result<(), &'static str> {
 }
 
 fn detect_clamav_build() -> Result<(), &'static str> {
-    println!("cargo:rerun-if-env-changed=LIBCLAMAV");
-
     if search_and_link_lib("LIBCLAMAV")? {
         eprintln!("NOTE: LIBCLAMAV defined. Examining LIB* environment variables");
         // Need to link with libclamav dependencies
 
         // LLVM is optional, and don't have a path to each library like we do with the other libs.
+        println!("cargo:rerun-if-env-changed=LLVM_LIBS");
+        println!("cargo:rerun-if-env-changed=LLVM_DIRS");
         let llvm_libs = env::var("LLVM_LIBS").unwrap_or("".into());
         if !llvm_libs.is_empty() {
             match env::var("LLVM_DIRS") {
@@ -274,6 +274,7 @@ fn detect_clamav_build() -> Result<(), &'static str> {
 //
 fn search_and_link_lib(environment_variable: &str) -> Result<bool, &'static str> {
     eprintln!("  - checking for {:?} in environment", environment_variable);
+    println!("cargo:rerun-if-env-changed={environment_variable}");
     let filepath_str = match env::var(environment_variable) {
         Err(env::VarError::NotPresent) => return Ok(false),
         Err(env::VarError::NotUnicode(_)) => return Err("environment value not unicode"),

--- a/libfreshclam/CMakeLists.txt
+++ b/libfreshclam/CMakeLists.txt
@@ -86,8 +86,11 @@ if(ENABLE_SHARED_LIB)
                     UNRESOLVED_DEPENDENCIES_VAR _u_deps
                     DIRECTORIES
                         $<TARGET_FILE_DIR:CURL::libcurl>
+                        $<TARGET_LINKER_FILE_DIR:CURL::libcurl>/../bin
                         $<TARGET_FILE_DIR:OpenSSL::SSL>
+                        $<TARGET_LINKER_FILE_DIR:OpenSSL::SSL>/../bin
                         $<TARGET_FILE_DIR:OpenSSL::Crypto>
+                        $<TARGET_LINKER_FILE_DIR:OpenSSL::Crypto>/../bin
                     POST_EXCLUDE_REGEXES
                         "[cC]:[\\/][wW][iI][nN][dD][oO][wW][sS]"
                 )

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -157,30 +157,30 @@ if(WIN32)
 
     set(NEW_PATH "$<TARGET_FILE_DIR:check_clamav>;$ENV{PATH}")
 
-    file(TO_NATIVE_PATH $<TARGET_FILE:OpenSSL::SSL>                             LIBSSL)
-    file(TO_NATIVE_PATH $<TARGET_FILE:OpenSSL::Crypto>                          LIBCRYPTO)
-    file(TO_NATIVE_PATH $<TARGET_FILE:ZLIB::ZLIB>                               LIBZ)
-    file(TO_NATIVE_PATH $<TARGET_FILE:BZip2::BZip2>                             LIBBZ2)
-    file(TO_NATIVE_PATH $<TARGET_FILE:PCRE2::pcre2>                             LIBPCRE2)
-    file(TO_NATIVE_PATH $<TARGET_FILE:LibXml2::LibXml2>                         LIBXML2)
+    file(TO_NATIVE_PATH $<TARGET_LINKER_FILE:OpenSSL::SSL>                             LIBSSL)
+    file(TO_NATIVE_PATH $<TARGET_LINKER_FILE:OpenSSL::Crypto>                          LIBCRYPTO)
+    file(TO_NATIVE_PATH $<TARGET_LINKER_FILE:ZLIB::ZLIB>                               LIBZ)
+    file(TO_NATIVE_PATH $<TARGET_LINKER_FILE:BZip2::BZip2>                             LIBBZ2)
+    file(TO_NATIVE_PATH $<TARGET_LINKER_FILE:PCRE2::pcre2>                             LIBPCRE2)
+    file(TO_NATIVE_PATH $<TARGET_LINKER_FILE:LibXml2::LibXml2>                         LIBXML2)
     if(NOT ENABLE_LIBCLAMAV_ONLY)
         # libcurl not used by libclamav and so is not defined in libclamav-only mode.
-        file(TO_NATIVE_PATH $<TARGET_FILE:CURL::libcurl>                            LIBCURL)
+        file(TO_NATIVE_PATH $<TARGET_LINKER_FILE:CURL::libcurl>                            LIBCURL)
     endif()
-    file(TO_NATIVE_PATH $<TARGET_FILE:JSONC::jsonc>                             LIBJSONC)
-    file(TO_NATIVE_PATH $<TARGET_FILE:PThreadW32::pthreadw32>                   LIBPTHREADW32)
-    file(TO_NATIVE_PATH $<TARGET_FILE:ClamAV::win32_compat>                     LIBWIN32COMPAT)
+    file(TO_NATIVE_PATH $<TARGET_LINKER_FILE:JSONC::jsonc>                             LIBJSONC)
+    file(TO_NATIVE_PATH $<TARGET_LINKER_FILE:PThreadW32::pthreadw32>                   LIBPTHREADW32)
+    file(TO_NATIVE_PATH $<TARGET_LINKER_FILE:ClamAV::win32_compat>                     LIBWIN32COMPAT)
 
     if(ENABLE_STATIC_LIB)
-        file(TO_NATIVE_PATH $<TARGET_FILE:clamav_static>                        LIBCLAMAV)
+        file(TO_NATIVE_PATH $<TARGET_LINKER_FILE:clamav_static>                        LIBCLAMAV)
         if (ENABLE_UNRAR)
-            file(TO_NATIVE_PATH $<TARGET_FILE:clamunrar_iface_static>           LIBCLAMUNRARIFACE)
-            file(TO_NATIVE_PATH $<TARGET_FILE:clamunrar_static>                 LIBCLAMUNRAR)
+            file(TO_NATIVE_PATH $<TARGET_LINKER_FILE:clamunrar_iface_static>           LIBCLAMUNRARIFACE)
+            file(TO_NATIVE_PATH $<TARGET_LINKER_FILE:clamunrar_static>                 LIBCLAMUNRAR)
         endif()
     else()
-        file(TO_NATIVE_PATH $<TARGET_FILE:clamav>                               LIBCLAMAV)
+        file(TO_NATIVE_PATH $<TARGET_LINKER_FILE:clamav>                               LIBCLAMAV)
     endif()
-    file(TO_NATIVE_PATH $<TARGET_FILE:${LIBMSPACK}>                             LIBCLAMMSPACK)
+    file(TO_NATIVE_PATH $<TARGET_LINKER_FILE:${LIBMSPACK}>                             LIBCLAMMSPACK)
     file(TO_NATIVE_PATH $<TARGET_FILE:check_clamav>                             CHECK_CLAMAV)
     if(ENABLE_APP)
         file(TO_NATIVE_PATH $<TARGET_FILE:check_clamd>                          CHECK_CLAMD)
@@ -462,13 +462,27 @@ if(WIN32)
                     UNRESOLVED_DEPENDENCIES_VAR _u_deps
                     DIRECTORIES
                         $<TARGET_FILE_DIR:OpenSSL::SSL>
+                        $<TARGET_LINKER_FILE_DIR:OpenSSL::SSL>/../bin
                         $<TARGET_FILE_DIR:OpenSSL::Crypto>
+                        $<TARGET_LINKER_FILE_DIR:OpenSSL::Crypto>/../bin
                         $<TARGET_FILE_DIR:ZLIB::ZLIB>
+                        $<TARGET_LINKER_FILE_DIR:ZLIB::ZLIB>/../bin
                         $<TARGET_FILE_DIR:BZip2::BZip2>
+                        $<TARGET_LINKER_FILE_DIR:BZip2::BZip2>/../bin
                         $<TARGET_FILE_DIR:PCRE2::pcre2>
+                        $<TARGET_LINKER_FILE_DIR:PCRE2::pcre2>/../bin
                         $<TARGET_FILE_DIR:LibXml2::LibXml2>
+                        $<TARGET_LINKER_FILE_DIR:LibXml2::LibXml2>/../bin
                         $<TARGET_FILE_DIR:CURL::libcurl>
+                        $<TARGET_LINKER_FILE_DIR:CURL::libcurl>/../bin
                         $<TARGET_FILE_DIR:JSONC::jsonc>
+                        $<TARGET_LINKER_FILE_DIR:JSONC::jsonc>/../bin
+                        $<TARGET_FILE_DIR:PThreadW32::pthreadw32>
+                        $<TARGET_LINKER_FILE_DIR:PThreadW32::pthreadw32>/../bin
+                        $<TARGET_FILE_DIR:Curses::curses>
+                        $<TARGET_LINKER_FILE_DIR:Curses::curses>/../bin
+                        $<TARGET_FILE_DIR:libcheck::check>
+                        $<TARGET_LINKER_FILE_DIR:libcheck::check>/../bin
                     POST_EXCLUDE_REGEXES
                         "[cC]:[\\/][wW][iI][nN][dD][oO][wW][sS]"
                     CONFLICTING_DEPENDENCIES_PREFIX CTEST_CONFLICTING_DEPENDENCIES
@@ -528,12 +542,23 @@ if(WIN32)
                     UNRESOLVED_DEPENDENCIES_VAR _u_deps
                     DIRECTORIES
                         $<TARGET_FILE_DIR:OpenSSL::SSL>
+                        $<TARGET_LINKER_FILE_DIR:OpenSSL::SSL>/../bin
                         $<TARGET_FILE_DIR:OpenSSL::Crypto>
+                        $<TARGET_LINKER_FILE_DIR:OpenSSL::Crypto>/../bin
                         $<TARGET_FILE_DIR:ZLIB::ZLIB>
+                        $<TARGET_LINKER_FILE_DIR:ZLIB::ZLIB>/../bin
                         $<TARGET_FILE_DIR:BZip2::BZip2>
+                        $<TARGET_LINKER_FILE_DIR:BZip2::BZip2>/../bin
                         $<TARGET_FILE_DIR:PCRE2::pcre2>
+                        $<TARGET_LINKER_FILE_DIR:PCRE2::pcre2>/../bin
                         $<TARGET_FILE_DIR:LibXml2::LibXml2>
+                        $<TARGET_LINKER_FILE_DIR:LibXml2::LibXml2>/../bin
                         $<TARGET_FILE_DIR:JSONC::jsonc>
+                        $<TARGET_LINKER_FILE_DIR:JSONC::jsonc>/../bin
+                        $<TARGET_FILE_DIR:PThreadW32::pthreadw32>
+                        $<TARGET_LINKER_FILE_DIR:PThreadW32::pthreadw32>/../bin
+                        $<TARGET_FILE_DIR:libcheck::check>
+                        $<TARGET_LINKER_FILE_DIR:libcheck::check>/../bin
                     POST_EXCLUDE_REGEXES
                         "[cC]:[\\/][wW][iI][nN][dD][oO][wW][sS]"
                     CONFLICTING_DEPENDENCIES_PREFIX CTEST_CONFLICTING_DEPENDENCIES

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -163,30 +163,30 @@ if(WIN32)
 
     set(NEW_PATH "$<TARGET_FILE_DIR:check_clamav>;$ENV{PATH}")
 
-    file(TO_NATIVE_PATH $<TARGET_FILE:OpenSSL::SSL>                             LIBSSL)
-    file(TO_NATIVE_PATH $<TARGET_FILE:OpenSSL::Crypto>                          LIBCRYPTO)
-    file(TO_NATIVE_PATH $<TARGET_FILE:ZLIB::ZLIB>                               LIBZ)
-    file(TO_NATIVE_PATH $<TARGET_FILE:BZip2::BZip2>                             LIBBZ2)
-    file(TO_NATIVE_PATH $<TARGET_FILE:PCRE2::pcre2>                             LIBPCRE2)
-    file(TO_NATIVE_PATH $<TARGET_FILE:LibXml2::LibXml2>                         LIBXML2)
+    file(TO_NATIVE_PATH $<TARGET_LINKER_FILE:OpenSSL::SSL>                             LIBSSL)
+    file(TO_NATIVE_PATH $<TARGET_LINKER_FILE:OpenSSL::Crypto>                          LIBCRYPTO)
+    file(TO_NATIVE_PATH $<TARGET_LINKER_FILE:ZLIB::ZLIB>                               LIBZ)
+    file(TO_NATIVE_PATH $<TARGET_LINKER_FILE:BZip2::BZip2>                             LIBBZ2)
+    file(TO_NATIVE_PATH $<TARGET_LINKER_FILE:PCRE2::pcre2>                             LIBPCRE2)
+    file(TO_NATIVE_PATH $<TARGET_LINKER_FILE:LibXml2::LibXml2>                         LIBXML2)
     if(NOT ENABLE_LIBCLAMAV_ONLY)
         # libcurl not used by libclamav and so is not defined in libclamav-only mode.
-        file(TO_NATIVE_PATH $<TARGET_FILE:CURL::libcurl>                            LIBCURL)
+        file(TO_NATIVE_PATH $<TARGET_LINKER_FILE:CURL::libcurl>                            LIBCURL)
     endif()
-    file(TO_NATIVE_PATH $<TARGET_FILE:JSONC::jsonc>                             LIBJSONC)
-    file(TO_NATIVE_PATH $<TARGET_FILE:PThreadW32::pthreadw32>                   LIBPTHREADW32)
-    file(TO_NATIVE_PATH $<TARGET_FILE:ClamAV::win32_compat>                     LIBWIN32COMPAT)
+    file(TO_NATIVE_PATH $<TARGET_LINKER_FILE:JSONC::jsonc>                             LIBJSONC)
+    file(TO_NATIVE_PATH $<TARGET_LINKER_FILE:PThreadW32::pthreadw32>                   LIBPTHREADW32)
+    file(TO_NATIVE_PATH $<TARGET_LINKER_FILE:ClamAV::win32_compat>                     LIBWIN32COMPAT)
 
     if(ENABLE_STATIC_LIB)
-        file(TO_NATIVE_PATH $<TARGET_FILE:clamav_static>                        LIBCLAMAV)
+        file(TO_NATIVE_PATH $<TARGET_LINKER_FILE:clamav_static>                        LIBCLAMAV)
         if (ENABLE_UNRAR)
-            file(TO_NATIVE_PATH $<TARGET_FILE:clamunrar_iface_static>           LIBCLAMUNRARIFACE)
-            file(TO_NATIVE_PATH $<TARGET_FILE:clamunrar_static>                 LIBCLAMUNRAR)
+            file(TO_NATIVE_PATH $<TARGET_LINKER_FILE:clamunrar_iface_static>           LIBCLAMUNRARIFACE)
+            file(TO_NATIVE_PATH $<TARGET_LINKER_FILE:clamunrar_static>                 LIBCLAMUNRAR)
         endif()
     else()
-        file(TO_NATIVE_PATH $<TARGET_FILE:clamav>                               LIBCLAMAV)
+        file(TO_NATIVE_PATH $<TARGET_LINKER_FILE:clamav>                               LIBCLAMAV)
     endif()
-    file(TO_NATIVE_PATH $<TARGET_FILE:${LIBMSPACK}>                             LIBCLAMMSPACK)
+    file(TO_NATIVE_PATH $<TARGET_LINKER_FILE:${LIBMSPACK}>                             LIBCLAMMSPACK)
     file(TO_NATIVE_PATH $<TARGET_FILE:check_clamav>                             CHECK_CLAMAV)
     file(TO_NATIVE_PATH $<TARGET_FILE:check_xlm_scanmap>                        CHECK_XLM_SCANMAP)
     if(ENABLE_APP)
@@ -471,13 +471,27 @@ if(WIN32)
                     UNRESOLVED_DEPENDENCIES_VAR _u_deps
                     DIRECTORIES
                         $<TARGET_FILE_DIR:OpenSSL::SSL>
+                        $<TARGET_LINKER_FILE_DIR:OpenSSL::SSL>/../bin
                         $<TARGET_FILE_DIR:OpenSSL::Crypto>
+                        $<TARGET_LINKER_FILE_DIR:OpenSSL::Crypto>/../bin
                         $<TARGET_FILE_DIR:ZLIB::ZLIB>
+                        $<TARGET_LINKER_FILE_DIR:ZLIB::ZLIB>/../bin
                         $<TARGET_FILE_DIR:BZip2::BZip2>
+                        $<TARGET_LINKER_FILE_DIR:BZip2::BZip2>/../bin
                         $<TARGET_FILE_DIR:PCRE2::pcre2>
+                        $<TARGET_LINKER_FILE_DIR:PCRE2::pcre2>/../bin
                         $<TARGET_FILE_DIR:LibXml2::LibXml2>
+                        $<TARGET_LINKER_FILE_DIR:LibXml2::LibXml2>/../bin
                         $<TARGET_FILE_DIR:CURL::libcurl>
+                        $<TARGET_LINKER_FILE_DIR:CURL::libcurl>/../bin
                         $<TARGET_FILE_DIR:JSONC::jsonc>
+                        $<TARGET_LINKER_FILE_DIR:JSONC::jsonc>/../bin
+                        $<TARGET_FILE_DIR:PThreadW32::pthreadw32>
+                        $<TARGET_LINKER_FILE_DIR:PThreadW32::pthreadw32>/../bin
+                        $<TARGET_FILE_DIR:Curses::curses>
+                        $<TARGET_LINKER_FILE_DIR:Curses::curses>/../bin
+                        $<TARGET_FILE_DIR:libcheck::check>
+                        $<TARGET_LINKER_FILE_DIR:libcheck::check>/../bin
                     POST_EXCLUDE_REGEXES
                         "[cC]:[\\/][wW][iI][nN][dD][oO][wW][sS]"
                     CONFLICTING_DEPENDENCIES_PREFIX CTEST_CONFLICTING_DEPENDENCIES
@@ -537,12 +551,23 @@ if(WIN32)
                     UNRESOLVED_DEPENDENCIES_VAR _u_deps
                     DIRECTORIES
                         $<TARGET_FILE_DIR:OpenSSL::SSL>
+                        $<TARGET_LINKER_FILE_DIR:OpenSSL::SSL>/../bin
                         $<TARGET_FILE_DIR:OpenSSL::Crypto>
+                        $<TARGET_LINKER_FILE_DIR:OpenSSL::Crypto>/../bin
                         $<TARGET_FILE_DIR:ZLIB::ZLIB>
+                        $<TARGET_LINKER_FILE_DIR:ZLIB::ZLIB>/../bin
                         $<TARGET_FILE_DIR:BZip2::BZip2>
+                        $<TARGET_LINKER_FILE_DIR:BZip2::BZip2>/../bin
                         $<TARGET_FILE_DIR:PCRE2::pcre2>
+                        $<TARGET_LINKER_FILE_DIR:PCRE2::pcre2>/../bin
                         $<TARGET_FILE_DIR:LibXml2::LibXml2>
+                        $<TARGET_LINKER_FILE_DIR:LibXml2::LibXml2>/../bin
                         $<TARGET_FILE_DIR:JSONC::jsonc>
+                        $<TARGET_LINKER_FILE_DIR:JSONC::jsonc>/../bin
+                        $<TARGET_FILE_DIR:PThreadW32::pthreadw32>
+                        $<TARGET_LINKER_FILE_DIR:PThreadW32::pthreadw32>/../bin
+                        $<TARGET_FILE_DIR:libcheck::check>
+                        $<TARGET_LINKER_FILE_DIR:libcheck::check>/../bin
                     POST_EXCLUDE_REGEXES
                         "[cC]:[\\/][wW][iI][nN][dD][oO][wW][sS]"
                     CONFLICTING_DEPENDENCIES_PREFIX CTEST_CONFLICTING_DEPENDENCIES


### PR DESCRIPTION
## Summary

- use Windows import libraries, rather than runtime DLLs, as Rust linker inputs
- model dynamic libcheck imports with separate `.lib` and `.dll` locations
- search dependency target directories and sibling `bin` directories when collecting runtime DLLs
- keep PCRE2 in module discovery when config discovery is preferred globally
- derive Windows package architecture names for non-Visual Studio generators
- rerun the Rust build script when dependency-library variables change

## Problem

Windows dependency packages conventionally install import libraries under `lib` and runtime DLLs under `bin`. Some of ClamAV's CMake wiring used `TARGET_FILE` where a linker input was required and searched only one side of that layout while collecting runtime dependencies.

With Curl's exported shared target, `TARGET_FILE` supplied `bin/libcurl.dll` to `libclamav_rust/build.rs`. The build script converted that filename into a request for `libcurl.lib`, but the actual import library is `lib/libcurl_imp.lib`. The resulting Rust test link failed with `LNK1181`.

Dynamic libcheck installations had a related issue: the existing fallback target represented `checkDynamic.lib` as an unknown imported target and did not model or validate the corresponding runtime DLL.

## Solution

Use `TARGET_LINKER_FILE` for the dependency paths passed to Rust. Represent a manually discovered dynamic libcheck target as `SHARED IMPORTED`, with `IMPORTED_IMPLIB` pointing to the `.lib` file and `IMPORTED_LOCATION` pointing to the DLL. Runtime dependency collection now checks both target runtime directories and the sibling `bin` directories derived from linker-file locations.

The patch also keeps PCRE2 in module mode alongside LibXml2, supplies a package-architecture fallback for generators that do not define `CMAKE_VS_PLATFORM_NAME`, and declares the Rust build script's library environment dependencies.

## Validation

- `git diff --check` passes
- clean x64 build completed all 394 targets
- all six x64 CTest groups passed
- x64 ZIP and MSI packages generated successfully from a dependency prefix with runtime DLLs under `bin`
- dynamic Check discovery resolved `lib/checkDynamic.lib` and `bin/checkDynamic.dll` separately
- the complete 13-recipe Mussels ARM64 dependency chain built successfully
- current ClamAV source built and installed for ARM64; `clamscan.exe` reports machine type `AA64`
- ARM64 ZIP and MSI packages generated successfully

ARM64 tests were compiled but not executed because validation ran on an x64 Windows host.

CLAM-3051
