### PR TITLE
ClamOnAcc: Fix truncation of long on-access paths

### DIFF
--- a/clamonacc/fanotif/fanotif.c
+++ b/clamonacc/fanotif/fanotif.c
@@ -158,9 +158,7 @@ int onas_fan_eloop(struct onas_context **ctx)
     char buf[4096];
     ssize_t bread;
     struct fanotify_event_metadata *fmd;
-    char proc_fd_fname[1024];
-    char fname[1024];
-    int len, check;
+    int check;
 
     FD_ZERO(&rfds);
     FD_SET((*ctx)->fan_fd, &rfds);
@@ -208,13 +206,15 @@ int onas_fan_eloop(struct onas_context **ctx)
             }
             scan = 1;
             if (fmd->fd >= 0) {
-                sprintf(proc_fd_fname, "/proc/self/fd/%d", fmd->fd);
-                errno = 0;
-                len   = readlink(proc_fd_fname, fname, sizeof(fname) - 1);
-                if (len == -1) {
+                char *fname       = NULL;
+                cl_error_t status = cli_get_filepath_from_filedesc(fmd->fd, &fname);
+
+                if (CL_SUCCESS != status) {
+                    int path_errno = errno;
+
                     close(fmd->fd);
-                    logg(LOGG_ERROR, "ClamFanotif: internal error (readlink() failed), %d, %s\n", fmd->fd, strerror(errno));
-                    if (errno == EBADF) {
+                    logg(LOGG_ERROR, "ClamFanotif: failed to resolve pathname for file descriptor %d: %s\n", fmd->fd, cl_strerror(status));
+                    if (path_errno == EBADF) {
                         logg(LOGG_INFO, "ClamWorker: fd already closed ... recovering ...\n");
                         fmd = FAN_EVENT_NEXT(fmd, bread);
                         continue;
@@ -222,7 +222,6 @@ int onas_fan_eloop(struct onas_context **ctx)
                         return 2;
                     }
                 }
-                fname[len] = '\0';
 
                 if ((check = onas_fan_checkowner(fmd->pid, (*ctx)->clamdopts))) {
                     scan = 0;
@@ -237,6 +236,7 @@ int onas_fan_eloop(struct onas_context **ctx)
                     event_data = calloc(1, sizeof(struct onas_scan_event));
                     if (NULL == event_data) {
                         close(fmd->fd);
+                        free(fname);
                         logg(LOGG_ERROR, "ClamFanotif: could not allocate memory for event data struct\n");
                         return 2;
                     }
@@ -250,19 +250,13 @@ int onas_fan_eloop(struct onas_context **ctx)
                     event_data->fmd = malloc(sizeof(struct fanotify_event_metadata));
                     if (NULL == event_data->fmd) {
                         close(fmd->fd);
+                        free(fname);
                         free(event_data);
                         logg(LOGG_ERROR, "ClamFanotif: could not allocate memory for event data struct fmd\n");
                         return 2;
                     }
                     memcpy(event_data->fmd, fmd, sizeof(struct fanotify_event_metadata));
-                    event_data->pathname = cli_safer_strdup(fname);
-                    if (NULL == event_data->pathname) {
-                        close(fmd->fd);
-                        free(event_data->fmd);
-                        free(event_data);
-                        logg(LOGG_ERROR, "ClamFanotif: could not allocate memory for event data struct pathname\n");
-                        return 2;
-                    }
+                    event_data->pathname = fname;
 
                     logg(LOGG_DEBUG, "ClamFanotif: attempting to feed consumer queue\n");
                     /* feed consumer queue */
@@ -291,6 +285,7 @@ int onas_fan_eloop(struct onas_context **ctx)
 
                         if (-1 == write((*ctx)->fan_fd, &res, sizeof(res))) {
                             close(fmd->fd);
+                            free(fname);
                             logg(LOGG_ERROR, "ClamFanotif: error occurred while excluding event\n");
                             return 2;
                         }
@@ -304,6 +299,7 @@ int onas_fan_eloop(struct onas_context **ctx)
                             return 2;
                         }
                     }
+                    free(fname);
                 }
             }
             fmd = FAN_EVENT_NEXT(fmd, bread);

--- a/libclamav/others_common.c
+++ b/libclamav/others_common.c
@@ -1462,35 +1462,52 @@ cl_error_t cli_get_filepath_from_filedesc(int desc, char **filepath)
     char *evaluated_filepath = NULL;
 
 #ifdef __linux__
-    char fname[PATH_MAX];
-
+    size_t fname_size = PATH_MAX;
     char link[32];
     ssize_t linksz;
-
-    memset(&fname, 0, PATH_MAX);
 
     if (NULL == filepath) {
         cli_errmsg("cli_get_filepath_from_filedesc: Invalid args.\n");
         goto done;
     }
 
+    *filepath = NULL;
+
     snprintf(link, sizeof(link), "/proc/self/fd/%u", desc);
     link[sizeof(link) - 1] = '\0';
 
-    if (-1 == (linksz = readlink(link, fname, PATH_MAX - 1))) {
-        cli_dbgmsg("cli_get_filepath_from_filedesc: Failed to resolve filename for descriptor %d (%s)\n", desc, link);
-        status = CL_EOPEN;
-        goto done;
-    }
+    while (fname_size <= CLI_MAX_ALLOCATION) {
+        evaluated_filepath = cli_max_malloc(fname_size);
+        if (NULL == evaluated_filepath) {
+            status = CL_EMEM;
+            goto done;
+        }
 
-    /* Success. Add null terminator */
-    fname[linksz] = '\0';
+        linksz = readlink(link, evaluated_filepath, fname_size - 1);
+        if (-1 == linksz) {
+            int readlink_errno = errno;
 
-    evaluated_filepath = CLI_STRNDUP(fname, CLI_STRNLEN(fname, PATH_MAX));
-    if (NULL == evaluated_filepath) {
-        cli_errmsg("cli_get_filepath_from_filedesc: Failed to allocate memory to store filename\n");
-        status = CL_EMEM;
-        goto done;
+            cli_dbgmsg("cli_get_filepath_from_filedesc: Failed to resolve filename for descriptor %d (%s)\n", desc, link);
+            free(evaluated_filepath);
+            evaluated_filepath = NULL;
+            status             = CL_EOPEN;
+            errno              = readlink_errno;
+            goto done;
+        }
+
+        if ((size_t)linksz < fname_size - 1) {
+            evaluated_filepath[linksz] = '\0';
+            break;
+        }
+
+        free(evaluated_filepath);
+        evaluated_filepath = NULL;
+
+        if (fname_size > CLI_MAX_ALLOCATION / 2) {
+            status = CL_EMAXSIZE;
+            goto done;
+        }
+        fname_size *= 2;
     }
 
 #elif C_DARWIN

--- a/unit_tests/check_clamav.c
+++ b/unit_tests/check_clamav.c
@@ -103,6 +103,55 @@ START_TEST(test_cl_debug)
 }
 END_TEST
 
+#ifdef __linux__
+START_TEST(test_cli_get_filepath_from_filedesc_long_path)
+{
+    char component[121];
+    char *expected_path = cli_safer_strdup(tmpdir);
+    char *resolved_path = NULL;
+    int fd              = -1;
+    unsigned int i;
+
+    ck_assert_ptr_nonnull(expected_path);
+    memset(component, 'a', sizeof(component) - 1);
+    component[sizeof(component) - 1] = '\0';
+
+    for (i = 0; i < 10; i++) {
+        size_t path_len = strlen(expected_path);
+        size_t new_len  = path_len + 1 + strlen(component) + 1;
+        char *new_path  = realloc(expected_path, new_len);
+
+        ck_assert_ptr_nonnull(new_path);
+        expected_path = new_path;
+        snprintf(expected_path + path_len, new_len - path_len, "/%s", component);
+        ck_assert_msg(0 == mkdir(expected_path, 0700), "mkdir failed for long path component: %s", strerror(errno));
+    }
+
+    {
+        size_t path_len = strlen(expected_path);
+        size_t new_len  = path_len + sizeof("/test-file");
+        char *new_path  = realloc(expected_path, new_len);
+
+        ck_assert_ptr_nonnull(new_path);
+        expected_path = new_path;
+        snprintf(expected_path + path_len, new_len - path_len, "/test-file");
+    }
+
+    ck_assert_msg(strlen(expected_path) > 1024, "test path is not long enough");
+    fd = open(expected_path, O_CREAT | O_RDONLY, 0600);
+    ck_assert_msg(fd >= 0, "open failed for long path: %s", strerror(errno));
+
+    ck_assert_int_eq(CL_SUCCESS, cli_get_filepath_from_filedesc(fd, &resolved_path));
+    ck_assert_ptr_nonnull(resolved_path);
+    ck_assert_str_eq(expected_path, resolved_path);
+
+    close(fd);
+    free(resolved_path);
+    free(expected_path);
+}
+END_TEST
+#endif
+
 #ifndef _WIN32
 /* extern const char *cl_retdbdir(void); */
 START_TEST(test_cl_retdbdir)
@@ -1465,6 +1514,9 @@ static Suite *test_cl_suite(void)
     tcase_add_test(tc_cl, test_cl_free);
     tcase_add_test(tc_cl, test_cl_build);
     tcase_add_test(tc_cl, test_cl_debug);
+#ifdef __linux__
+    tcase_add_test(tc_cl, test_cli_get_filepath_from_filedesc_long_path);
+#endif
 #ifndef _WIN32
     tcase_add_test(tc_cl, test_cl_retdbdir);
 #endif


### PR DESCRIPTION
Replace the fixed-size fanotify pathname buffer with dynamic file descriptor path resolution. Grow the Linux readlink buffer as needed instead of silently truncating paths at PATH_MAX.

Add a regression test covering file paths longer than 1024 bytes.

CLAM-2978