### PR TITLE
libclamav: avoid duplicate HandlerType alerts after retyping

### DIFF
--- a/libclamav/matcher.c
+++ b/libclamav/matcher.c
@@ -936,6 +936,10 @@ static cl_error_t lsig_eval(cli_ctx *ctx, struct cli_matcher *root, struct cli_a
             (void)cli_recursion_stack_pop(ctx); /* Restore the parent fmap */
 
             goto done;
+        } else {
+            // The retyped layer was already scanned as the requested type. Do not alert on it again.
+            status = CL_SUCCESS;
+            goto done;
         }
     }
 

--- a/libclamav/matcher.c
+++ b/libclamav/matcher.c
@@ -925,6 +925,13 @@ static cl_error_t lsig_eval(cli_ctx *ctx, struct cli_matcher *root, struct cli_a
                 goto done;
             }
 
+            /*
+             * The clean-cache key does not include the HandlerType. Do not let
+             * this retyped scan cache a result that could suppress a later scan
+             * of the same content using a different handler.
+             */
+            new_map->dont_cache_flag = true;
+
             status = cli_recursion_stack_push(ctx, new_map, ac_lsig->tdb.handlertype[0], true, LAYER_ATTRIBUTES_RETYPED); /* Perform scan with child fmap */
             if (CL_SUCCESS != status) {
                 cli_dbgmsg("Failed to re-scan fmap as a new type.\n");

--- a/libclamav/scanners.c
+++ b/libclamav/scanners.c
@@ -4767,10 +4767,13 @@ cl_error_t cli_magic_scan(cli_ctx *ctx, cli_file_t type)
     /*
      * Determine if caching is enabled.
      * The application may have specifically disabled caching. Also, if the application never loaded any signatures,
-     * then the cache will be NULL and caching will also be disabled.
+     * then the cache will be NULL and caching will also be disabled. Retyped
+     * layers must bypass the cache because its key does not include the
+     * HandlerType used to scan the layer.
      */
     if ((ctx->engine->engine_options & ENGINE_OPTIONS_DISABLE_CACHE) ||
-        (ctx->engine->cache == NULL)) {
+        (ctx->engine->cache == NULL) ||
+        (ctx->recursion_stack[ctx->recursion_level].attributes & LAYER_ATTRIBUTES_RETYPED)) {
         cache_enabled = false;
     }
 

--- a/unit_tests/clamscan/container_sigs_test.py
+++ b/unit_tests/clamscan/container_sigs_test.py
@@ -162,3 +162,31 @@ class TC(testcase.TestCase):
             'not_eicar.zip: OK',
         ]
         self.verify_output(output.out, expected=expected_stdout, unexpected=unexpected_stdout)
+
+    def test_handler_type_does_not_alert_on_retyped_layer(self):
+        self.step_name('Test that a HandlerType signature does not alert after retyping the layer')
+
+        marker = b'CLAMAV-TEST-HANDLERTYPE'
+        testfile = TC.path_tmp / 'handler_type_retype'
+        testfile.write_bytes(marker)
+
+        (TC.path_tmp / 'handler_type_retype.ldb').write_text(
+            'handler_type_retype;Engine:51-255,HandlerType:CL_TYPE_ZIP,Target:0;0;{}\n'.format(marker.hex())
+        )
+
+        command = '{valgrind} {valgrind_args} {clamscan} -d {path_db} {testfile} --allmatch'.format(
+            valgrind=TC.valgrind, valgrind_args=TC.valgrind_args, clamscan=TC.clamscan,
+            path_db=TC.path_tmp / 'handler_type_retype.ldb',
+            testfile=testfile,
+        )
+        output = self.execute_command(command)
+
+        assert output.ec == 0
+
+        expected_stdout = [
+            'handler_type_retype: OK',
+        ]
+        unexpected_stdout = [
+            'handler_type_retype.UNOFFICIAL FOUND',
+        ]
+        self.verify_output(output.out, expected=expected_stdout, unexpected=unexpected_stdout)

--- a/unit_tests/clamscan/container_sigs_test.py
+++ b/unit_tests/clamscan/container_sigs_test.py
@@ -190,3 +190,37 @@ class TC(testcase.TestCase):
             'handler_type_retype.UNOFFICIAL FOUND',
         ]
         self.verify_output(output.out, expected=expected_stdout, unexpected=unexpected_stdout)
+
+    def test_handler_type_retyped_layer_is_not_cached(self):
+        self.step_name('Test that one HandlerType scan does not cache a later HandlerType scan as clean')
+
+        marker = b'CLAMAV-TEST-HANDLERTYPE-CACHE'
+        testfile = TC.path_tmp / 'handler_type_cache'
+        testfile.write_bytes(marker)
+
+        (TC.path_tmp / 'handler_type_cache.ldb').write_text(
+            'handler_type_zip;Engine:51-255,HandlerType:CL_TYPE_ZIP,Target:0;0;{}\n'
+            'handler_type_pe;Engine:51-255,HandlerType:CL_TYPE_MSEXE,Target:0;0;{}\n'
+            'handler_type_pe_detection;Engine:51-255,Target:1;0;{}\n'.format(
+                marker.hex(), marker.hex(), marker.hex()
+            )
+        )
+
+        command = '{valgrind} {valgrind_args} {clamscan} -d {path_db} {testfile} --allmatch'.format(
+            valgrind=TC.valgrind, valgrind_args=TC.valgrind_args, clamscan=TC.clamscan,
+            path_db=TC.path_tmp / 'handler_type_cache.ldb',
+            testfile=testfile,
+        )
+        output = self.execute_command(command)
+
+        assert output.ec == 1
+
+        expected_stdout = [
+            'handler_type_cache: handler_type_pe_detection.UNOFFICIAL FOUND',
+        ]
+        unexpected_stdout = [
+            'handler_type_cache: OK',
+            'handler_type_cache: handler_type_zip.UNOFFICIAL FOUND',
+            'handler_type_cache: handler_type_pe.UNOFFICIAL FOUND',
+        ]
+        self.verify_output(output.out, expected=expected_stdout, unexpected=unexpected_stdout)


### PR DESCRIPTION
## Summary

HandlerType logical signatures could alert again when the retyped child layer was evaluated, including duplicate alerts for Target:0 signatures. The child scan now returns clean for the already-retyped layer instead of falling through to the alert path.

Adds a clamscan regression using a Target:0 HandlerType signature with --allmatch.

Jira: CLAM-3096

## Testing

- ctest --test-dir build -V -R '^clamscan$'\n- Exact reproducer scans clean with no FOUND output\n\n## Backport\n\nPlease backport this fix to the supported release branches.