### PR TITLE
AIX doesn't provide fstatat64()

### DIFF
--- a/common/actions.c
+++ b/common/actions.c
@@ -443,7 +443,11 @@ static int action_fstatat_nointr(int dirfd, const char *path, STATBUF *st, int f
     int rc;
 
     do {
-#if defined(HAVE_STAT64) && STAT64_OK
+#if defined(_AIX)
+        /* AIX: fstatat64 does not exist. Use stat64at which takes struct stat64*
+         * and is the 64-bit equivalent of fstatat. */
+        rc = stat64at(dirfd, path, st, flags);
+#elif defined(HAVE_STAT64) && STAT64_OK
         rc = fstatat64(dirfd, path, st, flags);
 #else
         rc = fstatat(dirfd, path, st, flags);


### PR DESCRIPTION
AIX exposes `stat64at()` as the 64-bit directory-relative stat call
instead of `fstatat64()`. Add a `defined(_AIX)` guard ahead of the
existing `HAVE_STAT64` branch so that `stat64at()` is called on AIX.