### PR TITLE
ClamDScan: reconnect and re-send when clamd drops an IDSESSION

### DIFF
--- a/clamdscan/proto.c
+++ b/clamdscan/proto.c
@@ -44,6 +44,9 @@
 #ifdef HAVE_SYS_SELECT_H
 #include <sys/select.h>
 #endif
+#ifdef _WIN32
+#include <windows.h>
+#endif
 #ifndef _WIN32
 #include <sys/resource.h>
 #endif
@@ -346,6 +349,7 @@ struct client_parallel_data {
     } *ids;
     unsigned int action_sources;
     unsigned int max_action_sources;
+    int restarts;
 };
 
 /* Sends a proper scan request to clamd and parses its replies
@@ -409,6 +413,11 @@ static int dspresult(struct client_parallel_data *c)
         free(bol);
     } while (rcv.cur != rcv.buf); /* clamd sends whole lines, so, on partial lines, we just assume
                                     more data can be recv()'d with close to zero latency */
+
+    /* The session is working again, so only consecutive failures count against
+     * the restart budget. */
+    c->restarts = 0;
+
     return 0;
 }
 
@@ -434,6 +443,119 @@ static void free_scanids(struct client_parallel_data *c)
         }
         free(id);
     }
+}
+
+/* Restarts allowed in a row without a verdict coming back in between. */
+#define MAX_SESSION_RESTARTS 3
+
+/* Delay before the second restart in a row, doubled for each further one. */
+#define SESSION_RESTART_DELAY 1
+
+static void session_restart_wait(unsigned int seconds)
+{
+#ifdef _WIN32
+    Sleep(seconds * 1000);
+#else
+    sleep(seconds);
+#endif
+}
+
+/* Re-establish the IDSESSION after clamd unexpectedly closed the
+ * connection, and re-send every outstanding (unanswered) request.
+ * Returns 0 on success, nonzero if the session could not be restored. */
+static int session_restart(struct client_parallel_data *c)
+{
+    static const char zIDSESSION[] = "zIDSESSION";
+    struct SCANID *outstanding;
+    struct SCANID *cur;
+    unsigned int n = 0;
+
+    if (++c->restarts > MAX_SESSION_RESTARTS) {
+        logg(LOGG_ERROR, "Connection to clamd lost %d consecutive times, giving up\n",
+             MAX_SESSION_RESTARTS);
+        return 1;
+    }
+
+    outstanding = c->ids;
+    c->ids      = NULL;
+    c->lastid   = 0;
+
+    closesocket(c->sockd);
+
+    if (c->restarts > 1) {
+        unsigned int delay = SESSION_RESTART_DELAY << (c->restarts - 2);
+        logg(LOGG_DEBUG, "Waiting %u second(s) before restarting the session\n", delay);
+        session_restart_wait(delay);
+    }
+
+    /* On failure the requests go back on the list, for free_scanids() to release. */
+    if ((c->sockd = dconnect(clamdopts)) < 0) {
+        c->ids = outstanding;
+        return 1;
+    }
+    if (sendln(c->sockd, zIDSESSION, sizeof(zIDSESSION))) {
+        closesocket(c->sockd);
+        c->sockd = -1;
+        c->ids   = outstanding;
+        return 1;
+    }
+
+    for (cur = outstanding; cur; cur = cur->next) n++;
+    logg(LOGG_WARNING,
+         "Connection to clamd lost (restart %d/%d); last request before "
+         "disconnect: %s; re-sending %u outstanding request(s)\n",
+         c->restarts, MAX_SESSION_RESTARTS,
+         outstanding ? outstanding->file : "(none)", n);
+
+    while ((cur = outstanding)) {
+        int res     = 0;
+        outstanding = cur->next;
+        switch (c->scantype) {
+#ifdef HAVE_FD_PASSING
+            case FILDES:
+                res = (NULL != cur->action_source)
+                          ? send_fdpass_fd(c->sockd, cur->action_source->scan_fd)
+                          : send_fdpass(c->sockd, cur->file);
+                break;
+#endif
+            case STREAM:
+                res = (NULL != cur->action_source)
+                          ? send_stream_fd_action(c->sockd, cur->action_source->scan_fd,
+                                                  cur->action_source->display_path, clamdopts)
+                          : send_stream(c->sockd, cur->file, clamdopts);
+                break;
+        }
+        if (res > 0) {
+            cur->id   = ++c->lastid;
+            cur->next = c->ids;
+            c->ids    = cur;
+            continue;
+        }
+        if (res == 0) {
+            /* Soft failure, e.g. the file vanished. */
+            logg(LOGG_ERROR, "Failed to re-send %s after reconnect\n", cur->file);
+            c->errors++;
+            free((void *)cur->file);
+            if (NULL != cur->action_source) {
+                action_source_close(cur->action_source);
+                free(cur->action_source);
+                if (c->action_sources > 0)
+                    c->action_sources--;
+            }
+            free(cur);
+            continue;
+        }
+        /* The new connection died as well. Put back both the not-yet-resent tail
+         * and the already-resent entries; re-sending a request twice is harmless. */
+        outstanding = cur; /* cur->next still points at the tail */
+        while ((cur = outstanding)) {
+            outstanding = cur->next;
+            cur->next   = c->ids;
+            c->ids      = cur;
+        }
+        return session_restart(c);
+    }
+    return 0;
 }
 
 /* FTW callback for scanning in IDSESSION mode
@@ -494,8 +616,10 @@ static cl_error_t parallel_callback(STATBUF *sb, char *filename, const char *pat
     if (action) {
         while (c->action_sources >= c->max_action_sources) {
             if (dspresult(c)) {
-                status = CL_BREAK;
-                goto done;
+                if (session_restart(c)) {
+                    status = CL_BREAK;
+                    goto done;
+                }
             }
         }
 
@@ -531,28 +655,41 @@ static cl_error_t parallel_callback(STATBUF *sb, char *filename, const char *pat
         }
         if (FD_ISSET(c->sockd, &rfds)) {
             if (dspresult(c)) {
-                status = CL_BREAK;
-                goto done;
-            } else
-                continue;
+                if (session_restart(c)) {
+                    status = CL_BREAK;
+                    goto done;
+                }
+            }
+            continue;
         }
         if (FD_ISSET(c->sockd, &wfds)) break;
     }
 
-    switch (c->scantype) {
+    while (1) {
+        switch (c->scantype) {
 #ifdef HAVE_FD_PASSING
-        case FILDES:
-            res = (NULL != action_source) ? send_fdpass_fd(c->sockd, action_source->scan_fd) : send_fdpass(c->sockd, scan_path);
-            break;
+            case FILDES:
+                res = (NULL != action_source) ? send_fdpass_fd(c->sockd, action_source->scan_fd) : send_fdpass(c->sockd, scan_path);
+                break;
 #endif
-        case STREAM:
-            res = (NULL != action_source) ? send_stream_fd_action(c->sockd, action_source->scan_fd, action_source->display_path, clamdopts) : send_stream(c->sockd, scan_path, clamdopts);
+            case STREAM:
+                res = (NULL != action_source) ? send_stream_fd_action(c->sockd, action_source->scan_fd, action_source->display_path, clamdopts) : send_stream(c->sockd, scan_path, clamdopts);
+                break;
+        }
+        if (res >= 0)
             break;
+        /* Connection-level failure: restore the session and send this file again. */
+        if (session_restart(c)) {
+            c->printok = 0;
+            c->errors++;
+            status = CL_BREAK;
+            goto done;
+        }
     }
-    if (res <= 0) {
+    if (res == 0) {
         c->printok = 0;
         c->errors++;
-        status = res ? CL_BREAK : CL_SUCCESS;
+        status = CL_SUCCESS;
         goto done;
     }
 
@@ -619,6 +756,7 @@ int parallel_client_scan(char *file, int scantype, int *infected, int *err, int 
     cdata.printok            = printinfected ^ 1;
     cdata.action_sources     = 0;
     cdata.max_action_sources = get_max_action_sources();
+    cdata.restarts           = 0;
     client_walk_policy_init(&cdata.walk_policy, file);
     data.data = &cdata;
 
@@ -628,13 +766,22 @@ int parallel_client_scan(char *file, int scantype, int *infected, int *err, int 
         *err += cdata.errors;
         *infected += cdata.infected;
         free_scanids(&cdata);
-        closesocket(cdata.sockd);
+        if (cdata.sockd >= 0)
+            closesocket(cdata.sockd);
         return 1;
     }
 
     sendln(cdata.sockd, zEND, sizeof(zEND));
-    while (cdata.ids && !dspresult(&cdata)) continue;
-    closesocket(cdata.sockd);
+    while (cdata.ids) {
+        if (dspresult(&cdata)) {
+            if (session_restart(&cdata))
+                break;
+            /* New session: terminate it too so remaining replies flush. */
+            sendln(cdata.sockd, zEND, sizeof(zEND));
+        }
+    }
+    if (cdata.sockd >= 0)
+        closesocket(cdata.sockd);
 
     *infected += cdata.infected;
     *err += cdata.errors;

--- a/clamdscan/proto.c
+++ b/clamdscan/proto.c
@@ -344,6 +344,7 @@ struct client_parallel_data {
     struct SCANID {
         unsigned int id;
         const char *file;
+        const char *scan_path; /* resolved path the request was sent for; NULL if it is `file` itself */
         action_source_t *action_source;
         struct SCANID *next;
     } *ids;
@@ -401,6 +402,7 @@ static int dspresult(struct client_parallel_data *c)
             }
         }
         free((void *)filename);
+        free((void *)(*id)->scan_path);
         if (NULL != action_source) {
             action_source_close(action_source);
             free(action_source);
@@ -434,6 +436,7 @@ static void free_scanids(struct client_parallel_data *c)
         c->ids = id->next;
 
         free((void *)id->file);
+        free((void *)id->scan_path);
         if (NULL != id->action_source) {
             action_source_close(id->action_source);
             free(id->action_source);
@@ -508,22 +511,47 @@ static int session_restart(struct client_parallel_data *c)
          outstanding ? outstanding->file : "(none)", n);
 
     while ((cur = outstanding)) {
-        int res     = 0;
-        outstanding = cur->next;
-        switch (c->scantype) {
+        const char *scan_path = cur->scan_path ? cur->scan_path : cur->file;
+        int res               = 0;
+
+        /* As in parallel_callback: consume the replies already available before
+         * sending, or clamd could sit blocked on a full reply pipe while we in
+         * turn sit blocked in send(). */
+        while (res == 0) {
+            fd_set rfds, wfds;
+            FD_ZERO(&rfds);
+            FD_SET(c->sockd, &rfds);
+            FD_ZERO(&wfds);
+            FD_SET(c->sockd, &wfds);
+            if (select(c->sockd + 1, &rfds, &wfds, NULL, NULL) < 0) {
+                if (errno == EINTR) continue;
+                logg(LOGG_ERROR, "select() failed while re-sending: %s\n", strerror(errno));
+                res = -1;
+            } else if (FD_ISSET(c->sockd, &rfds)) {
+                if (dspresult(c))
+                    res = -1;
+            } else if (FD_ISSET(c->sockd, &wfds)) {
+                break;
+            }
+        }
+
+        if (res == 0) {
+            outstanding = cur->next;
+            switch (c->scantype) {
 #ifdef HAVE_FD_PASSING
-            case FILDES:
-                res = (NULL != cur->action_source)
-                          ? send_fdpass_fd(c->sockd, cur->action_source->scan_fd)
-                          : send_fdpass(c->sockd, cur->file);
-                break;
+                case FILDES:
+                    res = (NULL != cur->action_source)
+                              ? send_fdpass_fd(c->sockd, cur->action_source->scan_fd)
+                              : send_fdpass(c->sockd, scan_path);
+                    break;
 #endif
-            case STREAM:
-                res = (NULL != cur->action_source)
-                          ? send_stream_fd_action(c->sockd, cur->action_source->scan_fd,
-                                                  cur->action_source->display_path, clamdopts)
-                          : send_stream(c->sockd, cur->file, clamdopts);
-                break;
+                case STREAM:
+                    res = (NULL != cur->action_source)
+                              ? send_stream_fd_action(c->sockd, cur->action_source->scan_fd,
+                                                      cur->action_source->display_path, clamdopts)
+                              : send_stream(c->sockd, scan_path, clamdopts);
+                    break;
+            }
         }
         if (res > 0) {
             cur->id   = ++c->lastid;
@@ -536,6 +564,7 @@ static int session_restart(struct client_parallel_data *c)
             logg(LOGG_ERROR, "Failed to re-send %s after reconnect\n", cur->file);
             c->errors++;
             free((void *)cur->file);
+            free((void *)cur->scan_path);
             if (NULL != cur->action_source) {
                 action_source_close(cur->action_source);
                 free(cur->action_source);
@@ -700,8 +729,11 @@ static cl_error_t parallel_callback(STATBUF *sb, char *filename, const char *pat
         goto done;
     }
 
-    cid->id            = ++c->lastid;
-    cid->file          = filename;
+    cid->id   = ++c->lastid;
+    cid->file = filename;
+    /* Keep the resolved path: a re-send must reopen what was first scanned,
+     * even if a symlink in the submitted path has been retargeted since. */
+    cid->scan_path     = real_filter_path;
     cid->action_source = action_source;
     cid->next          = c->ids;
     c->ids             = cid;
@@ -710,8 +742,9 @@ static cl_error_t parallel_callback(STATBUF *sb, char *filename, const char *pat
     }
 
     /* Give up ownership of the filename to the client parallel scan ID list */
-    filename      = NULL;
-    action_source = NULL;
+    filename         = NULL;
+    real_filter_path = NULL;
+    action_source    = NULL;
 
     status = CL_SUCCESS;
 

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -381,6 +381,15 @@ if(ENABLE_APP)
         set_property(TEST clamd_valgrind PROPERTY ENVIRONMENT ${ENVIRONMENT} VALGRIND=${Valgrind_EXECUTABLE})
     endif()
 
+    add_test(NAME clamdscan COMMAND ${PythonTest_COMMAND};clamdscan
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+    set_property(TEST clamdscan PROPERTY ENVIRONMENT ${ENVIRONMENT})
+    if(Valgrind_FOUND)
+        add_test(NAME clamdscan_valgrind COMMAND ${PythonTest_COMMAND};clamdscan
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+        set_property(TEST clamdscan_valgrind PROPERTY ENVIRONMENT ${ENVIRONMENT} VALGRIND=${Valgrind_EXECUTABLE})
+    endif()
+
     add_test(NAME freshclam COMMAND ${PythonTest_COMMAND};freshclam_test.py
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
     set_property(TEST freshclam PROPERTY ENVIRONMENT ${ENVIRONMENT})

--- a/unit_tests/clamdscan/session_restart_test.py
+++ b/unit_tests/clamdscan/session_restart_test.py
@@ -1,0 +1,497 @@
+# Copyright (C) 2026 Cisco Systems, Inc. and/or its affiliates. All rights reserved.
+
+"""Regression tests for ClamDScan IDSESSION recovery after clamd hangs up.
+
+These tests do not use a real clamd.  Making clamd drop a session in the middle
+of a scan depends on timing (a CommandReadTimeout expiry) and would be flaky.
+Instead they run clamdscan against a stand-in server that speaks just enough of
+the IDSESSION protocol and closes the connection at an exact point in the
+exchange, which makes every restart deterministic.
+"""
+
+import hashlib
+import os
+from pathlib import Path
+import platform
+import shutil
+import socket
+import struct
+import sys
+import tempfile
+import threading
+import unittest
+
+sys.path.append('../unit_tests')
+import testcase
+
+
+operating_system = platform.platform().split('-')[0].lower()
+
+# Must match MAX_SESSION_RESTARTS in clamdscan/proto.c.  It bounds restarts
+# that happen in a row without clamd answering in between, not the number of
+# disconnects a scan may recover from in total.
+MAX_SESSION_RESTARTS = 3
+
+# The stand-in server calls everything infected.  A verdict that never reaches
+# clamdscan is then visible in the infected count, which is what makes "this
+# file silently went unscanned" an assertable failure.
+SIGNATURE = 'ClamAV-Session-Restart-Test.UNOFFICIAL'
+
+# "Serve this connection normally", as opposed to a (requests, replies) drop.
+SERVE_NORMALLY = None
+
+
+class MessageReader(object):
+    """Reads the client half of the clamd protocol off a connected socket.
+
+    Every read goes through recvmsg() so that the descriptor a FILDES command
+    passes as SCM_RIGHTS ancillary data is never dropped on the floor.
+    """
+
+    def __init__(self, conn):
+        self._conn = conn
+        self._buffer = bytearray()
+        self._descriptors = []
+        self._at_eof = False
+
+    def _fill(self):
+        if self._at_eof:
+            return False
+
+        try:
+            data, ancillary, _flags, _addr = self._conn.recvmsg(
+                4096, socket.CMSG_SPACE(struct.calcsize('i')))
+        except OSError:
+            self._at_eof = True
+            return False
+
+        for level, kind, payload in ancillary:
+            if level == socket.SOL_SOCKET and kind == socket.SCM_RIGHTS:
+                count = len(payload) // struct.calcsize('i')
+                self._descriptors.extend(
+                    struct.unpack('{}i'.format(count),
+                                  payload[:count * struct.calcsize('i')]))
+
+        if not data:
+            self._at_eof = True
+            return False
+
+        self._buffer.extend(data)
+        return True
+
+    def read_exact(self, count):
+        while len(self._buffer) < count:
+            if not self._fill():
+                return None
+
+        data = bytes(self._buffer[:count])
+        del self._buffer[:count]
+        return data
+
+    def read_command(self):
+        """Returns the next NUL-terminated command, or None at end of stream."""
+        while True:
+            end = self._buffer.find(b'\0')
+            if end >= 0:
+                break
+            if not self._fill():
+                return None
+
+        command = bytes(self._buffer[:end])
+        del self._buffer[:end + 1]
+
+        # Every command clamdscan sends in a session is "z"-prefixed.
+        if command.startswith(b'z'):
+            command = command[1:]
+        return command
+
+    def read_stream(self):
+        """Reads the length-prefixed chunks that follow an INSTREAM command."""
+        payload = bytearray()
+
+        while True:
+            header = self.read_exact(4)
+            if header is None:
+                return None
+
+            size = struct.unpack('!I', header)[0]
+            if size == 0:
+                return bytes(payload)
+
+            chunk = self.read_exact(size)
+            if chunk is None:
+                return None
+            payload.extend(chunk)
+
+    def read_fildes(self):
+        """Reads the descriptor that follows a FILDES command, and its file."""
+        # The command is followed by a one byte message carrying the descriptor.
+        if self.read_exact(1) is None:
+            return None
+        if not self._descriptors:
+            return None
+
+        descriptor = self._descriptors.pop(0)
+        payload = bytearray()
+        try:
+            while True:
+                chunk = os.read(descriptor, 4096)
+                if not chunk:
+                    break
+                payload.extend(chunk)
+        finally:
+            os.close(descriptor)
+
+        return bytes(payload)
+
+
+class FakeClamd(threading.Thread):
+    """A clamd stand-in that can hang up in the middle of an IDSESSION.
+
+    `behaviors` is applied to connections in order.  Each entry is either
+    SERVE_NORMALLY, or a (requests, replies) pair meaning "answer the first this
+    many requests, then stop answering, and close the connection once this many
+    requests have arrived".  Whatever went unanswered is exactly what clamdscan
+    has to re-send.  Connections past the end of `behaviors` are served normally.
+    """
+
+    def __init__(self, socket_path, behaviors=(), accept_limit=None):
+        threading.Thread.__init__(self)
+        self.daemon = True
+
+        self.socket_path = str(socket_path)
+        self.behaviors = list(behaviors)
+        # Stop listening after this many connections, so that clamdscan's next
+        # reconnect is refused outright rather than the session merely dying.
+        self.accept_limit = accept_limit
+
+        self.connections = 0    # how many times clamdscan (re)connected
+        self.scanned = []       # digest of every file received, in order
+        self.error = None       # first protocol violation seen, if any
+
+        self._stopping = threading.Event()
+        self._listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self._listener.bind(self.socket_path)
+        self._listener.listen(8)
+        # Closing a listening socket does not wake up a blocked accept(), so
+        # poll instead of relying on the close in stop() to break the loop.
+        self._listener.settimeout(0.1)
+
+    def stop(self):
+        self._stopping.set()
+        self.join(timeout=60)
+        try:
+            self._listener.close()
+        except OSError:
+            pass
+
+    def run(self):
+        while not self._stopping.is_set():
+            try:
+                conn, _address = self._listener.accept()
+            except socket.timeout:
+                continue
+            except OSError:
+                return  # the listening socket went away
+
+            index = self.connections
+            self.connections += 1
+
+            behavior = SERVE_NORMALLY
+            if index < len(self.behaviors):
+                behavior = self.behaviors[index]
+
+            try:
+                conn.settimeout(None)
+                self._serve(conn, behavior)
+            except Exception as exc:  # noqa: BLE001 - reported back to the test
+                if self.error is None:
+                    self.error = exc
+            finally:
+                try:
+                    conn.close()
+                except OSError:
+                    pass
+
+            if self.accept_limit is not None and self.connections >= self.accept_limit:
+                try:
+                    self._listener.close()
+                except OSError:
+                    pass
+                return
+
+    def _serve(self, conn, behavior):
+        reader = MessageReader(conn)
+        last_id = 0
+        received = 0
+        answered = 0
+
+        while True:
+            command = reader.read_command()
+            if command is None:
+                return  # clamdscan closed the connection
+            if command == b'IDSESSION':
+                continue
+            if command == b'END':
+                return
+
+            if command == b'INSTREAM':
+                payload = reader.read_stream()
+                description = 'stream'
+            elif command == b'FILDES':
+                payload = reader.read_fildes()
+                description = 'fd[0]'
+            else:
+                raise AssertionError(
+                    'unexpected command from clamdscan: {}'.format(command))
+
+            if payload is None:
+                return  # truncated request; clamdscan went away mid-send
+
+            self.scanned.append(hashlib.sha256(payload).hexdigest())
+            last_id += 1
+            received += 1
+
+            if behavior is SERVE_NORMALLY or answered < behavior[1]:
+                self._reply(conn, last_id, description)
+                answered += 1
+
+            if behavior is not SERVE_NORMALLY and received >= behavior[0]:
+                # Hang up, leaving whatever went unanswered outstanding for
+                # clamdscan to re-send on a new session.
+                conn.close()
+                return
+
+    @staticmethod
+    def _reply(conn, scan_id, description):
+        conn.sendall('{}: {}: {} FOUND\0'.format(
+            scan_id, description, SIGNATURE).encode('utf-8'))
+
+
+@unittest.skipIf(operating_system == 'windows',
+                 'the stand-in clamd listens on an AF_UNIX socket.')
+class TC(testcase.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super(TC, cls).setUpClass()
+
+    @classmethod
+    def tearDownClass(cls):
+        super(TC, cls).tearDownClass()
+
+    def setUp(self):
+        super(TC, self).setUp()
+
+        self.server = None
+
+        # AF_UNIX paths are limited to ~108 bytes, and the test temp directory
+        # can be nested deeply enough to blow past that, so keep the socket in a
+        # directory of its own with a short path.
+        self.socket_dir = Path(tempfile.mkdtemp(prefix='clamdscan-sock-', dir='/tmp'))
+        self.socket_path = self.socket_dir / 'clamd.sock'
+
+        self.scan_dir = self.path_tmp / '{}-files'.format(self._testMethodName)
+        self.scan_dir.mkdir()
+
+    def tearDown(self):
+        if self.server is not None:
+            self.server.stop()
+            self.server = None
+
+        shutil.rmtree(str(self.socket_dir), ignore_errors=True)
+
+        super(TC, self).tearDown()
+        self.verify_valgrind_log()
+
+    def create_scan_files(self, count, size=0):
+        """Writes `count` files with unique contents, and returns their digests.
+
+        `size` pads each file out to at least that many bytes, for the tests
+        that need a request too large to fit in the socket buffer.
+        """
+        digests = []
+
+        for index in range(count):
+            payload = 'clamdscan-session-restart-{:04d}\n'.format(index).encode('utf-8')
+            if size > len(payload):
+                payload += b'.' * (size - len(payload))
+            (self.scan_dir / 'file-{:04d}'.format(index)).write_bytes(payload)
+            digests.append(hashlib.sha256(payload).hexdigest())
+
+        return digests
+
+    def start_fake_clamd(self, behaviors=(), accept_limit=None):
+        self.server = FakeClamd(self.socket_path, behaviors=behaviors,
+                                accept_limit=accept_limit)
+        self.server.start()
+        return self.server
+
+    def run_clamdscan(self, mode):
+        config = self.path_tmp / '{}-clamd.conf'.format(self._testMethodName)
+        config.write_text('LocalSocket {}\n'.format(self.socket_path))
+
+        return self.execute_command(
+            '{valgrind} {valgrind_args} {clamdscan} {mode} --multiscan -c {config} {target}'.format(
+                valgrind=TC.valgrind,
+                valgrind_args=TC.valgrind_args,
+                clamdscan=TC.clamdscan,
+                mode=mode,
+                config=config,
+                target=self.scan_dir))
+
+    def assert_server_healthy(self):
+        if self.server.error is not None:
+            raise self.server.error
+
+    def test_session_restart_01_stream_resends_outstanding(self):
+        """A mid-session hangup re-sends every unanswered stream request."""
+        self.step_name('Testing IDSESSION recovery in --stream mode')
+
+        expected = self.create_scan_files(20)
+
+        # Take 5 requests, answer 2 of them, then hang up: 3 requests are left
+        # outstanding and must reappear on the second session.
+        self.start_fake_clamd(behaviors=[(5, 2)])
+
+        output = self.run_clamdscan('--stream')
+        self.assert_server_healthy()
+
+        assert output.ec == 1  # everything is "infected", nothing errored
+
+        self.verify_output(output.err, expected=[
+            r'Connection to clamd lost \(restart 1/{}\)'.format(MAX_SESSION_RESTARTS),
+            r'outstanding request\(s\)',
+        ])
+        # Every file must come back with a verdict, including the re-sent ones.
+        self.verify_output(output.out, expected=['Infected files: 20'])
+        self.verify_output(output.out, unexpected=['Total errors:'])
+
+        assert self.server.connections == 2
+        assert set(self.server.scanned) == set(expected)
+
+    @unittest.skipIf(operating_system == 'windows', 'no FD passing on Windows')
+    def test_session_restart_02_fdpass_resends_outstanding(self):
+        """The same recovery, over the separate FD passing code path."""
+        self.step_name('Testing IDSESSION recovery in --fdpass mode')
+
+        expected = self.create_scan_files(20)
+
+        self.start_fake_clamd(behaviors=[(5, 2)])
+
+        output = self.run_clamdscan('--fdpass')
+        self.assert_server_healthy()
+
+        assert output.ec == 1
+
+        self.verify_output(output.err, expected=[
+            r'Connection to clamd lost \(restart 1/{}\)'.format(MAX_SESSION_RESTARTS),
+            r'outstanding request\(s\)',
+        ])
+        self.verify_output(output.out, expected=['Infected files: 20'])
+
+        assert self.server.connections == 2
+        assert set(self.server.scanned) == set(expected)
+
+    def test_session_restart_03_recovers_when_the_new_session_dies_too(self):
+        """A hangup that lands while re-sending is recovered from as well."""
+        self.step_name('Testing IDSESSION recovery when the new session also dies')
+
+        # The requests are sized so that the whole backlog does not fit in the
+        # socket buffer.  clamdscan is then still in send() when the second
+        # session is dropped, so the re-send itself fails rather than the
+        # failure only turning up on the following read.  That is the path that
+        # has to put the request back on the outstanding list.
+        expected = self.create_scan_files(20, size=64 * 1024)
+
+        # The first session dies with several requests outstanding; the
+        # replacement session then dies while those are being re-sent.
+        self.start_fake_clamd(behaviors=[(6, 0), (1, 0)])
+
+        output = self.run_clamdscan('--stream')
+        self.assert_server_healthy()
+
+        assert output.ec == 1
+
+        self.verify_output(output.err, expected=[
+            r'Connection to clamd lost \(restart 2/{}\)'.format(MAX_SESSION_RESTARTS),
+        ])
+        # A request dropped by the second failure would silently never be
+        # scanned again, leaving the count short.
+        self.verify_output(output.out, expected=['Infected files: 20'])
+        self.verify_output(output.out, unexpected=['Total errors:'])
+
+        assert self.server.connections == 3
+        assert set(self.server.scanned) == set(expected)
+
+    def test_session_restart_04_gives_up_after_max_restarts(self):
+        """clamdscan stops reconnecting once the restart budget is spent."""
+        self.step_name('Testing the IDSESSION restart budget')
+
+        self.create_scan_files(20)
+
+        # Every session dies after a single request and answers nothing, so no
+        # amount of reconnecting will make progress.
+        self.start_fake_clamd(behaviors=[(1, 0)] * (MAX_SESSION_RESTARTS + 5))
+
+        output = self.run_clamdscan('--stream')
+        self.assert_server_healthy()
+
+        assert output.ec == 2  # gave up with an error
+
+        self.verify_output(output.err, expected=[
+            'Connection to clamd lost {} consecutive times, giving up'.format(MAX_SESSION_RESTARTS),
+        ])
+
+        # The original connection plus one per restart, and not one more.
+        assert self.server.connections == MAX_SESSION_RESTARTS + 1
+
+    def test_session_restart_05_budget_only_counts_consecutive_failures(self):
+        """Disconnects that the scan recovers from do not use up the budget."""
+        self.step_name('Testing that the IDSESSION restart budget resets on progress')
+
+        file_count = 40
+
+        # Sized so that clamdscan cannot run far ahead of the server: the
+        # backlog left behind by a hangup stays small enough for the next
+        # session to absorb it, which is what a healthy clamd would do.
+        expected = self.create_scan_files(file_count, size=64 * 1024)
+
+        # Every session answers a few requests and then hangs up.  That is far
+        # more disconnects than the budget allows, but the scan makes progress
+        # across each one, so it has to run to completion rather than give up.
+        self.start_fake_clamd(behaviors=[(5, 5)] * file_count)
+
+        output = self.run_clamdscan('--stream')
+        self.assert_server_healthy()
+
+        assert output.ec == 1
+
+        self.verify_output(output.out, expected=['Infected files: {}'.format(file_count)])
+        self.verify_output(output.err, unexpected=['giving up'])
+
+        assert self.server.connections > MAX_SESSION_RESTARTS + 1
+        assert set(self.server.scanned) == set(expected)
+
+    def test_session_restart_06_releases_outstanding_when_reconnect_fails(self):
+        """Giving up on a reconnect must not leak the outstanding requests."""
+        self.step_name('Testing cleanup when the session cannot be restored')
+
+        self.create_scan_files(20)
+
+        # The session dies with requests outstanding and nothing is listening
+        # afterwards, so clamdscan gives up straight away.  Under Valgrind this
+        # is where the requests it was still holding would show up as leaked.
+        self.start_fake_clamd(behaviors=[(5, 0)], accept_limit=1)
+
+        output = self.run_clamdscan('--stream')
+        self.assert_server_healthy()
+
+        assert output.ec == 2  # gave up with an error, nothing was reported
+
+        self.verify_output(output.err, expected=['Could not connect to clamd'])
+        # Reconnecting is not retried, so the restart budget is untouched.
+        self.verify_output(output.err, unexpected=['giving up'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/unit_tests/clamdscan/session_restart_test.py
+++ b/unit_tests/clamdscan/session_restart_test.py
@@ -152,10 +152,17 @@ class FakeClamd(threading.Thread):
     SERVE_NORMALLY, or a (requests, replies) pair meaning "answer the first this
     many requests, then stop answering, and close the connection once this many
     requests have arrived".  Whatever went unanswered is exactly what clamdscan
-    has to re-send.  Connections past the end of `behaviors` are served normally.
+    has to re-send.  A pair may carry a third element, a callable run just
+    before that hangup.  Connections past the end of `behaviors` are served
+    normally.
+
+    `reply_buffer` shrinks the send buffer of every accepted connection, so
+    that replying blocks until clamdscan reads: the back-pressure of a clamd
+    whose threads are all stuck in send().
     """
 
-    def __init__(self, socket_path, behaviors=(), accept_limit=None):
+    def __init__(self, socket_path, behaviors=(), accept_limit=None,
+                 reply_buffer=None):
         threading.Thread.__init__(self)
         self.daemon = True
 
@@ -164,6 +171,7 @@ class FakeClamd(threading.Thread):
         # Stop listening after this many connections, so that clamdscan's next
         # reconnect is refused outright rather than the session merely dying.
         self.accept_limit = accept_limit
+        self.reply_buffer = reply_buffer
 
         self.connections = 0    # how many times clamdscan (re)connected
         self.scanned = []       # digest of every file received, in order
@@ -203,6 +211,9 @@ class FakeClamd(threading.Thread):
 
             try:
                 conn.settimeout(None)
+                if self.reply_buffer is not None:
+                    conn.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF,
+                                    self.reply_buffer)
                 self._serve(conn, behavior)
             except Exception as exc:  # noqa: BLE001 - reported back to the test
                 if self.error is None:
@@ -259,6 +270,8 @@ class FakeClamd(threading.Thread):
             if behavior is not SERVE_NORMALLY and received >= behavior[0]:
                 # Hang up, leaving whatever went unanswered outstanding for
                 # clamdscan to re-send on a new session.
+                if len(behavior) > 2:
+                    behavior[2]()
                 conn.close()
                 return
 
@@ -320,13 +333,14 @@ class TC(testcase.TestCase):
 
         return digests
 
-    def start_fake_clamd(self, behaviors=(), accept_limit=None):
+    def start_fake_clamd(self, behaviors=(), accept_limit=None, reply_buffer=None):
         self.server = FakeClamd(self.socket_path, behaviors=behaviors,
-                                accept_limit=accept_limit)
+                                accept_limit=accept_limit,
+                                reply_buffer=reply_buffer)
         self.server.start()
         return self.server
 
-    def run_clamdscan(self, mode):
+    def run_clamdscan(self, mode, target=None):
         config = self.path_tmp / '{}-clamd.conf'.format(self._testMethodName)
         config.write_text('LocalSocket {}\n'.format(self.socket_path))
 
@@ -337,7 +351,7 @@ class TC(testcase.TestCase):
                 clamdscan=TC.clamdscan,
                 mode=mode,
                 config=config,
-                target=self.scan_dir))
+                target=target if target is not None else self.scan_dir))
 
     def assert_server_healthy(self):
         if self.server.error is not None:
@@ -491,6 +505,71 @@ class TC(testcase.TestCase):
         self.verify_output(output.err, expected=['Could not connect to clamd'])
         # Reconnecting is not retried, so the restart budget is untouched.
         self.verify_output(output.err, unexpected=['giving up'])
+
+    def test_session_restart_07_resends_the_resolved_path(self):
+        """A re-send reopens the file the verdict will be reported for, even if
+        a symlink in the submitted path has been retargeted since."""
+        self.step_name('Testing that a re-send uses the resolved scan path')
+
+        submitted = b'the file that was submitted\n'
+
+        original = self.scan_dir / 'original'
+        original.mkdir()
+        (original / 'file.dat').write_bytes(submitted)
+        replacement = self.scan_dir / 'replacement'
+        replacement.mkdir()
+        (replacement / 'file.dat').write_bytes(b'the file swapped in afterwards\n')
+
+        link = self.scan_dir / 'link'
+        link.symlink_to(original, target_is_directory=True)
+
+        def retarget_link():
+            staged = self.scan_dir / 'staged-link'
+            staged.symlink_to(replacement, target_is_directory=True)
+            os.replace(staged, link)
+
+        # The session dies right after the request arrives, and the symlink is
+        # retargeted before clamdscan gets to re-send.
+        self.start_fake_clamd(behaviors=[(1, 0, retarget_link)])
+
+        output = self.run_clamdscan('--stream', target=link / 'file.dat')
+        self.assert_server_healthy()
+
+        assert output.ec == 1
+
+        self.verify_output(output.out, expected=['Infected files: 1'])
+
+        # Both sessions must have received the originally scanned file, not
+        # whatever the link points at by re-send time.
+        digest = hashlib.sha256(submitted).hexdigest()
+        assert self.server.scanned == [digest, digest]
+
+    def test_session_restart_08_drains_replies_while_resending(self):
+        """Replies arriving during a re-send are consumed, so a clamd that
+        cannot take more requests until they are does not deadlock the scan."""
+        self.step_name('Testing that a re-send does not deadlock on unread replies')
+
+        file_count = 200
+
+        # Far more data than fits in the socket buffers, so an unread backlog
+        # is guaranteed to stall the re-send.
+        expected = self.create_scan_files(file_count, size=64 * 1024)
+
+        # The first session takes everything and answers nothing, leaving the
+        # whole scan to be re-sent.  The second answers every request, but its
+        # shrunken send buffer only lets it keep reading if clamdscan consumes
+        # the replies while still re-sending.
+        self.start_fake_clamd(behaviors=[(file_count, 0)], reply_buffer=4096)
+
+        output = self.run_clamdscan('--stream')
+        self.assert_server_healthy()
+
+        assert output.ec == 1
+
+        self.verify_output(output.out, expected=['Infected files: {}'.format(file_count)])
+
+        assert self.server.connections == 2
+        assert set(self.server.scanned) == set(expected)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
In --multiscan mode clamdscan pipelines scan requests over a single IDSESSION connection. If that connection died, the scan was abandoned: every request still awaiting a verdict was silently dropped and the remaining files were never scanned.

Re-establish the session and re-send every outstanding request under a fresh id, giving up after 3 restarts in a row without a verdict in between, with a doubling delay between them.

The tests use a stand-in server that hangs up at an exact point in the exchange; making a real clamd drop a session would be timing-dependent.

## Real-world results

Previously, the following scan of a ~4M-file home directory always died after ~1M requests when clamd dropped the IDSESSION connection without logging anything, but with the patch it survives two disconnects and completes:

```
$ sudo clamdscan --multiscan --fdpass --infected --log=clamdscan.log $HOME
--------------------------------------
...
ERROR: Communication error
WARNING: Connection to clamd lost (restart 1/3); last request before disconnect: /home/shugo/.rbenv/versions/2.7.7/lib/ruby/gems/2.7.0/gems/rake-13.0.1/.github/workflows/windows.yml; re-sending 101 outstanding request(s)
/home/shugo/src/ruby-devcontainer/clamav/build/unit_tests/input/clamav_hdb_scanfiles/clam.exe.rtf: Clamav.Test.File-6 FOUND
...
----------- SCAN SUMMARY -----------
Infected files: 53
Total errors: 309
Time: 10826.240 sec (180 m 26 s)
Start Date: 2026:08:20 14:30:32
End Date:   2026:08:20 17:30:58
```
