### PR TITLE
cmake/FindCURSES: account for libtinfow

### DIFF
--- a/cmake/FindCURSES.cmake
+++ b/cmake/FindCURSES.cmake
@@ -73,6 +73,11 @@ if(NCURSES_NOT_FOUND EQUAL -1)
         )
     endif()
 
+    find_library(TINFO_LIBRARY
+        NAMES tinfo tinfow
+        PATHS ${PC_NCurses_LIBRARY_DIRS}
+    )
+
     include(FindPackageHandleStandardArgs)
     find_package_handle_standard_args(CURSES
         FOUND_VAR CURSES_FOUND


### PR DESCRIPTION
Closes: https://github.com/Cisco-Talos/clamav/issues/1623

I am adding this not because that I am confident that this is the right approach.  I am submitting proposal for code change, because I do not want to apply this patche with every new clamav release.