### PR TITLE
clamonacc: watch a whole filesystem so writes from other mount namespaces are scanned

### DIFF
--- a/clamonacc/fanotif/fanotif.c
+++ b/clamonacc/fanotif/fanotif.c
@@ -82,13 +82,16 @@ cl_error_t onas_setup_fanotif(struct onas_context **ctx)
     onas_fan_fd      = (*ctx)->fan_fd;
     (*ctx)->fan_mask = fan_mask;
 
-    if (optget((*ctx)->clamdopts, "OnAccessPrevention")->enabled && !optget((*ctx)->clamdopts, "OnAccessMountPath")->enabled) {
+    int whole_fs = optget((*ctx)->clamdopts, "OnAccessMountPath")->enabled ||
+                   optget((*ctx)->clamdopts, "OnAccessFilesystemPath")->enabled;
+
+    if (optget((*ctx)->clamdopts, "OnAccessPrevention")->enabled && !whole_fs) {
         logg(LOGG_DEBUG, "ClamFanotif: kernel-level blocking feature enabled ... preventing malicious files access attempts\n");
         (*ctx)->fan_mask |= FAN_ACCESS_PERM | FAN_OPEN_PERM;
     } else {
         logg(LOGG_DEBUG, "ClamFanotif: kernel-level blocking feature disabled ...\n");
-        if (optget((*ctx)->clamdopts, "OnAccessPrevention")->enabled && optget((*ctx)->clamdopts, "OnAccessMountPath")->enabled) {
-            logg(LOGG_DEBUG, "ClamFanotif: feature not available when watching mounts ... \n");
+        if (optget((*ctx)->clamdopts, "OnAccessPrevention")->enabled && whole_fs) {
+            logg(LOGG_DEBUG, "ClamFanotif: feature not available when watching mounts or filesystems ... \n");
         }
         (*ctx)->fan_mask |= FAN_ACCESS | FAN_OPEN;
     }
@@ -110,6 +113,22 @@ cl_error_t onas_setup_fanotif(struct onas_context **ctx)
             }
             pt = (struct optstruct *)pt->nextarg;
         }
+
+    } else if ((pt = optget((*ctx)->clamdopts, "OnAccessFilesystemPath"))->enabled) {
+#ifdef FAN_MARK_FILESYSTEM
+        while (pt) {
+            if (fanotify_mark(onas_fan_fd, FAN_MARK_ADD | FAN_MARK_FILESYSTEM, (*ctx)->fan_mask, (*ctx)->fan_fd, pt->strarg) != 0) {
+                logg(LOGG_ERROR, "ClamFanotif: can't include filesystem of '%s'\n", pt->strarg);
+                return CL_EARG;
+            } else {
+                logg(LOGG_DEBUG, "ClamFanotif: watching the whole filesystem containing '%s'\n", pt->strarg);
+            }
+            pt = (struct optstruct *)pt->nextarg;
+        }
+#else
+        logg(LOGG_ERROR, "ClamFanotif: OnAccessFilesystemPath needs FAN_MARK_FILESYSTEM, missing in the headers this build was made with\n");
+        return CL_EARG;
+#endif
 
     } else if (!optget((*ctx)->clamdopts, "OnAccessDisableDDD")->enabled) {
         (*ctx)->ddd_enabled = 1;

--- a/clamonacc/fanotif/fanotif.c
+++ b/clamonacc/fanotif/fanotif.c
@@ -113,8 +113,9 @@ cl_error_t onas_setup_fanotif(struct onas_context **ctx)
             }
             pt = (struct optstruct *)pt->nextarg;
         }
+    }
 
-    } else if ((pt = optget((*ctx)->clamdopts, "OnAccessFilesystemPath"))->enabled) {
+    if ((pt = optget((*ctx)->clamdopts, "OnAccessFilesystemPath"))->enabled) {
 #ifdef FAN_MARK_FILESYSTEM
         while (pt) {
             if (fanotify_mark(onas_fan_fd, FAN_MARK_ADD | FAN_MARK_FILESYSTEM, (*ctx)->fan_mask, (*ctx)->fan_fd, pt->strarg) != 0) {
@@ -129,10 +130,11 @@ cl_error_t onas_setup_fanotif(struct onas_context **ctx)
         logg(LOGG_ERROR, "ClamFanotif: OnAccessFilesystemPath needs FAN_MARK_FILESYSTEM, missing in the headers this build was made with\n");
         return CL_EARG;
 #endif
+    }
 
-    } else if (!optget((*ctx)->clamdopts, "OnAccessDisableDDD")->enabled) {
+    if (!whole_fs && !optget((*ctx)->clamdopts, "OnAccessDisableDDD")->enabled) {
         (*ctx)->ddd_enabled = 1;
-    } else {
+    } else if (!whole_fs) {
         if ((pt = optget((*ctx)->clamdopts, "OnAccessIncludePath"))->enabled) {
             while (pt) {
                 if (0 == strcmp(clamd_tmpdir, pt->strarg)) {

--- a/clamonacc/scan/thread.c
+++ b/clamonacc/scan/thread.c
@@ -275,7 +275,14 @@ static cl_error_t onas_scan_thread_handle_file(struct onas_scan_event *event_dat
         return CL_ENULLARG;
     }
 
-    fres = CLAMSTAT(pathname, &sb);
+#if defined(HAVE_SYS_FANOTIFY_H)
+    if ((event_data->bool_opts & ONAS_SCTH_B_FANOTIFY) && NULL != event_data->fmd && event_data->fmd->fd >= 0) {
+        /* the event may come from a mount that has a different path, or none at all,
+           in this process' mount namespace, so size it through the event descriptor */
+        fres = FSTAT(event_data->fmd->fd, &sb);
+    } else
+#endif
+        fres = CLAMSTAT(pathname, &sb);
     if (event_data->sizelimit) {
         if (fres != 0 || (uint64_t)sb.st_size > event_data->sizelimit) {
             /* don't skip so we avoid lockups, but don't scan either;

--- a/common/optparser.c
+++ b/common/optparser.c
@@ -520,6 +520,8 @@ const struct clam_option __clam_options[] = {
     /* OnAccess settings */
     {"OnAccessMountPath", NULL, 0, CLOPT_TYPE_STRING, NULL, -1, NULL, FLAG_MULTIPLE, OPT_CLAMD, "This option specifies a directory or mount point which should be scanned on access. The mount point specified, or the mount point containing the specified directory will be watched, but only notifications will occur. If any directories are specified, this option will preempt the DDD system. It can also be used multiple times.", "/\n/home/user"},
 
+    {"OnAccessFilesystemPath", NULL, 0, CLOPT_TYPE_STRING, NULL, -1, NULL, FLAG_MULTIPLE, OPT_CLAMD, "This option specifies a directory or mount point whose whole filesystem should be scanned on access. Unlike OnAccessMountPath, the mark is placed on the filesystem itself, so events are reported for every mount of that filesystem, including mounts in other mount namespaces (containers, systemd units with private mounts). Only notifications will occur, and this option preempts the DDD system. Requires Linux 4.20 or later. It can also be used multiple times.", "/\n/home/user"},
+
     {"OnAccessIncludePath", NULL, 0, CLOPT_TYPE_STRING, NULL, -1, NULL, FLAG_MULTIPLE, OPT_CLAMD, "This option specifies a directory (including all files and directories\ninside it), which should be scanned on access. This option can\nbe used multiple times.", "/home\n/students"},
 
     {"OnAccessExcludePath", NULL, 0, CLOPT_TYPE_STRING, NULL, -1, NULL, FLAG_MULTIPLE, OPT_CLAMD, "This option allows excluding directories from on-access scanning. It can\nbe used multiple times. Only works with DDD system.", "/home/bofh\n/root"},

--- a/etc/clamd.conf.sample
+++ b/etc/clamd.conf.sample
@@ -825,6 +825,19 @@ Example
 #OnAccessMountPath /
 #OnAccessMountPath /home/user
 
+# Set a path whose whole filesystem is to be watched. Unlike OnAccessMountPath,
+# the mark is placed on the filesystem itself, so events are reported for every
+# mount of that filesystem, including mounts made in other mount namespaces
+# (containers, systemd units with private mounts). Without this, writes done by
+# a process that has its own mount namespace produce no events at all.
+# As with OnAccessMountPath, this option preempts the DDD system, results in
+# verdicts only, and prevention is explicitly disallowed.
+# Requires Linux 4.20 or later.
+# It can be used multiple times.
+# Default: disabled
+#OnAccessFilesystemPath /
+#OnAccessFilesystemPath /home/user
+
 # With this option you can exclude the root UID (0). Processes run under
 # root with be able to access all files without triggering scans or
 # permission denied events.


### PR DESCRIPTION
A mount mark reports events only for the mount it was placed on. A process in its own mount namespace reaches the same superblock through its own copy of the mount, so `OnAccessMountPath` yields no event and the file is never scanned. That silently covers containers and any systemd unit with private mounts — on our hosting box it was every process that writes into the web roots, while `clamonacc` stayed `active` and reported nothing.

Reproducer on a tree watched with `OnAccessMountPath`:

```
# event delivered, file scanned
python3 -c 'open("/watched/plain","w").write(EICAR)'

# same write from its own mount namespace, no event
unshare -m --propagation private python3 -c 'open("/watched/nsprobe","w").write(EICAR)'
```

`FAN_MARK_FILESYSTEM` (Linux 4.20) marks the superblock, and the event arrives whichever mount the writer used. This adds `OnAccessFilesystemPath`, taking the same argument as `OnAccessMountPath` and watching the whole filesystem containing it: notification only, DDD preempted, prevention disallowed. Builds whose headers lack the flag keep compiling and report the option as unavailable.
