### PR TITLE
Prevent duplicate FreshClam cleanup

### DIFF
--- a/freshclam/freshclam.c
+++ b/freshclam/freshclam.c
@@ -23,6 +23,7 @@
 #endif
 
 #include <stdio.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
@@ -1675,7 +1676,8 @@ int main(int argc, char **argv)
     const char *logFileName            = NULL;
 #endif /* HAVE_PWD_H */
 
-    fc_ctx fc_context = {0};
+    fc_ctx fc_context             = {0};
+    bool libfreshclam_initialized = false;
 
 #ifndef _WIN32
     struct sigaction sigact;
@@ -1906,6 +1908,7 @@ int main(int argc, char **argv)
         status = FC_EINIT;
         goto done;
     }
+    libfreshclam_initialized = true;
 
     if (!optget(opts, "no-dns")->enabled && optget(opts, "DNSDatabaseInfo")->enabled) {
         dnsUpdateInfoServer = optget(opts, "DNSDatabaseInfo")->strarg;
@@ -2193,8 +2196,9 @@ done:
         free(cfgfile);
     }
 
-    /* Cleanup libfreshclam */
-    fc_cleanup();
+    if (libfreshclam_initialized) {
+        fc_cleanup();
+    }
 
     /* Remove temp directory */
     if (*g_freshclamTempDirectory) {


### PR DESCRIPTION
## Summary

- track whether FreshClam successfully initialized libfreshclam
- call `fc_cleanup()` from FreshClam only when initialization succeeded
- preserve libfreshclam's existing cleanup of partially initialized state

## Problem

`fc_initialize()` cleans up partially initialized global state before returning an error. FreshClam's common shutdown path then called `fc_cleanup()` unconditionally, so an initialization failure caused the same library state to be cleaned up a second time. This could double-free retained global resources and also paired one `curl_global_init()` with two `curl_global_cleanup()` calls.

## Solution

FreshClam now records when initialization completes successfully. A successful run transfers cleanup ownership to `main()` and performs one cleanup during shutdown. A failed initialization remains responsible for its own cleanup inside `fc_initialize()`, and exits before initialization do not call libfreshclam cleanup.

## Validation

- `cmake --build build --target freshclam-bin -j12`
- failed-initialization reproduction exits normally with status 2 instead of aborting
- `ctest --test-dir build -V -R '^freshclam$'` (10 passed, 1 skipped)
- `git diff --check`