### PR TITLE
libclamav: report skipped PCRE evaluation through AlertExceedsMax

### DIFF
--- a/clamscan/clamscan.c
+++ b/clamscan/clamscan.c
@@ -339,7 +339,7 @@ void help(void)
     mprintf(LOGG_INFO, "    --alert-encrypted-archive[=yes/no(*)] Alert on encrypted archives.\n");
     mprintf(LOGG_INFO, "    --alert-encrypted-doc[=yes/no(*)]    Alert on encrypted documents.\n");
     mprintf(LOGG_INFO, "    --alert-macros[=yes/no(*)]           Alert on OLE2 files containing VBA macros.\n");
-    mprintf(LOGG_INFO, "    --alert-exceeds-max[=yes/no(*)]      Alert on files that exceed max file size, max scan size, or max recursion limit.\n");
+    mprintf(LOGG_INFO, "    --alert-exceeds-max[=yes/no(*)]      Alert on files that exceed max file size, max scan size, max recursion, or PCRE max file size.\n");
     mprintf(LOGG_INFO, "    --alert-phishing-ssl[=yes/no(*)]     Alert on emails containing SSL mismatches in URLs.\n");
     mprintf(LOGG_INFO, "    --alert-phishing-cloak[=yes/no(*)]   Alert on emails containing cloaked URLs.\n");
     mprintf(LOGG_INFO, "    --alert-partition-intersection[=yes/no(*)] Alert on raw DMG image files containing partition intersections.\n");

--- a/clamscan/clamscan.c
+++ b/clamscan/clamscan.c
@@ -339,7 +339,7 @@ void help(void)
     mprintf(LOGG_INFO, "    --alert-encrypted-archive[=yes/no(*)] Alert on encrypted archives.\n");
     mprintf(LOGG_INFO, "    --alert-encrypted-doc[=yes/no(*)]    Alert on encrypted documents.\n");
     mprintf(LOGG_INFO, "    --alert-macros[=yes/no(*)]           Alert on OLE2 files containing VBA macros.\n");
-    mprintf(LOGG_INFO, "    --alert-exceeds-max[=yes/no(*)]      Alert on files that exceed max file size, max scan size, max recursion, or PCRE max file size.\n");
+    mprintf(LOGG_INFO, "    --alert-exceeds-max[=yes/no(*)]      Alert on files that exceed configured scan limits.\n");
     mprintf(LOGG_INFO, "    --alert-phishing-ssl[=yes/no(*)]     Alert on emails containing SSL mismatches in URLs.\n");
     mprintf(LOGG_INFO, "    --alert-phishing-cloak[=yes/no(*)]   Alert on emails containing cloaked URLs.\n");
     mprintf(LOGG_INFO, "    --alert-partition-intersection[=yes/no(*)] Alert on raw DMG image files containing partition intersections.\n");

--- a/docs/man/clamd.conf.5.in
+++ b/docs/man/clamd.conf.5.in
@@ -609,7 +609,7 @@ Alert on OLE2 files containing VBA macros (Heuristics.OLE2.ContainsMacros).
 Default: no
 .TP
 \fBAlertExceedsMax BOOL\fR
-When AlertExceedsMax is set, files exceeding the MaxFileSize, MaxScanSize, or MaxRecursion limit will be flagged with the virus name starting with "Heuristics.Limits.Exceeded".
+When AlertExceedsMax is set, files exceeding the MaxFileSize, MaxScanSize, MaxRecursion, or PCREMaxFileSize limit will be flagged with a name starting with "Heuristics.Limits.Exceeded". Exceeding PCREMaxFileSize means PCRE subsignature evaluation was skipped and the scan had reduced detection coverage.
 .br
 Default: no
 .TP

--- a/docs/man/clamd.conf.5.in
+++ b/docs/man/clamd.conf.5.in
@@ -609,7 +609,7 @@ Alert on OLE2 files containing VBA macros (Heuristics.OLE2.ContainsMacros).
 Default: no
 .TP
 \fBAlertExceedsMax BOOL\fR
-When AlertExceedsMax is set, files exceeding the MaxFileSize, MaxScanSize, MaxRecursion, or PCREMaxFileSize limit will be flagged with a name starting with "Heuristics.Limits.Exceeded". Exceeding PCREMaxFileSize means PCRE subsignature evaluation was skipped and the scan had reduced detection coverage.
+When AlertExceedsMax is set, files exceeding a configured scan limit will be flagged with a virus name starting with "Heuristics.Limits.Exceeded".
 .br
 Default: no
 .TP

--- a/docs/man/clamscan.1.in
+++ b/docs/man/clamscan.1.in
@@ -211,7 +211,7 @@ Alert on encrypted documents (encrypted .zip, .7zip, .rar, .pdf).
 Alert on OLE2 files containing VBA macros (Heuristics.OLE2.ContainsMacros).
 .TP
 \fB\-\-alert\-exceeds\-max[=yes/no(*)]\fR
-Alert on files that exceed max file size, max scan size, or max recursion limit (Heuristics.Limits.Exceeded).
+Alert on files that exceed max file size, max scan size, max recursion, or PCRE max file size limits (Heuristics.Limits.Exceeded). Exceeding the PCRE max file size means PCRE subsignature evaluation was skipped and the scan had reduced detection coverage.
 .TP
 \fB\-\-alert\-phishing\-ssl[=yes/no(*)]\fR
 Alert on emails containing SSL mismatches in URLs (might lead to false positives!).

--- a/docs/man/clamscan.1.in
+++ b/docs/man/clamscan.1.in
@@ -211,7 +211,7 @@ Alert on encrypted documents (encrypted .zip, .7zip, .rar, .pdf).
 Alert on OLE2 files containing VBA macros (Heuristics.OLE2.ContainsMacros).
 .TP
 \fB\-\-alert\-exceeds\-max[=yes/no(*)]\fR
-Alert on files that exceed max file size, max scan size, max recursion, or PCRE max file size limits (Heuristics.Limits.Exceeded). Exceeding the PCRE max file size means PCRE subsignature evaluation was skipped and the scan had reduced detection coverage.
+Alert on files that exceed configured scan limits (Heuristics.Limits.Exceeded).
 .TP
 \fB\-\-alert\-phishing\-ssl[=yes/no(*)]\fR
 Alert on emails containing SSL mismatches in URLs (might lead to false positives!).

--- a/etc/clamd.conf.sample
+++ b/etc/clamd.conf.sample
@@ -748,9 +748,8 @@ Example
 # Default: 100M
 #PCREMaxFileSize 400M
 
-# When AlertExceedsMax is set, files exceeding the MaxFileSize, MaxScanSize,
-# MaxRecursion, or PCREMaxFileSize limit will be flagged with a name starting with
-# "Heuristics.Limits.Exceeded".
+# When AlertExceedsMax is set, files exceeding a configured scan limit will
+# be flagged with a virus name starting with "Heuristics.Limits.Exceeded".
 # Default: no
 #AlertExceedsMax yes
 

--- a/etc/clamd.conf.sample
+++ b/etc/clamd.conf.sample
@@ -748,8 +748,8 @@ Example
 # Default: 100M
 #PCREMaxFileSize 400M
 
-# When AlertExceedsMax is set, files exceeding the MaxFileSize, MaxScanSize, or
-# MaxRecursion limit will be flagged with the virus name starting with
+# When AlertExceedsMax is set, files exceeding the MaxFileSize, MaxScanSize,
+# MaxRecursion, or PCREMaxFileSize limit will be flagged with a name starting with
 # "Heuristics.Limits.Exceeded".
 # Default: no
 #AlertExceedsMax yes

--- a/libclamav/matcher.c
+++ b/libclamav/matcher.c
@@ -217,6 +217,7 @@ static inline cl_error_t matcher_run(const struct cli_matcher *root,
                 if (maxfilesize && (map->len > maxfilesize)) {
                     cli_dbgmsg("matcher_run: pcre max filesize (map) exceeded (limit: %llu, needed: %llu)\n",
                                (long long unsigned)maxfilesize, (long long unsigned)map->len);
+                    cli_append_potentially_unwanted_if_heur_exceedsmax(ctx, "Heuristics.Limits.Exceeded.PCREMaxFileSize");
                     return CL_EMAXSIZE;
                 }
 
@@ -236,6 +237,7 @@ static inline cl_error_t matcher_run(const struct cli_matcher *root,
                 return rc;
             if (maxfilesize && (length > maxfilesize)) {
                 cli_dbgmsg("matcher_run: pcre max filesize (buf) exceeded (limit: %llu, needed: %u)\n", (long long unsigned)maxfilesize, length);
+                cli_append_potentially_unwanted_if_heur_exceedsmax(ctx, "Heuristics.Limits.Exceeded.PCREMaxFileSize");
                 return CL_EMAXSIZE;
             }
 

--- a/unit_tests/clamscan/regex_test.py
+++ b/unit_tests/clamscan/regex_test.py
@@ -122,6 +122,65 @@ rule regex
         ]
         self.verify_output(output.out, expected=expected_results)
 
+    def test_pcre_max_filesize_alert(self):
+        self.step_name('Test that skipped PCRE evaluation is visible with AlertExceedsMax')
+
+        testfile = TC.path_tmp / 'pcre-max-filesize.sample'
+        testfile.write_text('MZ hello blee' + ('A' * 1024))
+
+        regex_db = TC.path_tmp / 'pcre-max-filesize.ldb'
+        regex_db.write_text(
+            r'pcre_max_filesize;Engine:81-255,Target:0;0&1;68656c6c6f20;0/hello blee/'
+        )
+
+        command = (
+            '{valgrind} {valgrind_args} {clamscan} -d {path_db} '
+            '--pcre-max-filesize=512 --alert-exceeds-max=yes {testfile}'
+        ).format(
+            valgrind=TC.valgrind,
+            valgrind_args=TC.valgrind_args,
+            clamscan=TC.clamscan,
+            path_db=regex_db,
+            testfile=testfile,
+        )
+        output = self.execute_command(command)
+
+        assert output.ec == 1
+        self.verify_output(
+            output.out,
+            expected=['Heuristics.Limits.Exceeded.PCREMaxFileSize FOUND'],
+        )
+
+        command = (
+            '{valgrind} {valgrind_args} {clamscan} -d {path_db} '
+            '--pcre-max-filesize=512 --alert-exceeds-max=no {testfile}'
+        ).format(
+            valgrind=TC.valgrind,
+            valgrind_args=TC.valgrind_args,
+            clamscan=TC.clamscan,
+            path_db=regex_db,
+            testfile=testfile,
+        )
+        output = self.execute_command(command)
+
+        assert output.ec == 0
+        self.verify_output(output.out, expected=['pcre-max-filesize.sample: OK'])
+
+        command = (
+            '{valgrind} {valgrind_args} {clamscan} -d {path_db} '
+            '--pcre-max-filesize=2K --alert-exceeds-max=yes {testfile}'
+        ).format(
+            valgrind=TC.valgrind,
+            valgrind_args=TC.valgrind_args,
+            clamscan=TC.clamscan,
+            path_db=regex_db,
+            testfile=testfile,
+        )
+        output = self.execute_command(command)
+
+        assert output.ec == 1
+        self.verify_output(output.out, expected=['pcre_max_filesize.UNOFFICIAL FOUND'])
+
     def test_ldb_offset_pcre(self):
         self.step_name('Test LDB regex rules with an offset')
         # The offset feature starts the match some # of bytes after start of the pattern match


### PR DESCRIPTION
## Summary

Report `Heuristics.Limits.Exceeded.PCREMaxFileSize` through the existing
`AlertExceedsMax` mechanism when the PCRE matcher skips subsignature evaluation
because a file or buffer exceeds `PCREMaxFileSize`.

Closes #1785.

## Root cause

Both PCRE size-limit branches return `CL_EMAXSIZE`. The generic scanner result
handler intentionally converts non-fatal max conditions to success so remaining
analysis can continue. Unlike `MaxFileSize` and `MaxScanSize`, the PCRE-specific
limit did not first append an exceeds-max heuristic or metadata record. A scan
could therefore report `OK` without an operational indication that PCRE
subsignatures were not evaluated.

## Changes

- Report the limit through `cli_append_potentially_unwanted_if_heur_exceedsmax`
  for both fmap and buffer PCRE paths.
- Preserve existing behavior when `AlertExceedsMax` is disabled.
- Add regression coverage for alert enabled, alert disabled, and normal
  below-limit PCRE evaluation.
- Document that `AlertExceedsMax` covers `PCREMaxFileSize` and that exceeding it
  reduces detection coverage.

## Validation

- Full native ClamAV debug build completed successfully on macOS arm64.
- `python3 -m unittest -v clamscan.regex_test`: 6 tests passed.
- New regression test confirms:
  - above limit + alert enabled: heuristic reported, exit 1;
  - above limit + alert disabled: compatibility behavior retained, exit 0;
  - below limit: PCRE signature evaluated and detected.
- `git diff --check` passed.
