### PR TITLE
cmake: prefer the system allocator over mpool where it is better

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1013,9 +1013,6 @@ if(APPLE)
 endif()
 
 include(CheckFmapFeatures)
-if(WIN32)
-    set(USE_MPOOL 1)
-endif()
 
 add_definitions(-DHAVE_CONFIG_H)
 configure_file(clamav-config.h.cmake.in clamav-config.h)

--- a/cmake/CheckFmapFeatures.cmake
+++ b/cmake/CheckFmapFeatures.cmake
@@ -145,15 +145,66 @@ check_c_source_compiles(
     HAVE_SYSCONF_SC_PAGESIZE
 )
 
-# Check for mempool support
+# Which general-purpose allocator will libclamav be using?
+#
+# mpool outperforms glibc malloc, but not jemalloc or tcmalloc. Where one
+# of those is already in use the pool costs memory instead of saving it,
+# so prefer it. Nothing below runs a test program: cross compiling is
+# unaffected (see PR #90), and no library is added to the link line -
+# choosing the allocator stays the packager's decision.
+set(CLAMAV_ALLOCATOR "system")
+
+if(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+    # FreeBSD ships jemalloc as libc's malloc. Decided on the platform
+    # rather than probed, so that a probe failing for an unrelated
+    # reason cannot silently leave mpool enabled. STREQUAL, not MATCHES:
+    # GNU/kFreeBSD is glibc.
+    set(CLAMAV_ALLOCATOR "jemalloc")
+else()
+    # Only detectable when the allocator is on the probe's link line.
+    # LD_PRELOAD is not visible at configure time; nor is
+    # LDFLAGS=-ljemalloc, which CMake places ahead of the object file
+    # where --as-needed discards it. Use -D ENABLE_MPOOL=OFF for those.
+    check_symbol_exists(mallocx "jemalloc/jemalloc.h" HAVE_JEMALLOC_HEADER)
+    check_symbol_exists(tc_malloc_size "gperftools/tcmalloc.h" HAVE_TCMALLOC_HEADER)
+
+    if(HAVE_JEMALLOC_HEADER)
+        set(CLAMAV_ALLOCATOR "jemalloc")
+    elseif(HAVE_TCMALLOC_HEADER)
+        set(CLAMAV_ALLOCATOR "tcmalloc")
+    endif()
+endif()
+message(STATUS "General-purpose allocator detected: ${CLAMAV_ALLOCATOR}")
+
+# ENABLE_MPOOL: ON always, OFF never, AUTO (default) unless a better
+# allocator was detected. See #1377.
+if(NOT DEFINED ENABLE_MPOOL)
+    set(ENABLE_MPOOL "AUTO" CACHE STRING
+        "Use the built-in mpool allocator: ON, OFF, or AUTO (AUTO disables it when jemalloc or tcmalloc is detected)")
+endif()
+set_property(CACHE ENABLE_MPOOL PROPERTY STRINGS ON OFF AUTO)
+
+# DISABLE_MPOOL predates ENABLE_MPOOL and is still set by existing
+# packaging.
 if(DISABLE_MPOOL)
-    message("****** mempool support disabled (DISABLE_MPOOL enabled)")
+    set(ENABLE_MPOOL OFF)
+endif()
+
+# Check for mempool support
+if(ENABLE_MPOOL STREQUAL "OFF" OR NOT ENABLE_MPOOL)
+    message("****** mempool support disabled (ENABLE_MPOOL=OFF)")
+elseif(WIN32)
+    # Windows has no mmap and mpool uses its own backend, so the checks
+    # below do not apply to it.
+    set(USE_MPOOL 1)
 elseif(NOT HAVE_MMAP)
     message("****** mempool support disabled (mmap() not available or not usable)")
 elseif(NOT HAVE_GETPAGESIZE AND NOT HAVE_SYSCONF_SC_PAGESIZE)
     message("****** mempool support disabled (pagesize cannot be determined)")
 elseif(NOT HAVE_MMAP_MAP_ANON AND NOT HAVE_MMAP_MAP_ANONYMOUS)
     message("****** mempool support disabled (anonymous mmap not available)")
+elseif(ENABLE_MPOOL STREQUAL "AUTO" AND NOT CLAMAV_ALLOCATOR STREQUAL "system")
+    message("****** mempool support disabled (${CLAMAV_ALLOCATOR} detected; use -D ENABLE_MPOOL=ON to override)")
 else()
     set(USE_MPOOL 1)
 endif()


### PR DESCRIPTION
mpool was added in 2008 to avoid the overhead and fragmentation of the
allocators of that era. Its size classes were last regenerated in 2010. That
premise still holds against glibc and no longer holds against jemalloc or
tcmalloc.

Same engine, same 424 MB signature set (main + daily + bytecode + a
third-party set, 3,849,249 signatures), resident memory after
`cl_engine_compile()`:

| Allocator | RSS | vs mpool |
|---|---:|---:|
| mpool (as shipped) | 1,135,424 KB | — |
| glibc malloc 2.39 | 1,373,416 KB | +237,992 KB |
| jemalloc | 1,118,800 KB | -16,624 KB |
| tcmalloc | 1,084,452 KB | -50,972 KB |

FreeBSD ships jemalloc as libc's malloc, so this build disables mpool by default to get
a net memory improvement.

### What the change does

- FreeBSD is decided from `CMAKE_SYSTEM_NAME`. A header probe was tried first
  and rejected: on an unrelated failure it silently leaves mpool enabled,
  which is the expensive answer and an invisible one.
- Elsewhere, a link probe finds jemalloc or gperftools tcmalloc when the build
  names them.
- Nothing is executed, so cross compiling is unaffected (PR #90).
- Nothing is added to the link line; choosing the allocator stays the
  packager's decision.
- `LD_PRELOAD` is not visible at configure time. `-D ENABLE_MPOOL=OFF` covers
  that case and the option help says so.

### Resolves #1377

`ENABLE_MPOOL` becomes a documented `ON`/`OFF`/`AUTO` tri-state with
`set_property(... STRINGS ...)`. `DISABLE_MPOOL` keeps working, so existing
packaging does not break. Reported by @dilyanpalauzov.

### Testing

Each case configured, then the decision read back from the generated
`clamav-config.h` rather than from the configure log. 9/9:

| Case | Detected | mpool |
|---|---|---|
| default (glibc) | system | kept |
| `ENABLE_MPOOL=OFF` | system | disabled |
| `ENABLE_MPOOL=ON` | system | kept |
| `DISABLE_MPOOL=ON` (legacy) | system | disabled |
| `DISABLE_MPOOL=0` (legacy) | system | kept |
| jemalloc on the probe link line | jemalloc | disabled |
| jemalloc + `ENABLE_MPOOL=ON` | jemalloc | kept |
| `LDFLAGS=-ljemalloc` | system | kept |
| tcmalloc on the probe link line | tcmalloc | disabled |

The `LDFLAGS` row asserts a negative: CMake places linker flags ahead of the
object file, where `--as-needed` discards them, so that case is not
detectable.

`ENABLE_TESTS=ON`, `ctest`, idle machine:

| | pass rate | failures |
|---|---|---|
| `origin/main` | 82% (9/11) | `clamscan`, `clamscan_valgrind` |
| this branch | 82% (9/11) | `clamscan`, `clamscan_valgrind` |

Identical failure sets. Both failures are pre-existing and unrelated:
`unit_tests/CMakeLists.txt:366,370` pass a test *name* to `python3 -m
unittest` where the sibling `clamd` entry passes a module *file*, and there is
no `clamscan_test.py` in the tree.