### PR TITLE
libclamav: front-code the virus names of hash signatures

### DIFF
--- a/libclamav/matcher-hash.c
+++ b/libclamav/matcher-hash.c
@@ -21,6 +21,9 @@
 
 #include <string.h>
 #include <stdlib.h>
+#ifdef CL_THREAD_SAFE
+#include <pthread.h>
+#endif
 
 #include "matcher.h"
 #include "others.h"
@@ -121,6 +124,691 @@ cl_error_t cli_hash_type_from_name(const char *name, cli_hash_type_t *type_out)
     return CL_SUCCESS;
 }
 
+/* ------------------------------------------------------------------ *
+ * The name store
+ *
+ * See matcher-hash.h for the shape. Everything here is either load-time
+ * (single threaded, from cli_loadhash() and friends) or match-time
+ * (multi threaded, from cli_hm_scan()); nothing in between.
+ * ------------------------------------------------------------------ */
+
+/** Bytes per chunk of the load-time name arena. A name may not straddle
+ * two chunks: an offset is turned back into a chunk and a position by
+ * dividing by this. */
+#define HM_NAMETMP_CHUNK (1024 * 1024)
+
+/** Slots the decoded-name cache is first allocated with. */
+#define HM_NAME_CACHE_INIT 64
+
+/** The cache grows once it is this full, numerator over denominator.
+ * Linear probing degrades sharply past about seven tenths. */
+#define HM_NAME_CACHE_LOAD_NUM 7
+#define HM_NAME_CACHE_LOAD_DEN 10
+
+/** Multiplier of the cache's hash: 2^32 divided by the golden ratio,
+ * Knuth's constant for multiplicative hashing. Odd, so the mapping onto
+ * the capacity mask is one to one. */
+#define HM_NAME_CACHE_MULT 2654435761U
+
+/** Decoded names, by entry number. Open addressing, plain malloc: this
+ * is written while scanning, and the pool has no lock of its own. */
+struct hm_namecache {
+    uint32_t *keys; /* entry number + 1; 0 marks a free slot */
+    char **vals;
+    uint32_t capacity; /* power of two, 0 while empty */
+    uint32_t used;
+};
+
+struct cli_hm_names {
+    /* Load time only. Freed whole by hm_flush(). */
+    char **chunks;
+    uint32_t nchunks;
+    uint32_t chunk_used;
+
+    /* Built once by hm_flush(), in the pool, at its final size. */
+    uint8_t *blob;
+    uint32_t blob_len;
+    uint32_t *block_off;
+    uint32_t nblocks;
+    uint32_t count;
+
+    /* Match time. */
+    struct hm_namecache cache;
+    int ready; /* blob, block_off and mutex are all usable */
+#ifdef CL_THREAD_SAFE
+    pthread_mutex_t mutex;
+#endif
+};
+
+static const char *hm_name_tmp(const struct cli_hm_names *nm, uint32_t off)
+{
+    return nm->chunks[off / HM_NAMETMP_CHUNK] + (off % HM_NAMETMP_CHUNK);
+}
+
+/* Copies name into the load-time arena and returns its offset, or
+ * HM_NAME_NONE for a signature added without a name. */
+static cl_error_t hm_name_store(struct cli_matcher *root, const char *name, uint32_t *off_out)
+{
+    struct cli_hm_names *nm;
+    size_t len;
+
+    if (!name) {
+        *off_out = HM_NAME_NONE;
+        return CL_SUCCESS;
+    }
+
+    if (!root->hm_names) {
+        root->hm_names = MPOOL_CALLOC(root->mempool, 1, sizeof(*root->hm_names));
+        if (!root->hm_names) {
+            cli_errmsg("hm_name_store: failed to allocate the name store\n");
+            return CL_EMEM;
+        }
+    }
+    nm = root->hm_names;
+
+    len = strlen(name) + 1;
+    if (len > HM_NAMETMP_CHUNK) {
+        cli_errmsg("hm_name_store: signature name of %zu bytes is too long\n", len);
+        return CL_EMALFDB;
+    }
+
+    if (!nm->nchunks || nm->chunk_used + len > HM_NAMETMP_CHUNK) {
+        char **nc;
+        char *chunk;
+
+        if ((uint64_t)(nm->nchunks + 1) * HM_NAMETMP_CHUNK >= HM_NAME_NONE) {
+            cli_errmsg("hm_name_store: too many signature names to index\n");
+            return CL_EMEM;
+        }
+
+        nc = cli_safer_realloc(nm->chunks, sizeof(*nm->chunks) * (nm->nchunks + 1));
+        if (!nc) {
+            cli_errmsg("hm_name_store: failed to grow the name arena\n");
+            return CL_EMEM;
+        }
+        nm->chunks = nc;
+
+        chunk = malloc(HM_NAMETMP_CHUNK);
+        if (!chunk) {
+            cli_errmsg("hm_name_store: failed to allocate a name chunk\n");
+            return CL_EMEM;
+        }
+
+        nm->chunks[nm->nchunks++] = chunk;
+        nm->chunk_used            = 0;
+    }
+
+    *off_out = (nm->nchunks - 1) * HM_NAMETMP_CHUNK + nm->chunk_used;
+    memcpy(nm->chunks[nm->nchunks - 1] + nm->chunk_used, name, len);
+    nm->chunk_used += (uint32_t)len;
+
+    return CL_SUCCESS;
+}
+
+static void hm_nametmp_free(struct cli_hm_names *nm)
+{
+    uint32_t i;
+
+    for (i = 0; i < nm->nchunks; i++)
+        free(nm->chunks[i]);
+    free(nm->chunks);
+
+    nm->chunks     = NULL;
+    nm->nchunks    = 0;
+    nm->chunk_used = 0;
+}
+
+/** A length in the blob is a single byte, unless it is this value, which
+ * escapes to a 32-bit little-endian length in the four bytes after it. */
+#define HM_LEN_ESCAPE 0xff
+
+/** Bytes an escaped length occupies: the escape and the four value bytes. */
+#define HM_LEN_ESCAPE_BYTES 5
+
+static uint32_t hm_len_bytes(uint32_t v)
+{
+    return (v < HM_LEN_ESCAPE) ? 1 : HM_LEN_ESCAPE_BYTES;
+}
+
+static void hm_put_len(uint8_t *p, uint32_t *pos, uint32_t v)
+{
+    if (v < HM_LEN_ESCAPE) {
+        p[(*pos)++] = (uint8_t)v;
+        return;
+    }
+    p[(*pos)++] = HM_LEN_ESCAPE;
+    p[(*pos)++] = (uint8_t)v;
+    p[(*pos)++] = (uint8_t)(v >> 8);
+    p[(*pos)++] = (uint8_t)(v >> 16);
+    p[(*pos)++] = (uint8_t)(v >> 24);
+}
+
+/* Reads a length, or HM_NAME_NONE if the blob ends inside one. A real
+ * length can never be HM_NAME_NONE: a name is shorter than a chunk. */
+static uint32_t hm_get_len(const uint8_t *p, uint32_t *pos, uint32_t end)
+{
+    uint32_t v;
+
+    if (*pos >= end)
+        return HM_NAME_NONE;
+
+    v = p[(*pos)++];
+    if (v == HM_LEN_ESCAPE) {
+        if (*pos + 4 > end)
+            return HM_NAME_NONE;
+        v = (uint32_t)p[*pos] | ((uint32_t)p[*pos + 1] << 8) |
+            ((uint32_t)p[*pos + 2] << 16) | ((uint32_t)p[*pos + 3] << 24);
+        *pos += 4;
+    }
+
+    return v;
+}
+
+/** Sets in the array hm_collect_sets() builds before it has to grow it. */
+#define HM_NAME_SETS_INIT 64
+
+/* Every hash set of a root, in one order that all three passes below
+ * agree on: a signature is paired with its name by counting positions,
+ * so the traversal must not vary between them. */
+static cl_error_t hm_collect_sets(struct cli_matcher *root, struct cli_sz_hash ***sets_out, uint32_t *nsets_out)
+{
+    cli_hash_type_t type;
+    struct cli_sz_hash **sets = NULL;
+    uint32_t n = 0, cap = 0;
+
+    for (type = CLI_HASH_MD5; type < CLI_HASH_AVAIL_TYPES; type++) {
+        struct cli_htu32 *ht                 = &root->hm.sizehashes[type];
+        const struct cli_htu32_element *item = NULL;
+
+        if (!ht->capacity)
+            continue;
+
+        while ((item = cli_htu32_next(ht, item))) {
+            if (n == cap) {
+                struct cli_sz_hash **ns;
+
+                cap = cap ? cap * 2 : 64;
+                ns  = cli_safer_realloc(sets, sizeof(*sets) * cap);
+                if (!ns) {
+                    free(sets);
+                    return CL_EMEM;
+                }
+                sets = ns;
+            }
+            sets[n++] = (struct cli_sz_hash *)item->data.as_ptr;
+        }
+    }
+
+    for (type = CLI_HASH_MD5; type < CLI_HASH_AVAIL_TYPES; type++) {
+        if (n == cap) {
+            struct cli_sz_hash **ns;
+
+            cap = cap ? cap * 2 : 64;
+            ns  = cli_safer_realloc(sets, sizeof(*sets) * cap);
+            if (!ns) {
+                free(sets);
+                return CL_EMEM;
+            }
+            sets = ns;
+        }
+        sets[n++] = &root->hwild.hashes[type];
+    }
+
+    *sets_out  = sets;
+    *nsets_out = n;
+
+    return CL_SUCCESS;
+}
+
+/** Bits of the arena offset the presort takes per counting pass; two
+ * passes at this width cover a 32-bit offset. */
+#define HM_PRESORT_BITS 16
+#define HM_PRESORT_RADIX (1u << HM_PRESORT_BITS)
+#define HM_PRESORT_MASK (HM_PRESORT_RADIX - 1)
+
+/* Puts the entry order into arena order - the order the names were
+ * written in - before a single byte of any name is compared.
+ *
+ * The order that arrives here is the order the hash tables were walked
+ * in, which bears no relation to where a name sits in the arena, so
+ * every merge pass below would be a random walk over it and the sort
+ * would spend its time waiting for memory rather than comparing. Two
+ * counting passes over one digit of the offset cost a sequential sweep
+ * each and hand the merge an input whose pages are already resident.
+ *
+ * This is an optimisation and nothing else - the sort is correct
+ * without it - so a failed allocation skips it rather than failing the
+ * load. */
+static void hm_name_presort(const uint32_t *off, uint32_t *idx, uint32_t *scratch, uint32_t n)
+{
+    uint32_t *cnt;
+    uint32_t i, k;
+
+    cnt = calloc(HM_PRESORT_RADIX + 1, sizeof(*cnt));
+    if (!cnt)
+        return;
+
+    for (i = 0; i < n; i++)
+        cnt[(off[idx[i]] & HM_PRESORT_MASK) + 1]++;
+    for (k = 1; k <= HM_PRESORT_RADIX; k++)
+        cnt[k] += cnt[k - 1];
+    for (i = 0; i < n; i++)
+        scratch[cnt[off[idx[i]] & HM_PRESORT_MASK]++] = idx[i];
+
+    memset(cnt, 0, (HM_PRESORT_RADIX + 1) * sizeof(*cnt));
+
+    for (i = 0; i < n; i++)
+        cnt[((off[scratch[i]] >> HM_PRESORT_BITS) & HM_PRESORT_MASK) + 1]++;
+    for (k = 1; k <= HM_PRESORT_RADIX; k++)
+        cnt[k] += cnt[k - 1];
+    for (i = 0; i < n; i++)
+        idx[cnt[(off[scratch[i]] >> HM_PRESORT_BITS) & HM_PRESORT_MASK]++] = scratch[i];
+
+    free(cnt);
+}
+
+/* Bottom-up merge sort of the entry order by name. Not the quicksort
+ * hm_sort() uses on hashes: names arrive in database order, which is
+ * often close to sorted, and a first-element pivot over millions of
+ * entries would degrade badly on exactly that input. */
+static void hm_name_msort(const struct cli_hm_names *nm, const uint32_t *off, uint32_t *idx, uint32_t *scratch, uint32_t n)
+{
+    uint32_t width;
+
+    for (width = 1; width < n; width *= 2) {
+        uint32_t i;
+
+        for (i = 0; i < n; i += 2 * width) {
+            uint32_t l = i;
+            uint32_t m = i + width;
+            uint32_t r = i + 2 * width;
+            uint32_t a, b, k;
+
+            if (m > n) m = n;
+            if (r > n) r = n;
+
+            a = l;
+            b = m;
+            k = l;
+
+            while (a < m && b < r) {
+                if (strcmp(hm_name_tmp(nm, off[idx[a]]), hm_name_tmp(nm, off[idx[b]])) <= 0)
+                    scratch[k++] = idx[a++];
+                else
+                    scratch[k++] = idx[b++];
+            }
+            while (a < m)
+                scratch[k++] = idx[a++];
+            while (b < r)
+                scratch[k++] = idx[b++];
+        }
+
+        memcpy(idx, scratch, sizeof(*idx) * n);
+    }
+}
+
+/** Bytes the front-coded blob starts at before it has to be grown. */
+#define HM_NAME_BLOB_INIT (64 * 1024)
+
+/* Sorts the names, writes the front-coded blob and the block offsets,
+ * and turns every signature's arena offset into an entry number. */
+static cl_error_t hm_names_build(struct cli_matcher *root)
+{
+    struct cli_hm_names *nm   = root->hm_names;
+    struct cli_sz_hash **sets = NULL;
+    uint32_t nsets = 0, named = 0, s, i, j;
+    uint32_t *off = NULL, *idx = NULL, *scratch = NULL;
+    uint8_t *blob       = NULL;
+    uint32_t *block_off = NULL;
+    uint32_t blob_len = 0, blob_cap = 0, nblocks = 0, entries = 0;
+    const char *prev = NULL;
+    cl_error_t ret   = CL_EMEM;
+
+    if (CL_SUCCESS != (ret = hm_collect_sets(root, &sets, &nsets)))
+        return ret;
+
+    for (s = 0; s < nsets; s++)
+        for (i = 0; i < sets[s]->items; i++)
+            if (sets[s]->name_idx[i] != HM_NAME_NONE)
+                named++;
+
+    if (!nm || !named) {
+        free(sets);
+        return CL_SUCCESS;
+    }
+
+    off     = malloc(sizeof(*off) * named);
+    idx     = malloc(sizeof(*idx) * named);
+    scratch = malloc(sizeof(*scratch) * named);
+    if (!off || !idx || !scratch) {
+        cli_errmsg("hm_names_build: failed to allocate %u name slots\n", named);
+        goto done;
+    }
+
+    j = 0;
+    for (s = 0; s < nsets; s++)
+        for (i = 0; i < sets[s]->items; i++)
+            if (sets[s]->name_idx[i] != HM_NAME_NONE) {
+                off[j] = sets[s]->name_idx[i];
+                idx[j] = j;
+                j++;
+            }
+
+    hm_name_presort(off, idx, scratch, named);
+    hm_name_msort(nm, off, idx, scratch, named);
+
+    /* Every one of these arrays is four bytes per hash signature, so
+     * each one is given up as soon as it is dead: this runs while the
+     * whole name arena is still live, and that is the process's peak. */
+    free(scratch);
+    scratch = NULL;
+
+    nblocks   = (named + HM_NAME_BLOCK - 1) / HM_NAME_BLOCK;
+    block_off = malloc(sizeof(*block_off) * nblocks);
+    if (!block_off) {
+        cli_errmsg("hm_names_build: failed to allocate %u block offsets\n", nblocks);
+        goto done;
+    }
+
+    for (j = 0; j < named; j++) {
+        const char *cur = hm_name_tmp(nm, off[idx[j]]);
+        uint32_t lcp    = 0;
+        uint32_t len    = (uint32_t)strlen(cur);
+
+        if (prev && !strcmp(prev, cur)) {
+            /* Equal names collapse onto one entry; there are few of
+             * them, but they cost nothing to fold in here. */
+            off[idx[j]] = entries - 1;
+            continue;
+        }
+
+        if (entries % HM_NAME_BLOCK == 0) {
+            /* A restart point: nothing inherited, so a decode can begin
+             * here. This is what block_off[] indexes. */
+            block_off[entries / HM_NAME_BLOCK] = blob_len;
+        } else {
+            while (lcp < len && prev[lcp] && prev[lcp] == cur[lcp])
+                lcp++;
+        }
+
+        if (blob_len + hm_len_bytes(lcp) + hm_len_bytes(len - lcp) + (len - lcp) > blob_cap) {
+            uint8_t *nb;
+
+            blob_cap = blob_cap ? blob_cap * 2 : HM_NAME_BLOB_INIT;
+            while (blob_len + hm_len_bytes(lcp) + hm_len_bytes(len - lcp) + (len - lcp) > blob_cap)
+                blob_cap *= 2;
+
+            nb = cli_safer_realloc(blob, blob_cap);
+            if (!nb) {
+                cli_errmsg("hm_names_build: failed to grow the name blob\n");
+                goto done;
+            }
+            blob = nb;
+        }
+
+        hm_put_len(blob, &blob_len, lcp);
+        hm_put_len(blob, &blob_len, len - lcp);
+        memcpy(blob + blob_len, cur + lcp, len - lcp);
+        blob_len += len - lcp;
+
+        prev        = cur;
+        off[idx[j]] = entries++;
+    }
+
+    free(idx);
+    idx = NULL;
+    hm_nametmp_free(nm);
+
+    /* Into the pool, once, at the final size. */
+    nblocks  = (entries + HM_NAME_BLOCK - 1) / HM_NAME_BLOCK;
+    nm->blob = MPOOL_MALLOC(root->mempool, blob_len);
+    if (!nm->blob) {
+        cli_errmsg("hm_names_build: failed to allocate %u name bytes\n", blob_len);
+        goto done;
+    }
+    memcpy(nm->blob, blob, blob_len);
+
+    nm->block_off = MPOOL_MALLOC(root->mempool, sizeof(*nm->block_off) * nblocks);
+    if (!nm->block_off) {
+        cli_errmsg("hm_names_build: failed to allocate %u block offsets\n", nblocks);
+        goto done;
+    }
+    memcpy(nm->block_off, block_off, sizeof(*nm->block_off) * nblocks);
+
+    nm->blob_len = blob_len;
+    nm->nblocks  = nblocks;
+    nm->count    = entries;
+
+#ifdef CL_THREAD_SAFE
+    if (pthread_mutex_init(&nm->mutex, NULL)) {
+        cli_errmsg("hm_names_build: failed to initialise the name cache mutex\n");
+        goto done;
+    }
+#endif
+    nm->ready = 1;
+
+    j = 0;
+    for (s = 0; s < nsets; s++)
+        for (i = 0; i < sets[s]->items; i++)
+            if (sets[s]->name_idx[i] != HM_NAME_NONE)
+                sets[s]->name_idx[i] = off[j++];
+
+    cli_dbgmsg("hm_names_build: %u names (%u distinct) in %u bytes\n", named, entries, blob_len);
+
+    ret = CL_SUCCESS;
+
+done:
+    free(off);
+    free(idx);
+    free(scratch);
+    free(blob);
+    free(block_off);
+    free(sets);
+
+    /* Harmless if the success path already did it. */
+    hm_nametmp_free(nm);
+
+    return ret;
+}
+
+/* Rebuilds one name from the blob. The entry inherits a prefix from the
+ * one before it, so the walk starts at the block this entry belongs to.
+ * Returns a malloc'd string. */
+static char *hm_name_decode(const struct cli_hm_names *nm, uint32_t entry)
+{
+    uint32_t first = (entry / HM_NAME_BLOCK) * HM_NAME_BLOCK;
+    uint32_t pos, k, len = 0, maxlen = 0;
+    char *buf;
+
+    if (entry >= nm->count)
+        return NULL;
+
+    /* First pass: how long the longest name in the walk is, which is
+     * how big the buffer the second pass builds in has to be. */
+    pos = nm->block_off[entry / HM_NAME_BLOCK];
+    for (k = first; k <= entry; k++) {
+        uint32_t lcp  = hm_get_len(nm->blob, &pos, nm->blob_len);
+        uint32_t tail = hm_get_len(nm->blob, &pos, nm->blob_len);
+
+        /* Written as a subtraction: hm_get_len() leaves pos <= blob_len,
+         * so blob_len - pos cannot wrap, whereas pos + tail could. */
+        if (lcp == HM_NAME_NONE || tail == HM_NAME_NONE ||
+            lcp > len || tail > nm->blob_len - pos)
+            return NULL;
+
+        len = lcp + tail;
+        if (len > maxlen)
+            maxlen = len;
+        pos += tail;
+    }
+
+    buf = malloc(maxlen + 1);
+    if (!buf)
+        return NULL;
+
+    /* Second pass walks the same bytes the first pass just validated,
+     * so it does not re-check them. */
+    len = 0;
+    pos = nm->block_off[entry / HM_NAME_BLOCK];
+    for (k = first; k <= entry; k++) {
+        uint32_t lcp  = hm_get_len(nm->blob, &pos, nm->blob_len);
+        uint32_t tail = hm_get_len(nm->blob, &pos, nm->blob_len);
+
+        memcpy(buf + lcp, nm->blob + pos, tail);
+        len = lcp + tail;
+        pos += tail;
+    }
+    buf[len] = '\0';
+
+    return buf;
+}
+
+/* Where an entry belongs, in one place: the two probe loops in hm_name()
+ * and the rehash below have to agree on it. capacity is a power of two
+ * and is never zero here. */
+static inline uint32_t hm_cache_slot(uint32_t entry, uint32_t capacity)
+{
+    return (entry * HM_NAME_CACHE_MULT) & (capacity - 1);
+}
+
+static cl_error_t hm_cache_grow(struct hm_namecache *c)
+{
+    uint32_t newcap = c->capacity ? c->capacity * 2 : HM_NAME_CACHE_INIT;
+    uint32_t *keys;
+    char **vals;
+    uint32_t i;
+
+    keys = calloc(newcap, sizeof(*keys));
+    vals = calloc(newcap, sizeof(*vals));
+    if (!keys || !vals) {
+        free(keys);
+        free(vals);
+        return CL_EMEM;
+    }
+
+    for (i = 0; i < c->capacity; i++) {
+        uint32_t slot;
+
+        if (!c->keys[i])
+            continue;
+
+        slot = hm_cache_slot(c->keys[i] - 1, newcap);
+        while (keys[slot])
+            slot = (slot + 1) & (newcap - 1);
+
+        keys[slot] = c->keys[i];
+        vals[slot] = c->vals[i];
+    }
+
+    free(c->keys);
+    free(c->vals);
+    c->keys     = keys;
+    c->vals     = vals;
+    c->capacity = newcap;
+
+    return CL_SUCCESS;
+}
+
+/* The name of one hash signature, valid for as long as the engine is
+ * loaded. NULL means the signature has no name; a decode failure is
+ * reported by *failed, because that is not the same thing. */
+static const char *hm_name(const struct cli_matcher *root, uint32_t entry, int *failed)
+{
+    struct cli_hm_names *nm = root->hm_names;
+    const char *name        = NULL;
+    uint32_t slot;
+
+    *failed = 0;
+
+    if (entry == HM_NAME_NONE)
+        return NULL;
+
+    if (!nm || !nm->ready) {
+        *failed = 1;
+        return NULL;
+    }
+
+#ifdef CL_THREAD_SAFE
+    if (pthread_mutex_lock(&nm->mutex)) {
+        cli_errmsg("hm_name: mutex lock fail\n");
+        *failed = 1;
+        return NULL;
+    }
+#endif
+
+    if (nm->cache.capacity) {
+        slot = hm_cache_slot(entry, nm->cache.capacity);
+        while (nm->cache.keys[slot]) {
+            if (nm->cache.keys[slot] == entry + 1) {
+                name = nm->cache.vals[slot];
+                goto unlock;
+            }
+            slot = (slot + 1) & (nm->cache.capacity - 1);
+        }
+    }
+
+    if (nm->cache.used * HM_NAME_CACHE_LOAD_DEN >= nm->cache.capacity * HM_NAME_CACHE_LOAD_NUM)
+        if (CL_SUCCESS != hm_cache_grow(&nm->cache)) {
+            *failed = 1;
+            goto unlock;
+        }
+
+    {
+        char *decoded = hm_name_decode(nm, entry);
+
+        if (!decoded) {
+            *failed = 1;
+            goto unlock;
+        }
+
+        slot = hm_cache_slot(entry, nm->cache.capacity);
+        while (nm->cache.keys[slot])
+            slot = (slot + 1) & (nm->cache.capacity - 1);
+
+        nm->cache.keys[slot] = entry + 1;
+        nm->cache.vals[slot] = decoded;
+        nm->cache.used++;
+        name = decoded;
+    }
+
+unlock:
+#ifdef CL_THREAD_SAFE
+    pthread_mutex_unlock(&nm->mutex);
+#endif
+
+    return name;
+}
+
+static void hm_names_free(struct cli_matcher *root)
+{
+    struct cli_hm_names *nm = root->hm_names;
+    uint32_t i;
+
+    if (!nm)
+        return;
+
+    hm_nametmp_free(nm);
+
+    for (i = 0; i < nm->cache.capacity; i++)
+        if (nm->cache.keys[i])
+            free(nm->cache.vals[i]);
+    free(nm->cache.keys);
+    free(nm->cache.vals);
+
+    if (nm->blob)
+        MPOOL_FREE(root->mempool, nm->blob);
+    if (nm->block_off)
+        MPOOL_FREE(root->mempool, nm->block_off);
+
+#ifdef CL_THREAD_SAFE
+    if (nm->ready)
+        pthread_mutex_destroy(&nm->mutex);
+#endif
+
+    MPOOL_FREE(root->mempool, nm);
+    root->hm_names = NULL;
+}
+
 cl_error_t hm_addhash_str(struct cl_engine *engine, hash_purpose_t purpose, const char *strhash, uint32_t size, const char *virusname)
 {
     cli_hash_type_t type;
@@ -169,6 +857,7 @@ cl_error_t hm_addhash_bin(struct cl_engine *engine, hash_purpose_t purpose, cons
     struct cli_sz_hash *szh;
     struct cli_htu32 *ht;
     cl_error_t ret;
+    uint32_t nameoff;
     struct cli_matcher *root = NULL;
 
     if (purpose == HASH_PURPOSE_PE_SECTION_DETECT) {
@@ -238,20 +927,24 @@ cl_error_t hm_addhash_bin(struct cl_engine *engine, hash_purpose_t purpose, cons
         /* size 0 = wildcard */
         szh = &root->hwild.hashes[type];
     }
+    ret = hm_name_store(root, virusname, &nameoff);
+    if (CL_SUCCESS != ret)
+        return ret;
+
     szh->items++;
 
     szh->hash_array = MPOOL_REALLOC2(root->mempool, szh->hash_array, hlen * szh->items);
     if (!szh->hash_array) {
         cli_errmsg("hm_addhash_bin: failed to grow hash array to %u entries\n", szh->items);
         szh->items = 0;
-        MPOOL_FREE(root->mempool, (void *)szh->virusnames);
-        szh->virusnames = NULL;
+        MPOOL_FREE(root->mempool, szh->name_idx);
+        szh->name_idx = NULL;
         return CL_EMEM;
     }
 
-    szh->virusnames = MPOOL_REALLOC2(root->mempool, (void *)szh->virusnames, sizeof(*szh->virusnames) * szh->items);
-    if (!szh->virusnames) {
-        cli_errmsg("hm_addhash_bin: failed to grow virusname array to %u entries\n", szh->items);
+    szh->name_idx = MPOOL_REALLOC2(root->mempool, szh->name_idx, sizeof(*szh->name_idx) * szh->items);
+    if (!szh->name_idx) {
+        cli_errmsg("hm_addhash_bin: failed to grow name index to %u entries\n", szh->items);
         szh->items = 0;
         MPOOL_FREE(root->mempool, szh->hash_array);
         szh->hash_array = NULL;
@@ -259,7 +952,7 @@ cl_error_t hm_addhash_bin(struct cl_engine *engine, hash_purpose_t purpose, cons
     }
 
     memcpy(&szh->hash_array[(szh->items - 1) * hlen], binhash, hlen);
-    szh->virusnames[(szh->items - 1)] = virusname;
+    szh->name_idx[(szh->items - 1)] = nameoff;
 
     return CL_SUCCESS;
 }
@@ -281,7 +974,7 @@ static void hm_sort(struct cli_sz_hash *szh, size_t l, size_t r, unsigned int ke
     uint8_t piv[CLI_HASHLEN_MAX], tmph[CLI_HASHLEN_MAX];
     size_t l1, r1;
 
-    const char *tmpv;
+    uint32_t tmpv;
 
     if (l + 1 >= r)
         return;
@@ -294,11 +987,11 @@ static void hm_sort(struct cli_sz_hash *szh, size_t l, size_t r, unsigned int ke
             r1--;
             if (l1 == r1) break;
             memcpy(tmph, &szh->hash_array[keylen * l1], keylen);
-            tmpv = szh->virusnames[l1];
+            tmpv = szh->name_idx[l1];
             memcpy(&szh->hash_array[keylen * l1], &szh->hash_array[keylen * r1], keylen);
-            szh->virusnames[l1] = szh->virusnames[r1];
+            szh->name_idx[l1] = szh->name_idx[r1];
             memcpy(&szh->hash_array[keylen * r1], tmph, keylen);
-            szh->virusnames[r1] = tmpv;
+            szh->name_idx[r1] = tmpv;
         } else
             l1++;
     }
@@ -306,26 +999,27 @@ static void hm_sort(struct cli_sz_hash *szh, size_t l, size_t r, unsigned int ke
     l1--;
     if (l1 != l) {
         memcpy(tmph, &szh->hash_array[keylen * l1], keylen);
-        tmpv = szh->virusnames[l1];
+        tmpv = szh->name_idx[l1];
         memcpy(&szh->hash_array[keylen * l1], &szh->hash_array[keylen * l], keylen);
-        szh->virusnames[l1] = szh->virusnames[l];
+        szh->name_idx[l1] = szh->name_idx[l];
         memcpy(&szh->hash_array[keylen * l], tmph, keylen);
-        szh->virusnames[l] = tmpv;
+        szh->name_idx[l] = tmpv;
     }
 
     hm_sort(szh, l, l1, keylen);
     hm_sort(szh, r1, r, keylen);
 }
 
-/* flush both size-specific and agnostic hash sets */
-void hm_flush(struct cli_matcher *root)
+/* Sort both size-specific and agnostic hash sets, then build the name
+ * table over the result. */
+cl_error_t hm_flush(struct cli_matcher *root)
 {
     cli_hash_type_t type;
     unsigned int keylen;
     struct cli_sz_hash *szh;
 
     if (!root)
-        return;
+        return CL_SUCCESS;
 
     for (type = CLI_HASH_MD5; type < CLI_HASH_AVAIL_TYPES; type++) {
         struct cli_htu32 *ht                 = &root->hm.sizehashes[type];
@@ -351,6 +1045,8 @@ void hm_flush(struct cli_matcher *root)
         if (szh->items > 1)
             hm_sort(szh, 0, szh->items, keylen);
     }
+
+    return hm_names_build(root);
 }
 
 bool cli_hm_have_size(const struct cli_matcher *root, cli_hash_type_t type, uint32_t size)
@@ -368,7 +1064,7 @@ bool cli_hm_have_any(const struct cli_matcher *root, cli_hash_type_t type)
     return (root && (root->hwild.hashes[type].items || root->hm.sizehashes[type].capacity));
 }
 
-static cl_error_t hm_scan(const uint8_t *digest, const char **virname, const struct cli_sz_hash *szh, cli_hash_type_t type)
+static cl_error_t hm_scan(const struct cli_matcher *root, const uint8_t *digest, const char **virname, const struct cli_sz_hash *szh, cli_hash_type_t type)
 {
     unsigned int keylen;
     size_t l, r;
@@ -391,8 +1087,15 @@ static cl_error_t hm_scan(const uint8_t *digest, const char **virname, const str
         } else if (res > 0)
             l = c + 1;
         else {
-            if (virname)
-                *virname = szh->virusnames[c];
+            if (virname) {
+                int failed;
+
+                *virname = hm_name(root, szh->name_idx[c], &failed);
+                if (failed) {
+                    cli_errmsg("hm_scan: failed to materialise the signature name\n");
+                    return CL_EMEM;
+                }
+            }
             return CL_VIRUS;
         }
     }
@@ -414,7 +1117,7 @@ cl_error_t cli_hm_scan(const uint8_t *digest, uint32_t size, const char **virnam
 
     szh = (struct cli_sz_hash *)item->data.as_ptr;
 
-    return hm_scan(digest, virname, szh, type);
+    return hm_scan(root, digest, virname, szh, type);
 }
 
 /* cli_hm_scan_wild will scan only size-agnostic hashes, if any */
@@ -423,7 +1126,7 @@ cl_error_t cli_hm_scan_wild(const uint8_t *digest, const char **virname, const s
     if (!digest || !root || !root->hwild.hashes[type].items)
         return CL_CLEAN;
 
-    return hm_scan(digest, virname, &root->hwild.hashes[type], type);
+    return hm_scan(root, digest, virname, &root->hwild.hashes[type], type);
 }
 
 /* free both size-specific and agnostic hash sets */
@@ -445,9 +1148,7 @@ void hm_free(struct cli_matcher *root)
             struct cli_sz_hash *szh = (struct cli_sz_hash *)item->data.as_ptr;
 
             MPOOL_FREE(root->mempool, szh->hash_array);
-            while (szh->items)
-                MPOOL_FREE(root->mempool, (void *)szh->virusnames[--szh->items]);
-            MPOOL_FREE(root->mempool, (void *)szh->virusnames);
+            MPOOL_FREE(root->mempool, szh->name_idx);
             MPOOL_FREE(root->mempool, szh);
         }
         CLI_HTU32_FREE(ht, root->mempool);
@@ -460,8 +1161,9 @@ void hm_free(struct cli_matcher *root)
             continue;
 
         MPOOL_FREE(root->mempool, szh->hash_array);
-        while (szh->items)
-            MPOOL_FREE(root->mempool, (void *)szh->virusnames[--szh->items]);
-        MPOOL_FREE(root->mempool, (void *)szh->virusnames);
+        MPOOL_FREE(root->mempool, szh->name_idx);
     }
+
+    /* One blob, not 3.3 million strings. */
+    hm_names_free(root);
 }

--- a/libclamav/matcher-hash.h
+++ b/libclamav/matcher-hash.h
@@ -37,9 +37,26 @@ typedef enum {
     HASH_PURPOSE_PE_IMPORT_DETECT       /** PE import hash malware detection (aka .imp) */
 } hash_purpose_t;
 
+/** Name table entry number of a signature that was added without a name.
+ * asn1.c adds authenticode false-positive hashes that way. */
+#define HM_NAME_NONE 0xffffffff
+
+/** Number of front-coded name entries per restart point. A decode walks
+ * from the start of the block, so this trades decode work against the
+ * size of the block offset table. */
+#define HM_NAME_BLOCK 16
+
+/** Front-coded virus names for one matcher root, shared by all of its
+ * size buckets. Opaque outside matcher-hash.c. */
+struct cli_hm_names;
+
 struct cli_sz_hash {
     uint8_t *hash_array;
-    const char **virusnames;
+    /** Per signature, an entry number in root->hm_names, or HM_NAME_NONE.
+     * Between hm_addhash_bin() and hm_flush() this holds a byte offset
+     * into the load-time name arena instead; hm_flush() rewrites every
+     * entry once the names have been sorted and coded. */
+    uint32_t *name_idx;
     uint32_t items;
 };
 
@@ -51,9 +68,13 @@ struct cli_hash_wild {
     struct cli_sz_hash hashes[CLI_HASH_AVAIL_TYPES];
 };
 
+/* hm_addhash_str() and hm_addhash_bin() copy virusname; the caller keeps
+ * ownership of the buffer it passes, and may pass NULL for no name. */
 cl_error_t hm_addhash_str(struct cl_engine *engine, hash_purpose_t purpose, const char *strhash, uint32_t size, const char *virusname);
 cl_error_t hm_addhash_bin(struct cl_engine *engine, hash_purpose_t purpose, const void *binhash, cli_hash_type_t type, uint32_t size, const char *virusname);
-void hm_flush(struct cli_matcher *root);
+/* Sorts every hash set and builds the name table. Must be called once,
+ * after loading and before scanning. */
+cl_error_t hm_flush(struct cli_matcher *root);
 cl_error_t cli_hm_scan(const uint8_t *digest, uint32_t size, const char **virname, const struct cli_matcher *root, cli_hash_type_t type);
 cl_error_t cli_hm_scan_wild(const uint8_t *digest, const char **virname, const struct cli_matcher *root, cli_hash_type_t type);
 bool cli_hm_have_size(const struct cli_matcher *root, cli_hash_type_t type, uint32_t size);

--- a/libclamav/matcher.c
+++ b/libclamav/matcher.c
@@ -655,7 +655,15 @@ cl_error_t cli_check_fp(cli_ctx *ctx, const char *vname)
 
                 }
 
-                if (cli_hm_scan(hash, map->len, &virname, ctx->engine->hm_fp, hash_type) == CL_VIRUS) {
+                ret = cli_hm_scan(hash, map->len, &virname, ctx->engine->hm_fp, hash_type);
+                if (CL_SUCCESS != ret && CL_VIRUS != ret) {
+                    /* The file could not be checked against the false positive
+                     * signatures, so the alert has to stand. */
+                    cli_dbgmsg("cli_check_fp: Failed to check the hash against the false positive signatures\n");
+                    status = CL_VIRUS;
+                    goto done;
+                }
+                if (CL_VIRUS == ret) {
                     cli_dbgmsg("cli_check_fp: Found false positive detection for %s (fp sig: %s)\n", cli_hash_name(hash_type), virname);
 
                     source_len = strlen(virname) + strlen("false positive signature match: ") + 1;
@@ -673,7 +681,13 @@ cl_error_t cli_check_fp(cli_ctx *ctx, const char *vname)
                     status = CL_VERIFIED;
                     goto done;
                 }
-                if (cli_hm_scan_wild(hash, &virname, ctx->engine->hm_fp, hash_type) == CL_VIRUS) {
+                ret = cli_hm_scan_wild(hash, &virname, ctx->engine->hm_fp, hash_type);
+                if (CL_SUCCESS != ret && CL_VIRUS != ret) {
+                    cli_dbgmsg("cli_check_fp: Failed to check the hash against the false positive signatures\n");
+                    status = CL_VIRUS;
+                    goto done;
+                }
+                if (CL_VIRUS == ret) {
                     cli_dbgmsg("cli_check_fp: Found false positive detection for %s (fp sig: %s)\n", cli_hash_name(hash_type), virname);
 
                     source_len = strlen(virname) + strlen("false positive signature match: ") + 1;
@@ -695,7 +709,13 @@ cl_error_t cli_check_fp(cli_ctx *ctx, const char *vname)
                 if (CLI_HASH_MD5 != hash_type) {
                     /* See whether the hash matches those loaded in from .cat files
                      * (associated with the .CAB file type) */
-                    if (cli_hm_scan(hash, 1, &virname, ctx->engine->hm_fp, hash_type) == CL_VIRUS) {
+                    ret = cli_hm_scan(hash, 1, &virname, ctx->engine->hm_fp, hash_type);
+                    if (CL_SUCCESS != ret && CL_VIRUS != ret) {
+                        cli_dbgmsg("cli_check_fp: Failed to check the hash against the catalog false positive signatures\n");
+                        status = CL_VIRUS;
+                        goto done;
+                    }
+                    if (CL_VIRUS == ret) {
                         cli_dbgmsg("cli_check_fp: Found .CAB false positive detection for %s via catalog file\n", cli_hash_name(hash_type));
 
                         source_len = strlen(virname) + strlen("false positive signature match: ") + 1;
@@ -1379,6 +1399,9 @@ cl_error_t cli_scan_fmap(cli_ctx *ctx, cli_file_t ftype, bool filetype_only, str
                 if (ret != CL_SUCCESS) {
                     goto done;
                 }
+            } else if (ret != CL_SUCCESS) {
+                cli_dbgmsg("cli_scan_fmap: Error checking size-based hash signatures\n");
+                goto done;
             }
 
             /* Do hash scan checking hash sigs with wildcard size.
@@ -1390,6 +1413,9 @@ cl_error_t cli_scan_fmap(cli_ctx *ctx, cli_file_t ftype, bool filetype_only, str
                 if (ret != CL_SUCCESS) {
                     goto done;
                 }
+            } else if (ret != CL_SUCCESS) {
+                cli_dbgmsg("cli_scan_fmap: Error checking size-agnostic hash signatures\n");
+                goto done;
             }
         }
     }

--- a/libclamav/matcher.h
+++ b/libclamav/matcher.h
@@ -142,6 +142,7 @@ struct cli_matcher {
     /* HASH */
     struct cli_hash_patt hm;
     struct cli_hash_wild hwild;
+    struct cli_hm_names *hm_names;
 
     /* Extended Aho-Corasick */
     uint32_t ac_partsigs, ac_nodes, ac_lists, ac_patterns, ac_lsigs;

--- a/libclamav/openioc.c
+++ b/libclamav/openioc.c
@@ -299,10 +299,12 @@ int openioc_parse(const char *fname, int fd, struct cl_engine *engine, unsigned 
             }
         }
 
-        vp        = virusname;
-        virusname = CLI_MPOOL_VIRNAME(engine->mempool, virusname, options & CL_DB_OFFICIAL);
+        vp = virusname;
+        /* hm_addhash_str() copies the name; this buffer only has to live
+         * until it returns, so it does not come from the pool. */
+        virusname = cli_virname(virusname, options & CL_DB_OFFICIAL);
         if (!(virusname)) {
-            cli_dbgmsg("openioc_parse: MPOOL_MALLOC for virname memory failed.\n");
+            cli_dbgmsg("openioc_parse: allocating virname memory failed.\n");
             xmlTextReaderClose(reader);
             xmlFreeTextReader(reader);
             free(vp);
@@ -317,6 +319,8 @@ int openioc_parse(const char *fname, int fd, struct cl_engine *engine, unsigned 
                        rc, hashlen, virusname);
         else
             hash_count++;
+
+        free(virusname);
 
         xmlFree(elem->hash);
         free(elem);

--- a/libclamav/pe.c
+++ b/libclamav/pe.c
@@ -601,15 +601,27 @@ static cl_error_t scan_pe_mdb(cli_ctx *ctx, struct cli_exe_section *exe_section)
 
     /* Do scans */
     for (type = CLI_HASH_MD5; type < CLI_HASH_AVAIL_TYPES; type++) {
-        if (foundsize[type] && cli_hm_scan(hashset[type], exe_section->rsz, &virname, mdb_sect, type) == CL_VIRUS) {
-            ret = cli_append_virus(ctx, virname);
-            if (ret != CL_SUCCESS) {
+        if (foundsize[type]) {
+            ret = cli_hm_scan(hashset[type], exe_section->rsz, &virname, mdb_sect, type);
+            if (ret == CL_VIRUS) {
+                ret = cli_append_virus(ctx, virname);
+                if (ret != CL_SUCCESS) {
+                    break;
+                }
+            } else if (ret != CL_SUCCESS) {
+                cli_dbgmsg("scan_pe_mdb: Error checking size-based section hash signatures\n");
                 break;
             }
         }
-        if (foundwild[type] && cli_hm_scan_wild(hashset[type], &virname, mdb_sect, type) == CL_VIRUS) {
-            ret = cli_append_virus(ctx, virname);
-            if (ret != CL_SUCCESS) {
+        if (foundwild[type]) {
+            ret = cli_hm_scan_wild(hashset[type], &virname, mdb_sect, type);
+            if (ret == CL_VIRUS) {
+                ret = cli_append_virus(ctx, virname);
+                if (ret != CL_SUCCESS) {
+                    break;
+                }
+            } else if (ret != CL_SUCCESS) {
+                cli_dbgmsg("scan_pe_mdb: Error checking size-agnostic section hash signatures\n");
                 break;
             }
         }
@@ -2598,17 +2610,25 @@ static cl_error_t scan_pe_imp(cli_ctx *ctx, struct cli_exe_info *peinfo)
 
     /* Do scans */
     for (type = CLI_HASH_MD5; type < CLI_HASH_AVAIL_TYPES; type++) {
-        if (cli_hm_scan(hashset[type], impsz, &virname, imp, type) == CL_VIRUS) {
+        ret = cli_hm_scan(hashset[type], impsz, &virname, imp, type);
+        if (ret == CL_VIRUS) {
             ret = cli_append_virus(ctx, virname);
             if (ret != CL_SUCCESS) {
                 break;
             }
+        } else if (ret != CL_SUCCESS) {
+            cli_dbgmsg("scan_pe_imp: Error checking size-based import hash signatures\n");
+            break;
         }
-        if (cli_hm_scan_wild(hashset[type], &virname, imp, type) == CL_VIRUS) {
-            cli_append_virus(ctx, virname);
+        ret = cli_hm_scan_wild(hashset[type], &virname, imp, type);
+        if (ret == CL_VIRUS) {
+            ret = cli_append_virus(ctx, virname);
             if (ret != CL_SUCCESS) {
                 break;
             }
+        } else if (ret != CL_SUCCESS) {
+            cli_dbgmsg("scan_pe_imp: Error checking size-agnostic import hash signatures\n");
+            break;
         }
     }
 

--- a/libclamav/readdb.c
+++ b/libclamav/readdb.c
@@ -2915,15 +2915,20 @@ static int cli_loadhash(FILE *fs, struct cl_engine *engine, unsigned int *signo,
             }
         }
 
-        virname = CLI_MPOOL_VIRNAME(engine->mempool, pt, options & CL_DB_OFFICIAL);
+        /* hm_addhash_str() copies the name into the root's name store,
+         * so this one only has to live until it returns - and must not
+         * come from the pool, which cannot recycle 3 M short-lived
+         * strings. */
+        virname = cli_virname(pt, options & CL_DB_OFFICIAL);
         if (!virname) {
             ret = CL_EMALFDB;
             break;
         }
 
-        if (CL_SUCCESS != (ret = hm_addhash_str(engine, purpose, tokens[hash_field], size, virname))) {
+        ret = hm_addhash_str(engine, purpose, tokens[hash_field], size, virname);
+        free((void *)virname);
+        if (CL_SUCCESS != ret) {
             cli_errmsg("cli_loadhash: Malformed hash string at line %u\n", line);
-            MPOOL_FREE(engine->mempool, (void *)virname);
             break;
         }
 
@@ -6016,19 +6021,23 @@ cl_error_t cl_engine_compile(struct cl_engine *engine)
     }
 
     if (engine->hm_hdb)
-        hm_flush(engine->hm_hdb);
+        if (CL_SUCCESS != (ret = hm_flush(engine->hm_hdb)))
+            return ret;
     TASK_COMPLETE();
 
     if (engine->hm_mdb)
-        hm_flush(engine->hm_mdb);
+        if (CL_SUCCESS != (ret = hm_flush(engine->hm_mdb)))
+            return ret;
     TASK_COMPLETE();
 
     if (engine->hm_imp)
-        hm_flush(engine->hm_imp);
+        if (CL_SUCCESS != (ret = hm_flush(engine->hm_imp)))
+            return ret;
     TASK_COMPLETE();
 
     if (engine->hm_fp)
-        hm_flush(engine->hm_fp);
+        if (CL_SUCCESS != (ret = hm_flush(engine->hm_fp)))
+            return ret;
     TASK_COMPLETE();
 
     if ((ret = cli_build_regex_list(engine->phish_allow_list_matcher))) {


### PR DESCRIPTION
A hash signature keeps its name as a pooled string plus an 8-byte entry in a
parallel `virusnames[]` array. On a 424 MB signature set that is 80.7 MB of name
bytes and 26.4 MB of pointers against 53.2 MB of hash payload — the names cost
more than twice what they name.

Interning them is worthless: 3,290,969 of 3,292,090 are distinct. But they share
long prefixes — sorted neighbours agree on 21.7 bytes of a 23.5 byte average — so
sorting them and front coding each entry as `[lcp][len][tail]` stores the same
names in 18.0 MB. A restart point every 16 entries gives a decode somewhere to
begin, and `name_idx[]` replaces the pointer array with one 32-bit entry number
per signature.

Names are decoded on match into a per-root cache that lives as long as the
engine, which is the lifetime `evidence_get_last_alert()` documents for the
pointer it hands out. `hm_addhash_str()` and `hm_addhash_bin()` copy the name
they are given rather than taking ownership, so `cli_loadhash()` and
`openioc_parse()` pass an ordinary `cli_virname()` and free it.

The sort is preceded by a counting sort on the name arena offset. Entry order
arrives from a hash-table walk, so comparing names in that order makes every
merge pass a random walk over a 77 MB arena; on this set that pre-pass is
1.6 s of the load time below.

### Measured

424 MB signature set (3,849,249 signatures), RSS after `cl_engine_compile()`,
3 runs per arm, spread under 0.01 %:

| Build | before | after | delta |
|---|---:|---:|---:|
| mpool (as shipped) | 1,135,465 KB | 1,036,364 KB | **-99,101 (-8.7 %)** |
| `DISABLE_MPOOL=ON` | 1,392,657 KB | 1,122,487 KB | **-270,170 (-19.4 %)** |

Peak RSS falls with it, 1,135,465 → 1,129,584 KB, even though the table is built
while the load-time name arena is still resident.

Engine load time rises **10.21 s → 11.87 s (+16 %)** on that set, from sorting
3.3 M names; both arms' run-to-run spread is under 1.5 %. Scan time over a
2,401-file tree is unchanged within the spread of the measurement, -0.6 ± 1.1 s
on 127 s.

### Behaviour

Scan output is byte-identical over that tree, EICAR control included. The one new
failure mode is an out-of-memory while decoding a name, which makes
`cli_hm_scan()` return `CL_EMEM` rather than report a match it cannot name;
`hm_flush()` returns `cl_error_t` for the same reason, so a failed allocation
while building the table is not swallowed.

Verified with the test suite (same failure set as the base), a
byte-for-byte scan-output comparison over 2,401 files, an OpenIOC database
load, an 8-thread concurrent-decode run, the escaped-length paths at names up
to 608 bytes, and AddressSanitizer with a positive control.

