### PR TITLE
libfreshclam: fix use-after-free in fc_cleanup on init failure

### DIFF
--- a/libfreshclam/libfreshclam.c
+++ b/libfreshclam/libfreshclam.c
@@ -353,6 +353,7 @@ void fc_cleanup(void)
     }
     if (NULL != g_signVerifier) {
         codesign_verifier_free(g_signVerifier);
+        g_signVerifier = NULL;
     }
 }
 


### PR DESCRIPTION
fc_cleanup() frees g_signVerifier but does not set it to NULL. When fc_initialize() fails, fc_cleanup() is called internally and then again by freshclam at exit, causing a double free that results in a segmentation fault.

Set g_signVerifier to NULL after freeing it, matching the pattern used by other pointers in fc_cleanup().

Triggered when freshclam cannot write to the database directory.