### PR TITLE
docs: add HTML documentation set (HLD, libclamav API, clamd protocol)

### DIFF
--- a/docs/html/api.html
+++ b/docs/html/api.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>libclamav C API</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<aside class="rail">
+  <div class="brand">ClamAV<small>libclamav C API</small></div>
+  <nav>
+    <div class="group">
+      <h4>Pages</h4>
+      <a href="index.html">Architecture (HLD)</a>
+      <a class="current" href="api.html">libclamav C API</a>
+      <a href="clamd-protocol.html">clamd Protocol</a>
+    </div>
+    <div class="group">
+      <h4>On this page</h4>
+      <a href="#lifecycle">Engine lifecycle</a>
+      <a href="#scanning">Scanning</a>
+      <a href="#fmap">In-memory maps</a>
+      <a href="#callbacks">Callbacks</a>
+      <a href="#database">Databases</a>
+      <a href="#errors">Return codes</a>
+    </div>
+  </nav>
+</aside>
+<main>
+  <p class="eyebrow">API Reference · <code>libclamav/clamav.h</code></p>
+  <h1>libclamav C API</h1>
+  <p class="lede">The public interface for embedding the ClamAV scan engine. Operations below are grouped swagger-style: a category chip, the signature, then parameters and responses. All functions return <code>cl_error_t</code> unless noted; <code>CL_SUCCESS</code> means the call worked.</p>
+
+  <div class="note">Canonical flow: <code>cl_init()</code> → <code>cl_engine_new()</code> → <code>cl_load()</code> → <code>cl_engine_compile()</code> → scan → <code>cl_engine_free()</code>.</div>
+
+  <h2 id="lifecycle">Engine lifecycle</h2>
+
+  <details class="op"><summary><span class="chip ctrl">INIT</span><span class="sig">cl_error_t cl_init(unsigned int initoptions)</span><span class="summary-note">once per process</span></summary>
+    <div class="body">
+      <p>Initializes global library state (crypto, locale, rand). Must be called exactly once before any other API. Pass <code>CL_INIT_DEFAULT</code>.</p>
+      <p><span class="resp-ok">CL_SUCCESS</span> — library ready · <span class="resp-err">CL_E*</span> — initialization failed; do not proceed.</p>
+    </div>
+  </details>
+
+  <details class="op"><summary><span class="chip ctrl">CREATE</span><span class="sig">struct cl_engine *cl_engine_new(void)</span><span class="summary-note">new engine instance</span></summary>
+    <div class="body">
+      <p>Allocates a scan engine with default settings and a reference count of 1.</p>
+      <p><span class="resp-ok">engine*</span> — configure and load databases into it · <span class="resp-err">NULL</span> — allocation failure.</p>
+    </div>
+  </details>
+
+  <details class="op"><summary><span class="chip ctrl">CONFIG</span><span class="sig">cl_engine_set_num / get_num · set_str / get_str</span><span class="summary-note">tune limits &amp; options</span></summary>
+    <div class="body">
+      <p>Typed getters/setters keyed by <code>enum cl_engine_field</code>. Numeric fields include <code>CL_ENGINE_MAX_FILESIZE</code>, <code>CL_ENGINE_MAX_SCANSIZE</code>, <code>CL_ENGINE_MAX_RECURSION</code>, <code>CL_ENGINE_PCRE_MATCH_LIMIT</code>; string fields include <code>CL_ENGINE_TMPDIR</code> and <code>CL_ENGINE_PUA_CATEGORIES</code>.</p>
+      <div class="tablewrap"><table>
+        <tr><th>Param</th><th>Type</th><th>Description</th></tr>
+        <tr><td><code>engine</code></td><td><code>struct cl_engine *</code></td><td>Target engine (before <code>cl_engine_compile</code>)</td></tr>
+        <tr><td><code>field</code></td><td><code>enum cl_engine_field</code></td><td>Which setting</td></tr>
+        <tr><td><code>num / str</code></td><td><code>long long / const char *</code></td><td>New value (setters)</td></tr>
+      </table></div>
+      <p><span class="resp-ok">CL_SUCCESS</span> · <span class="resp-err">CL_EARG</span> — wrong field type or null engine.</p>
+    </div>
+  </details>
+
+  <details class="op"><summary><span class="chip ctrl">COMPILE</span><span class="sig">cl_error_t cl_engine_compile(struct cl_engine *engine)</span><span class="summary-note">finalize before scanning</span></summary>
+    <div class="body">
+      <p>Builds the matcher automata from all loaded signatures. Required after <code>cl_load()</code> and before any scan; the engine's settings are frozen afterward.</p>
+      <p><span class="resp-ok">CL_SUCCESS</span> — engine scannable · <span class="resp-err">CL_EMEM / CL_EMALFDB</span> — compilation failed.</p>
+    </div>
+  </details>
+
+  <details class="op"><summary><span class="chip ctrl">REFCOUNT</span><span class="sig">cl_engine_addref · cl_engine_free</span><span class="summary-note">shared ownership</span></summary>
+    <div class="body">
+      <p><code>cl_engine_addref()</code> increments the reference count for multithreaded sharing; <code>cl_engine_free()</code> decrements and destroys the engine when it reaches zero. <code>cl_engine_settings_copy / _apply / _free</code> snapshot settings across engine reloads.</p>
+    </div>
+  </details>
+
+  <h2 id="scanning">Scanning</h2>
+  <p>All scan entry points take a <code>struct cl_scan_options</code> with four bitfields — <code>general</code>, <code>parse</code>, <code>heuristic</code>, <code>mail</code>, <code>dev</code> — e.g. <code>CL_SCAN_GENERAL_ALLMATCHES</code>, <code>CL_SCAN_PARSE_ARCHIVE</code>, <code>CL_SCAN_HEURISTIC_ENCRYPTED_ARCHIVE</code>.</p>
+
+  <details class="op" open><summary><span class="chip scan">SCAN</span><span class="sig">cl_scanfile(path, &amp;virname, &amp;scanned, engine, options)</span><span class="summary-note">scan by path</span></summary>
+    <div class="body">
+      <div class="tablewrap"><table>
+        <tr><th>Param</th><th>Type</th><th>Description</th></tr>
+        <tr><td><code>filename</code></td><td><code>const char *</code></td><td>Path of the file to scan</td></tr>
+        <tr><td><code>virname</code></td><td><code>const char **</code></td><td>Out: detection name when a signature alerts</td></tr>
+        <tr><td><code>scanned</code></td><td><code>unsigned long *</code></td><td>Out (optional): data scanned, in CL_COUNT_PRECISION units</td></tr>
+        <tr><td><code>engine</code></td><td><code>const struct cl_engine *</code></td><td>Compiled engine</td></tr>
+        <tr><td><code>scanoptions</code></td><td><code>struct cl_scan_options *</code></td><td>Scan option bitfields</td></tr>
+      </table></div>
+      <p><span class="resp-ok">CL_CLEAN</span> — no detection · <span class="resp-err">CL_VIRUS</span> — detection, name in <code>virname</code> · <span class="resp-err">CL_E*</span> — scan error.</p>
+    </div>
+  </details>
+
+  <details class="op"><summary><span class="chip scan">SCAN</span><span class="sig">cl_scandesc(desc, filename, &amp;virname, &amp;scanned, engine, options)</span><span class="summary-note">scan an open fd</span></summary>
+    <div class="body">
+      <p>Same contract as <code>cl_scanfile()</code> but reads from an already-open file descriptor; <code>filename</code> is metadata only (may be NULL). This is what clamd uses for <code>FILDES</code>.</p>
+    </div>
+  </details>
+
+  <details class="op"><summary><span class="chip scan">SCAN</span><span class="sig">cl_scanmap_callback(map, filename, &amp;virname, &amp;scanned, engine, options, context)</span><span class="summary-note">scan memory</span></summary>
+    <div class="body">
+      <p>Scans a <code>cl_fmap_t</code> built from a buffer or handle — no file on disk required. The <code>context</code> pointer is passed through to every callback fired during the scan.</p>
+    </div>
+  </details>
+
+  <details class="op"><summary><span class="chip scan">SCAN-EX</span><span class="sig">cl_scanfile_ex · cl_scandesc_ex · cl_scanmap_ex</span><span class="summary-note">extended verdict API</span></summary>
+    <div class="body">
+      <p>Extended variants that report results through a <code>cl_verdict_t</code> and expose per-layer detail via the <code>cl_scan_layer</code> accessors (<code>cl_scan_layer_get_fmap / _get_type / _get_recursion_level / _get_last_alert / _get_attributes</code>…), pairing with the <code>cl_engine_set_scan_callback()</code> mid-scan hook.</p>
+    </div>
+  </details>
+
+  <h2 id="fmap">In-memory maps (cl_fmap)</h2>
+  <details class="op"><summary><span class="chip strm">MAP</span><span class="sig">cl_fmap_open_memory(start, len) · cl_fmap_open_handle(...)</span><span class="summary-note">wrap data for scanning</span></summary>
+    <div class="body">
+      <p><code>cl_fmap_open_memory()</code> wraps an existing buffer; <code>cl_fmap_open_handle()</code> wraps an arbitrary handle with a user-supplied <code>pread</code>-style callback so libclamav can page data on demand. Companion accessors: <code>cl_fmap_set_name/_set_path</code>, <code>cl_fmap_get_size/_get_fd/_get_data</code>, hash helpers (<code>cl_fmap_set_hash / _get_hash / _have_hash</code>), and <code>cl_fmap_close()</code> to release the map.</p>
+    </div>
+  </details>
+
+  <h2 id="callbacks">Callbacks</h2>
+  <p>Registered per-engine; each receives the scan's <code>context</code> pointer. A callback's return value can veto or alter the verdict for its layer.</p>
+  <div class="tablewrap"><table>
+    <tr><th>Setter</th><th>Fires</th><th>Typical use</th></tr>
+    <tr><td><code>cl_engine_set_clcb_pre_cache</code></td><td>Before the clean-cache lookup, for every layer</td><td>Force-scan or skip files</td></tr>
+    <tr><td><code>cl_engine_set_clcb_file_inspection</code></td><td>After type identification (clamd-oriented)</td><td>Policy on embedded content</td></tr>
+    <tr><td><code>cl_engine_set_clcb_pre_scan</code> / <code>_post_scan</code></td><td>Around each layer's matching</td><td>Logging, verdict override</td></tr>
+    <tr><td><code>cl_engine_set_clcb_virus_found</code></td><td>On each detection</td><td>Alert reporting (esp. all-match mode)</td></tr>
+    <tr><td><code>cl_engine_set_scan_callback</code></td><td>At selected pipeline locations (ex-API)</td><td>Layer-by-layer inspection</td></tr>
+    <tr><td><code>cl_engine_set_clcb_sigload</code> / <code>_sigload_progress</code></td><td>During <code>cl_load()</code></td><td>Skip signatures / progress bars</td></tr>
+    <tr><td><code>cl_engine_set_clcb_hash</code> · <code>_meta</code> · <code>_file_props</code> · <code>_vba</code></td><td>On hash computation, container metadata, file properties, extracted VBA</td><td>Telemetry &amp; DLP</td></tr>
+    <tr><td><code>cl_set_clcb_msg</code></td><td>Library log messages (global)</td><td>Route warnings into your logger</td></tr>
+  </table></div>
+
+  <h2 id="database">Databases &amp; updates</h2>
+  <details class="op"><summary><span class="chip stat">LOAD</span><span class="sig">cl_load(path, engine, &amp;signo, dboptions)</span><span class="summary-note">load signatures</span></summary>
+    <div class="body">
+      <p>Loads a database file or a whole directory (see <code>cl_retdbdir()</code> for the default). <code>signo</code> accumulates the signature count. <code>dboptions</code>: <code>CL_DB_STDOPT</code>, <code>CL_DB_BYTECODE</code>, <code>CL_DB_OFFICIAL_ONLY</code>, …</p>
+      <p><span class="resp-ok">CL_SUCCESS</span> · <span class="resp-err">CL_EMALFDB / CL_EOPEN</span> — malformed or unreadable database.</p>
+    </div>
+  </details>
+  <details class="op"><summary><span class="chip stat">CVD</span><span class="sig">cl_cvdhead · cl_cvdparse · cl_cvdverify(_ex) · cl_cvdunpack(_ex) · cl_cvdgetage</span><span class="summary-note">container inspection</span></summary>
+    <div class="body">
+      <p>Read a CVD's 512-byte header (version, signature count, build time), verify its digital signature (the <code>_ex</code> forms use the newer certs-directory external-signature scheme), unpack contents, or check database age.</p>
+    </div>
+  </details>
+  <details class="op"><summary><span class="chip stat">WATCH</span><span class="sig">cl_statinidir · cl_statchkdir · cl_statfree</span><span class="summary-note">detect db changes</span></summary>
+    <div class="body">
+      <p>Snapshot a database directory and later test whether it changed — the mechanism behind clamd's self-check/reload cycle.</p>
+    </div>
+  </details>
+
+  <h2 id="errors">Return codes (<code>cl_error_t</code>)</h2>
+  <div class="tablewrap"><table>
+    <tr><th>Code</th><th>Meaning</th></tr>
+    <tr><td><span class="resp-ok">CL_SUCCESS / CL_CLEAN</span></td><td>Operation succeeded / no detection</td></tr>
+    <tr><td><span class="resp-err">CL_VIRUS</span></td><td>Signature alerted; name via <code>virname</code> or callback</td></tr>
+    <tr><td><span class="resp-err">CL_EMEM · CL_EOPEN · CL_EREAD · CL_EWRITE</span></td><td>Resource and I/O failures</td></tr>
+    <tr><td><span class="resp-err">CL_EMALFDB · CL_EUNPACK · CL_EPARSE</span></td><td>Bad database / unpacking / parsing errors</td></tr>
+    <tr><td><span class="resp-err">CL_EMAXREC · CL_EMAXSIZE · CL_EMAXFILES</span></td><td>Engine limit reached (usually treated as clean)</td></tr>
+    <tr><td><span class="resp-err">CL_BREAK</span></td><td>Scan aborted by a callback</td></tr>
+  </table></div>
+  <p>Use <code>cl_strerror(code)</code> for a printable message and <code>cl_retver()</code> for the library version string.</p>
+
+  <footer>libclamav API — source of truth: <code>libclamav/clamav.h</code>. See also the <a href="clamd-protocol.html">clamd protocol</a>.</footer>
+</main>
+</body>
+</html>

--- a/docs/html/clamd-protocol.html
+++ b/docs/html/clamd-protocol.html
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>clamd Wire Protocol</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<aside class="rail">
+  <div class="brand">ClamAV<small>clamd Wire Protocol</small></div>
+  <nav>
+    <div class="group">
+      <h4>Pages</h4>
+      <a href="index.html">Architecture (HLD)</a>
+      <a href="api.html">libclamav C API</a>
+      <a class="current" href="clamd-protocol.html">clamd Protocol</a>
+    </div>
+    <div class="group">
+      <h4>On this page</h4>
+      <a href="#conventions">Conventions</a>
+      <a href="#scan-cmds">Scan commands</a>
+      <a href="#stream-cmds">Streaming</a>
+      <a href="#control-cmds">Control</a>
+      <a href="#stats-cmds">Introspection</a>
+      <a href="#sessions">Sessions</a>
+    </div>
+  </nav>
+</aside>
+<main>
+  <p class="eyebrow">Protocol Reference · <code>clamd/session.c</code></p>
+  <h1>clamd Wire Protocol</h1>
+  <p class="lede">clamd speaks a plain-text command protocol over a TCP or Unix-domain socket. Each command below is documented like an API endpoint: category chip, command line, request semantics, and response format.</p>
+
+  <h2 id="conventions">Conventions</h2>
+  <ul>
+    <li>Terminate commands with a newline (<code>\n</code>) or NUL (<code>\0</code>). Prefix with <code>z</code> for NUL-delimited or <code>n</code> for newline-delimited responses — e.g. <code>zSCAN file\0</code>. Prefixed form is strongly recommended so filenames with newlines can't break parsing.</li>
+    <li>Path-taking commands require the path to be readable <em>by the clamd process</em> — clients on remote hosts should use <code>INSTREAM</code> instead.</li>
+    <li>Scan replies follow <code>&lt;path&gt;: &lt;result&gt;</code>, where result is <span class="resp-ok">OK</span>, <span class="resp-err">&lt;Signature.Name&gt; FOUND</span>, or <span class="resp-err">&lt;message&gt; ERROR</span>.</li>
+  </ul>
+
+  <h2 id="scan-cmds">Scan commands</h2>
+
+  <details class="op" open><summary><span class="chip scan">SCAN</span><span class="sig">SCAN &lt;path&gt;</span><span class="summary-note">scan file or directory</span></summary>
+    <div class="body">
+      <p>Scans a file or recursively a directory; stops at the first detection.</p>
+      <pre><code>→ zSCAN /home/user/eicar.com\0
+← /home/user/eicar.com: Win.Test.EICAR_HDB-1 FOUND</code></pre>
+    </div>
+  </details>
+
+  <details class="op"><summary><span class="chip scan">SCAN</span><span class="sig">CONTSCAN &lt;path&gt;</span><span class="summary-note">don't stop on detection</span></summary>
+    <div class="body"><p>Like <code>SCAN</code>, but continues through the rest of the tree after a detection, reporting one line per file.</p></div>
+  </details>
+
+  <details class="op"><summary><span class="chip scan">SCAN</span><span class="sig">MULTISCAN &lt;path&gt;</span><span class="summary-note">parallel scan</span></summary>
+    <div class="body"><p>Distributes the files under <code>path</code> across clamd's thread pool (thrmgr) for parallel scanning. Not allowed inside an <code>IDSESSION</code>.</p></div>
+  </details>
+
+  <details class="op"><summary><span class="chip scan">SCAN</span><span class="sig">ALLMATCHSCAN &lt;path&gt;</span><span class="summary-note">report every signature</span></summary>
+    <div class="body"><p>Scans with all-match mode enabled so every matching signature is reported for each file, not just the first.</p></div>
+  </details>
+
+  <h2 id="stream-cmds">Streaming &amp; descriptor passing</h2>
+
+  <details class="op" open><summary><span class="chip strm">STREAM</span><span class="sig">INSTREAM</span><span class="summary-note">scan data sent over the socket</span></summary>
+    <div class="body">
+      <p>Client streams file content in chunks: each chunk is a 4-byte <strong>big-endian length</strong> followed by that many bytes; a zero-length chunk ends the stream. Exceeding the daemon's <code>StreamMaxLength</code> gets <code>INSTREAM size limit exceeded ERROR</code> and disconnect.</p>
+      <pre><code>→ zINSTREAM\0
+→ [00 00 10 00][4096 bytes] … [00 00 00 00]
+← stream: Eicar-Signature FOUND</code></pre>
+    </div>
+  </details>
+
+  <details class="op"><summary><span class="chip strm">STREAM</span><span class="sig">FILDES</span><span class="summary-note">pass an open fd (Unix socket only)</span></summary>
+    <div class="body"><p>Sends a file descriptor via <code>SCM_RIGHTS</code> ancillary data; clamd scans the descriptor directly. Fastest local option — no copy, no path-permission issues.</p></div>
+  </details>
+
+  <h2 id="control-cmds">Control</h2>
+
+  <details class="op"><summary><span class="chip ctrl">CTRL</span><span class="sig">PING</span><span class="summary-note">liveness check</span></summary>
+    <div class="body"><p>Replies <span class="resp-ok">PONG</span>. Used by clamdscan and health checks.</p></div>
+  </details>
+
+  <details class="op"><summary><span class="chip ctrl">CTRL</span><span class="sig">RELOAD</span><span class="summary-note">reload databases</span></summary>
+    <div class="body"><p>Reloads the signature databases (concurrently with ongoing scans, since the engine is refcounted). Replies <span class="resp-ok">RELOADING</span>.</p></div>
+  </details>
+
+  <details class="op"><summary><span class="chip ctrl">CTRL</span><span class="sig">SHUTDOWN</span><span class="summary-note">stop the daemon</span></summary>
+    <div class="body"><p>Performs a clean shutdown, closing sockets and finishing in-flight work.</p></div>
+  </details>
+
+  <details class="op"><summary><span class="chip ctrl">CTRL</span><span class="sig">SELFCHECK</span><span class="summary-note">trigger db freshness check</span></summary>
+    <div class="body"><p>Runs the periodic database self-check (normally driven by <code>SelfCheck</code> interval) immediately.</p></div>
+  </details>
+
+  <h2 id="stats-cmds">Introspection</h2>
+
+  <details class="op"><summary><span class="chip stat">INFO</span><span class="sig">VERSION</span><span class="summary-note">engine + db version</span></summary>
+    <div class="body"><pre><code>← ClamAV 1.x.x/27xxx/&lt;db build date&gt;</code></pre></div>
+  </details>
+
+  <details class="op"><summary><span class="chip stat">INFO</span><span class="sig">VERSIONCOMMANDS</span><span class="summary-note">capability discovery</span></summary>
+    <div class="body"><p>Returns the version plus a pipe-separated list of supported commands — use this for feature detection instead of parsing version numbers.</p></div>
+  </details>
+
+  <details class="op"><summary><span class="chip stat">INFO</span><span class="sig">STATS</span><span class="summary-note">thread-pool &amp; queue state</span></summary>
+    <div class="body"><p>Multi-line report of pool threads (live/idle/max), queue length, and memory stats, terminated by <code>END</code>. This is what clamdtop renders.</p></div>
+  </details>
+
+  <details class="op"><summary><span class="chip stat">INFO</span><span class="sig">DETSTATS · DETSTATSCLEAR</span><span class="summary-note">detection counters</span></summary>
+    <div class="body"><p>Reads (and resets) internal detection statistics counters.</p></div>
+  </details>
+
+  <h2 id="sessions">Sessions</h2>
+
+  <details class="op" open><summary><span class="chip ctrl">SESSION</span><span class="sig">IDSESSION … END</span><span class="summary-note">multiplexed connection</span></summary>
+    <div class="body">
+      <p>Opens a session in which multiple commands can be pipelined on one connection. Every reply is prefixed with a request ID: <code>&lt;id&gt;: &lt;reply&gt;</code>, so responses can be matched even when they arrive out of order. Within a session, only NUL-delimited (<code>z</code>-prefixed) commands are accepted, and <code>SCAN</code>/<code>MULTISCAN</code>-style path recursion is restricted — prefer <code>INSTREAM</code> and <code>FILDES</code>. <code>END</code> closes the session.</p>
+      <pre><code>→ zIDSESSION\0 zPING\0 zINSTREAM\0[chunks] zEND\0
+← 1: PONG
+← 2: stream: OK</code></pre>
+    </div>
+  </details>
+
+  <div class="warn">Commands not recognized, oversized command lines, or size-limit violations cause clamd to reply with an <code>ERROR</code> line and close the connection. Idle connections are dropped after <code>CommandReadTimeout</code>.</div>
+
+  <footer>clamd protocol — sources: <code>clamd/session.h</code>, <code>clamd/session.c</code>, <code>clamd/server-th.c</code>. Also documented in <code>man clamd(8)</code>.</footer>
+</main>
+</body>
+</html>

--- a/docs/html/index.html
+++ b/docs/html/index.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>ClamAV Engine Atlas</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<aside class="rail">
+  <div class="brand">ClamAV<small>Engine Atlas — HLD</small></div>
+  <nav>
+    <div class="group">
+      <h4>Pages</h4>
+      <a class="current" href="index.html">Architecture (HLD)</a>
+      <a href="api.html">libclamav C API</a>
+      <a href="clamd-protocol.html">clamd Protocol</a>
+    </div>
+    <div class="group">
+      <h4>On this page</h4>
+      <a href="#overview">System overview</a>
+      <a href="#diagram">Layer diagram</a>
+      <a href="#components">Components</a>
+      <a href="#scanflow">Scan pipeline</a>
+      <a href="#signatures">Signature databases</a>
+      <a href="#build">Build &amp; layout</a>
+    </div>
+  </nav>
+</aside>
+<main>
+  <p class="eyebrow">High-Level Design</p>
+  <h1>ClamAV Engine Atlas</h1>
+  <p class="lede">ClamAV is an open-source antivirus toolkit built around a single scanning library, <code>libclamav</code>, with a family of daemons and command-line tools layered on top. This atlas maps the components, the scan pipeline, and where each responsibility lives in the source tree.</p>
+
+  <h2 id="overview">System overview</h2>
+  <p>Everything that detects malware lives in <strong>libclamav</strong>: file-type identification, archive and document extraction, unpacking, pattern matching, and a sandboxed bytecode virtual machine for complex signatures. The tools around it are thin by design:</p>
+  <ul>
+    <li><strong>clamscan</strong> links libclamav directly for one-shot command-line scanning.</li>
+    <li><strong>clamd</strong> loads the engine once and serves scans over a TCP or Unix socket (see the <a href="clamd-protocol.html">protocol reference</a>); <strong>clamdscan</strong>, <strong>clamdtop</strong>, <strong>clamonacc</strong> (on-access scanning via fanotify), and <strong>clamav-milter</strong> (sendmail/postfix mail filtering) are its clients.</li>
+    <li><strong>freshclam</strong> / <strong>libfreshclam</strong> download and verify signature databases (CVD/CLD) from mirrors.</li>
+    <li><strong>sigtool</strong>, <strong>clambc</strong>, and <strong>clamsubmit</strong> support signature authoring, bytecode inspection, and sample submission.</li>
+  </ul>
+
+  <h2 id="diagram">Layer diagram</h2>
+  <div class="diagram">
+    <div class="layer">
+      <h4>Clients &amp; integrations</h4>
+      <div class="boxes">
+        <span class="box">clamdscan</span><span class="box">clamdtop</span><span class="box">clamonacc</span><span class="box">clamav-milter</span><span class="box">third-party apps</span>
+      </div>
+    </div>
+    <div class="arrow">▼ clamd wire protocol (TCP / Unix socket) ▼</div>
+    <div class="layer">
+      <h4>Front ends</h4>
+      <div class="boxes">
+        <span class="box">clamd (multithreaded daemon)</span><span class="box">clamscan (CLI)</span><span class="box">freshclam (updater)</span><span class="box">sigtool</span><span class="box">clambc</span>
+      </div>
+    </div>
+    <div class="arrow">▼ C API — <code>libclamav/clamav.h</code> ▼</div>
+    <div class="layer">
+      <h4>Scan engine — libclamav</h4>
+      <div class="boxes">
+        <span class="box core">scanners.c dispatch</span><span class="box core">matcher-ac / matcher-bm / matcher-pcre</span><span class="box">filetypes</span><span class="box">fmap (file mapping)</span><span class="box">cache (clean-file cache)</span><span class="box">bytecode VM</span><span class="box">phishcheck</span><span class="box">dconf</span>
+      </div>
+    </div>
+    <div class="arrow">▼ format parsers &amp; unpackers ▼</div>
+    <div class="layer">
+      <h4>Parsers, unpackers &amp; helpers</h4>
+      <div class="boxes">
+        <span class="box">pe / elf / macho</span><span class="box">zip · rar (libclamunrar) · 7z · cab (libclammspack)</span><span class="box">pdf · ole2 · msdoc · xlm</span><span class="box">html · js normalizer</span><span class="box">upx · aspack · petite …</span><span class="box">libclamav_rust (Rust parsers: onenote, alz, udf, …)</span>
+      </div>
+    </div>
+  </div>
+
+  <h2 id="components">Components</h2>
+  <div class="tablewrap"><table>
+    <tr><th>Directory</th><th>Component</th><th>Responsibility</th></tr>
+    <tr><td><code>libclamav/</code></td><td>Scan engine</td><td>Core detection library: engine lifecycle, file-type magic, format parsers, matchers, bytecode VM, clean-file cache.</td></tr>
+    <tr><td><code>libclamav_rust/</code></td><td>Rust engine half</td><td>Memory-safe parsers (OneNote, ALZ, UDF, EVTX…), CVD signing/verification, logging bridge. Built into libclamav.</td></tr>
+    <tr><td><code>clamd/</code></td><td>Scan daemon</td><td>Threaded server (<code>server-th.c</code>, <code>thrmgr.c</code>), session/command handling (<code>session.c</code>), TCP + local sockets.</td></tr>
+    <tr><td><code>clamscan/</code></td><td>CLI scanner</td><td>Direct libclamav consumer; option parsing and file-tree walking.</td></tr>
+    <tr><td><code>clamdscan/</code> · <code>clamdtop/</code> · <code>clamonacc/</code></td><td>Daemon clients</td><td>Remote scanning, live monitoring TUI, on-access scanning (fanotify) forwarding to clamd.</td></tr>
+    <tr><td><code>freshclam/</code> + <code>libfreshclam/</code></td><td>Updater</td><td>Mirror negotiation, CDIFF incremental updates, CVD signature verification.</td></tr>
+    <tr><td><code>clamav-milter/</code></td><td>Mail filter</td><td>Milter-protocol integration for MTAs, scanning mail through clamd.</td></tr>
+    <tr><td><code>libclamunrar/</code> · <code>libclammspack/</code></td><td>Bundled decompressors</td><td>RAR extraction (separately licensed) and Microsoft CAB/CHM/SZDD support.</td></tr>
+    <tr><td><code>sigtool/</code> · <code>clambc/</code> · <code>clamsubmit/</code> · <code>clamconf/</code></td><td>Tooling</td><td>Signature authoring/inspection, bytecode testing, sample submission, config dump.</td></tr>
+    <tr><td><code>common/</code></td><td>Shared code</td><td>Option parsing, config file handling, output helpers shared by the tools.</td></tr>
+    <tr><td><code>unit_tests/</code> · <code>fuzz/</code></td><td>Quality</td><td>libcheck unit tests, integration tests, libFuzzer harnesses.</td></tr>
+  </table></div>
+
+  <h2 id="scanflow">Scan pipeline</h2>
+  <p>Every scan — whether it enters through <code>cl_scanfile()</code>, a descriptor, or an in-memory map — converges on the same recursive pipeline inside libclamav:</p>
+  <div class="diagram">
+    <div class="arrow"><code>cl_scanfile / cl_scandesc / cl_scanmap_*</code></div>
+    <div class="arrow">▼</div>
+    <div class="boxes" style="justify-content:center"><span class="box core">fmap — map file into memory (fmap.c)</span></div>
+    <div class="arrow">▼ hash lookup — skip if known clean (cache.c) ▼</div>
+    <div class="boxes" style="justify-content:center"><span class="box core">file-type identification (filetypes.c, magic + type signatures)</span></div>
+    <div class="arrow">▼ dispatch by type (scanners.c) ▼</div>
+    <div class="boxes" style="justify-content:center"><span class="box">container parser extracts children (zip, pdf, ole2, pe resources…)</span><span class="box">↺ recurse on each embedded object</span></div>
+    <div class="arrow">▼ every layer's raw + normalized data ▼</div>
+    <div class="boxes" style="justify-content:center"><span class="box core">matchers: Aho-Corasick · Boyer-Moore · PCRE · hash sets · YARA rules</span><span class="box core">bytecode signatures (sandboxed VM)</span></div>
+    <div class="arrow">▼</div>
+    <div class="boxes" style="justify-content:center"><span class="box">verdict: CL_CLEAN → cache hash · CL_VIRUS → report name via callbacks</span></div>
+  </div>
+  <p>Recursion is bounded by engine limits (<code>max-recursion</code>, <code>max-filesize</code>, <code>max-scansize</code>…) set through <code>cl_engine_set_num()</code>. Scan-phase callbacks (<code>pre_cache</code>, <code>pre_scan</code>, <code>post_scan</code>, <code>file_inspection</code>, <code>virus_found</code>) let embedding applications observe or veto each layer.</p>
+
+  <h2 id="signatures">Signature databases</h2>
+  <p>Detections come from database files loaded with <code>cl_load()</code>, distributed as signed <strong>CVD</strong> archives (<code>main.cvd</code>, <code>daily.cvd</code>, <code>bytecode.cvd</code>) and patched incrementally into <strong>CLD</strong> files by freshclam. Major signature types:</p>
+  <div class="tablewrap"><table>
+    <tr><th>Extension</th><th>Type</th><th>Matcher</th></tr>
+    <tr><td><code>.hdb / .hsb</code></td><td>File hash (MD5/SHA)</td><td>Hash table</td></tr>
+    <tr><td><code>.ndb / .ldb</code></td><td>Body patterns / logical signatures</td><td>Aho-Corasick + Boyer-Moore, logical expression evaluator</td></tr>
+    <tr><td><code>.cbc</code></td><td>Bytecode signatures</td><td>Sandboxed bytecode VM (interpreter or JIT)</td></tr>
+    <tr><td><code>.pdb / .wdb</code></td><td>Phishing URL rules / allow-lists</td><td>phishcheck / regex</td></tr>
+    <tr><td><code>.yar / .yara</code></td><td>YARA rules</td><td>Embedded YARA compiler</td></tr>
+    <tr><td><code>.crb</code></td><td>Authenticode certificate trust/block</td><td>crtmgr</td></tr>
+  </table></div>
+
+  <h2 id="build">Build &amp; layout</h2>
+  <p>The project builds with <strong>CMake</strong> (<code>CMakeLists.txt</code>, presets in <code>CMakePresets.json</code>) and <strong>Cargo</strong> for the Rust components, which CMake orchestrates. Windows-specific glue lives in <code>win32/</code>; packaging metadata in <code>vcpkg.json</code> and the Docker notes in <code>README.Docker.md</code>.</p>
+  <pre><code>cmake -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build
+ctest --test-dir build</code></pre>
+
+  <footer>ClamAV Engine Atlas — generated from source at branch <code>man-html</code>. Continue with the <a href="api.html">libclamav C API</a> or the <a href="clamd-protocol.html">clamd protocol</a>.</footer>
+</main>
+</body>
+</html>

--- a/docs/html/style.css
+++ b/docs/html/style.css
@@ -1,0 +1,119 @@
+/* ClamAV Documentation — shared stylesheet */
+:root {
+  --paper: #f6f7f4;
+  --card: #ffffff;
+  --ink: #1a2320;
+  --ink-soft: #4c5a55;
+  --line: #dde3de;
+  --accent: #0e7268;
+  --accent-soft: #e3f0ee;
+  --alert: #b3402a;
+  --chip-scan: #1d7a3e;
+  --chip-ctrl: #2458a6;
+  --chip-stat: #6b3fa0;
+  --chip-strm: #a3641a;
+  --code-bg: #eef1ec;
+  --mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  --serif: Georgia, "Times New Roman", serif;
+  --sans: -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+}
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --paper: #111917; --card: #18211e; --ink: #e4eae6; --ink-soft: #9db0a9;
+    --line: #26332e; --accent: #4fc0b2; --accent-soft: #14302c;
+    --alert: #e07a5f; --code-bg: #0d1412;
+    --chip-scan: #4cae6e; --chip-ctrl: #6d9fe0; --chip-stat: #a982d6; --chip-strm: #d19a55;
+  }
+}
+:root[data-theme="dark"] {
+  --paper: #111917; --card: #18211e; --ink: #e4eae6; --ink-soft: #9db0a9;
+  --line: #26332e; --accent: #4fc0b2; --accent-soft: #14302c;
+  --alert: #e07a5f; --code-bg: #0d1412;
+  --chip-scan: #4cae6e; --chip-ctrl: #6d9fe0; --chip-stat: #a982d6; --chip-strm: #d19a55;
+}
+* { box-sizing: border-box; margin: 0; }
+body {
+  background: var(--paper); color: var(--ink);
+  font: 16px/1.6 var(--sans);
+}
+a { color: var(--accent); text-decoration: none; }
+a:hover, a:focus-visible { text-decoration: underline; }
+a:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+/* Layout: fixed rail + column */
+.rail {
+  position: fixed; top: 0; left: 0; bottom: 0; width: 250px;
+  border-right: 1px solid var(--line); padding: 28px 22px;
+  display: flex; flex-direction: column; gap: 26px; overflow-y: auto;
+  background: var(--card);
+}
+.rail .brand { font-family: var(--serif); font-size: 1.35rem; letter-spacing: -0.01em; color: var(--ink); }
+.rail .brand small { display: block; font-family: var(--sans); font-size: 0.68rem; letter-spacing: 0.14em; text-transform: uppercase; color: var(--ink-soft); margin-top: 4px; }
+.rail nav { display: flex; flex-direction: column; gap: 20px; }
+.rail .group { display: flex; flex-direction: column; gap: 6px; }
+.rail .group h4 { font-size: 0.68rem; letter-spacing: 0.14em; text-transform: uppercase; color: var(--ink-soft); font-weight: 600; }
+.rail .group a { color: var(--ink); font-size: 0.9rem; padding: 2px 0; }
+.rail .group a.current { color: var(--accent); font-weight: 600; }
+main { margin-left: 250px; padding: 56px 48px 96px; max-width: 880px; }
+@media (max-width: 900px) {
+  .rail { position: static; width: auto; border-right: 0; border-bottom: 1px solid var(--line); }
+  main { margin-left: 0; padding: 32px 20px 64px; }
+}
+
+/* Typography */
+h1 { font-family: var(--serif); font-size: 2.3rem; line-height: 1.15; letter-spacing: -0.015em; text-wrap: balance; margin-bottom: 10px; }
+.lede { color: var(--ink-soft); font-size: 1.08rem; max-width: 62ch; margin-bottom: 40px; }
+h2 { font-family: var(--serif); font-size: 1.5rem; letter-spacing: -0.01em; margin: 56px 0 14px; padding-top: 18px; border-top: 1px solid var(--line); text-wrap: balance; }
+h3 { font-size: 1.05rem; margin: 28px 0 8px; }
+p { max-width: 68ch; margin-bottom: 12px; }
+.eyebrow { font-size: 0.7rem; letter-spacing: 0.16em; text-transform: uppercase; color: var(--accent); font-weight: 700; margin-bottom: 8px; }
+
+/* Code */
+code { font-family: var(--mono); font-size: 0.86em; background: var(--code-bg); padding: 1px 5px; border-radius: 3px; }
+pre { background: var(--code-bg); border: 1px solid var(--line); border-radius: 6px; padding: 14px 16px; overflow-x: auto; margin: 14px 0; }
+pre code { background: none; padding: 0; font-size: 0.82rem; line-height: 1.55; }
+
+/* Tables */
+.tablewrap { overflow-x: auto; margin: 14px 0; }
+table { border-collapse: collapse; width: 100%; font-size: 0.88rem; }
+th { text-align: left; font-size: 0.7rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--ink-soft); border-bottom: 2px solid var(--line); padding: 6px 12px 6px 0; }
+td { border-bottom: 1px solid var(--line); padding: 8px 12px 8px 0; vertical-align: top; }
+td code { white-space: nowrap; }
+
+/* Swagger-style operation cards */
+.op { border: 1px solid var(--line); border-radius: 8px; background: var(--card); margin: 14px 0; overflow: hidden; }
+.op > summary {
+  list-style: none; cursor: pointer; display: flex; align-items: center; gap: 12px;
+  padding: 12px 16px; flex-wrap: wrap;
+}
+.op > summary::-webkit-details-marker { display: none; }
+.op > summary:hover { background: var(--accent-soft); }
+.op[open] > summary { border-bottom: 1px solid var(--line); }
+.op .body { padding: 16px 18px 20px; }
+.chip {
+  font-family: var(--mono); font-size: 0.68rem; font-weight: 700; letter-spacing: 0.06em;
+  color: #fff; border-radius: 4px; padding: 4px 9px; min-width: 64px; text-align: center;
+}
+:root[data-theme="dark"] .chip, .chip { color: #fff; }
+.chip.scan { background: var(--chip-scan); }
+.chip.ctrl { background: var(--chip-ctrl); }
+.chip.stat { background: var(--chip-stat); }
+.chip.strm { background: var(--chip-strm); }
+.sig { font-family: var(--mono); font-size: 0.84rem; }
+.summary-note { color: var(--ink-soft); font-size: 0.82rem; margin-left: auto; }
+.resp-ok { color: var(--chip-scan); font-family: var(--mono); }
+.resp-err { color: var(--alert); font-family: var(--mono); }
+
+/* HLD diagram */
+.diagram { border: 1px solid var(--line); border-radius: 8px; background: var(--card); padding: 22px; margin: 20px 0; overflow-x: auto; }
+.layer { border: 1px solid var(--line); border-radius: 6px; padding: 12px 16px; margin: 10px 0; }
+.layer h4 { font-size: 0.7rem; letter-spacing: 0.14em; text-transform: uppercase; color: var(--accent); margin-bottom: 8px; }
+.boxes { display: flex; flex-wrap: wrap; gap: 8px; }
+.box { font-family: var(--mono); font-size: 0.78rem; background: var(--accent-soft); border: 1px solid var(--line); color: var(--ink); border-radius: 4px; padding: 5px 10px; }
+.box.core { background: var(--accent); color: #fff; border-color: var(--accent); }
+.arrow { text-align: center; color: var(--ink-soft); font-size: 0.85rem; padding: 2px 0; }
+
+/* Callouts */
+.note { border-left: 3px solid var(--accent); background: var(--accent-soft); padding: 10px 14px; border-radius: 0 6px 6px 0; margin: 14px 0; font-size: 0.92rem; max-width: 70ch; }
+.warn { border-left: 3px solid var(--alert); background: var(--code-bg); padding: 10px 14px; border-radius: 0 6px 6px 0; margin: 14px 0; font-size: 0.92rem; max-width: 70ch; }
+footer { margin-top: 72px; padding-top: 16px; border-top: 1px solid var(--line); color: var(--ink-soft); font-size: 0.8rem; }


### PR DESCRIPTION
database loading, and return codes.
- **clamd Wire Protocol** — `clamd-protocol.html`: the plain-text socket protocol documented endpoint-style — command conventions (`z`/`n` prefixes), scan commands, `INSTREAM` streaming, control and introspection commands, and `IDSESSION` sessions.
- **style.css**: shared stylesheet (sidebar navigation, category chips, collapsible operation blocks).

### Notes

- Documentation only — no code changes.
- All pages are self-contained and cross-linked via a shared sidebar.

<img width="1366" height="651" alt="image" src="https://github.com/user-attachments/assets/f6aa605e-795f-4c0c-93c7-8ea96fe62a2b" />
